### PR TITLE
feat: add caching to submissions

### DIFF
--- a/packages/react-app-revamp/components/_pages/DialogModalSendProposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalSendProposal/index.tsx
@@ -36,7 +36,7 @@ export const DialogModalSendProposal = (props: DialogModalSendProposalProps) => 
   const { asPath } = useRouter();
   const { sendProposal, isLoading, error, isSuccess } = useSubmitProposal();
   const { transactionData } = useSubmitProposalStore(state => state);
-  const { contestPrompt, contestStatus, contestMaxProposalCount } = useContestStore(state => state);
+  const { contestPrompt, contestStatus, contestMaxProposalCount, votesOpen } = useContestStore(state => state);
   const { listProposalsIds } = useProposalStore(state => state);
   const {
     amountOfTokensRequiredToSubmitEntry,
@@ -75,7 +75,7 @@ export const DialogModalSendProposal = (props: DialogModalSendProposalProps) => 
       const submissionCache: SubmissionCache = {
         contestId,
         content,
-        lastEdited: new Date(),
+        expiresAt: votesOpen,
       };
       saveSubmissionToLocalStorage("submissions", submissionCache);
     },

--- a/packages/react-app-revamp/helpers/submissionCaching.ts
+++ b/packages/react-app-revamp/helpers/submissionCaching.ts
@@ -3,7 +3,7 @@ import { loadFromLocalStorage, saveToLocalStorage } from "./localStorage";
 export interface SubmissionCache {
   contestId: string;
   content: string;
-  lastEdited: Date;
+  expiresAt: Date;
 }
 
 export const saveSubmissionToLocalStorage = (key: string, submissionCache: SubmissionCache) => {
@@ -27,10 +27,9 @@ export const loadSubmissionFromLocalStorage = (key: string, contestId: string): 
 
   if (submissionCache) {
     const currentTime = new Date();
-    const lastEdited = new Date(submissionCache.lastEdited);
-    const timeDifferenceInHours = (currentTime.getTime() - lastEdited.getTime()) / (1000 * 60 * 60);
+    const expiresAt = submissionCache.expiresAt;
 
-    if (timeDifferenceInHours > 2) {
+    if (currentTime > expiresAt) {
       removeSubmissionFromLocalStorage(key, contestId);
       return null;
     } else {


### PR DESCRIPTION
## What does this PR do and why?

In this PR, we added caching to submissions so users do not use their work by any means, even if they closed a browser by mistake or changed network.

I'll quickly explain what I have taken in mind during the creation of these:

- I've added `submissions` key that stores an array of submissions, therefore if you jump from one contest to another, it will save content for both of them.
- I've added a little check on frontend, if it passes more than 2 hours, we would clean these submissions. The reason for that is so they do not stack on each other, if you submit a proposal, it would be removed from storage.

Let me know if you think that an interval of 2 hours is too much, but I think that if someone writes a long submission it could take near to an hour with breaks so in my mind 2 hours is a maximum that sounds good.