### PR TITLE
chore: update oz submodule to 4 9

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 [submodule "packages/forge/lib/openzeppelin-contracts"]
 	path = packages/forge/lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts.git
-	branch = master
+	branch = release-v4.9


### PR DESCRIPTION
Saw [this tweet](https://twitter.com/OpenZeppelin/status/1669816616157319168?s=20) and so wanted to get up to date because we use the Merkle Tree library! This PR points us at the latest release on the latest release branch: `release-v4.9`.