### PR TITLE
bug: add try/catch for fetching ENS name

### DIFF
--- a/packages/react-app-revamp/hooks/useContestEvents/index.ts
+++ b/packages/react-app-revamp/hooks/useContestEvents/index.ts
@@ -56,6 +56,7 @@ export function useContestEvents() {
           functionName: "getProposal",
           args: proposalId,
         });
+
         let author;
         try {
           author = await fetchEnsName({
@@ -63,15 +64,9 @@ export function useContestEvents() {
             chainId: chain.mainnet.id,
           });
         } catch (error: any) {
-          if (error.message.includes("network does not support ENS")) {
-            // Fallback for when ENS is not supported
-            console.log("ENS not supported on this network, using address directly");
-            author = proposal[0];
-          } else {
-            // Handle other errors
-            throw error;
-          }
+          author = proposal[0];
         }
+
         const proposalData: any = {
           authorEthereumAddress: proposal[0],
           author: author ?? proposal[0],

--- a/packages/react-app-revamp/hooks/useContestEvents/index.ts
+++ b/packages/react-app-revamp/hooks/useContestEvents/index.ts
@@ -56,10 +56,22 @@ export function useContestEvents() {
           functionName: "getProposal",
           args: proposalId,
         });
-        const author = await fetchEnsName({
-          address: proposal[0],
-          chainId: chain.mainnet.id,
-        });
+        let author;
+        try {
+          author = await fetchEnsName({
+            address: proposal[0],
+            chainId: chain.mainnet.id,
+          });
+        } catch (error: any) {
+          if (error.message.includes("network does not support ENS")) {
+            // Fallback for when ENS is not supported
+            console.log("ENS not supported on this network, using address directly");
+            author = proposal[0];
+          } else {
+            // Handle other errors
+            throw error;
+          }
+        }
         const proposalData: any = {
           authorEthereumAddress: proposal[0],
           author: author ?? proposal[0],

--- a/packages/react-app-revamp/hooks/useProposalVotes/index.ts
+++ b/packages/react-app-revamp/hooks/useProposalVotes/index.ts
@@ -176,14 +176,7 @@ export function useProposalVotes(id: number | string) {
           chainId: wagmiChain.mainnet.id,
         });
       } catch (error: any) {
-        if (error.message.includes("network does not support ENS")) {
-          // Fallback for when ENS is not supported
-          console.log("ENS not supported on this network, using address directly");
-          author = userAddress;
-        } else {
-          // Handle other errors
-          console.error("Failed to fetch ENS name for address:", userAddress, error);
-        }
+        author = userAddress;
       }
 
       const displayAddress = author ?? shortenEthereumAddress(userAddress);

--- a/packages/react-app-revamp/hooks/useProposalVotes/index.ts
+++ b/packages/react-app-revamp/hooks/useProposalVotes/index.ts
@@ -169,10 +169,22 @@ export function useProposalVotes(id: number | string) {
 
       const { forVotes, againstVotes } = data ?? {};
 
-      const author = await fetchEnsName({
-        address: userAddress,
-        chainId: wagmiChain.mainnet.id,
-      });
+      let author;
+      try {
+        author = await fetchEnsName({
+          address: userAddress,
+          chainId: wagmiChain.mainnet.id,
+        });
+      } catch (error: any) {
+        if (error.message.includes("network does not support ENS")) {
+          // Fallback for when ENS is not supported
+          console.log("ENS not supported on this network, using address directly");
+          author = userAddress;
+        } else {
+          // Handle other errors
+          console.error("Failed to fetch ENS name for address:", userAddress, error);
+        }
+      }
 
       const displayAddress = author ?? shortenEthereumAddress(userAddress);
       // @ts-ignore


### PR DESCRIPTION
## What does this PR do and why?

This PR addresses app errors caused by fetching ENS names in non-supporting networks.

Exception handling has been improved by wrapping `fetchEnsName` calls in try-catch blocks. In cases where ENS is unsupported, the ETH address is utilized directly, ensuring app functions across diffrent networks.

I'm logging it for now so i can see in console tomorrow if this is the case! 