### PR TITLE
test: update tests

### DIFF
--- a/packages/forge/test/Contest.t.sol
+++ b/packages/forge/test/Contest.t.sol
@@ -197,7 +197,7 @@ contract ContestTest is Test {
         contest.proposeWithoutProof(unpermissionedAuthorProposal1);
     }
 
-    function testVote() public {
+    function testVote1() public {
         vm.startPrank(PERMISSIONED_ADDRESS_1);
 
         vm.warp(1681650001);
@@ -208,6 +208,17 @@ contract ContestTest is Test {
         vm.stopPrank();
 
         assertEq(totalVotes, 10 ether);
+    }
+
+    function testVote2() public {
+        vm.warp(1681650001);
+        vm.prank(PERMISSIONED_ADDRESS_1);
+        uint256 proposalId = contest.propose(firstProposalPA1, submissionProof1);
+        vm.warp(1681660001);
+        vm.prank(PERMISSIONED_ADDRESS_2);
+        uint256 totalVotes = contest.castVote(proposalId, 0, 100 ether, 1 ether, votingProof2);
+
+        assertEq(totalVotes, 100 ether);
     }
 
     function testVoteWithoutProof() public {

--- a/packages/forge/test/Contest.t.sol
+++ b/packages/forge/test/Contest.t.sol
@@ -23,27 +23,40 @@ contract ContestTest is Test {
     ];
 
     /*
-        For this merkle tree:
+        Voting merkle tree:
         {
             "decimals": 18,
             "airdrop": {
-                "0x016C8780e5ccB32E5CAA342a926794cE64d9C364": 10,
-                "0x185a4dc360ce69bdccee33b3784b0282f7961aea": 100
+                "0xd698e31229aB86334924ed9DFfd096a71C686900": 10,
+                "0x5b45e296C06ab3dAD836BCBc0fBd7a4b75b83C02": 100
+            }
+        }
+
+        Submission merkle tree (both are value 10 because that's just the dummy value 
+        that we make proposal merkle trees have and check against for a simpler flow):
+        {
+            "decimals": 18,
+            "airdrop": {
+                "0xd698e31229aB86334924ed9DFfd096a71C686900": 10,
+                "0x5b45e296C06ab3dAD836BCBc0fBd7a4b75b83C02": 10
             }
         }
     */
-    bytes32 public constant SUB_AND_VOTING_MERKLE_ROOT =
-        bytes32(0xd0aa6a4e5b4e13462921d7518eebdb7b297a7877d6cfe078b0c318827392fb55);
+    bytes32 public constant VOTING_MERKLE_ROOT =
+        bytes32(0xdb0fd5147843d56c8f32dd8b2ab5bfe04c1fe199d121790ff805fb0f0f7019c5);
+    bytes32 public constant SUBMISSION_MERKLE_ROOT =
+        bytes32(0x7665f9790e783f13b614dacf6e7624e755b188e1bb086d301855d73f9b81fa85);
     bytes32 public constant SUB_ZERO_MERKLE_ROOT =
         bytes32(0x0000000000000000000000000000000000000000000000000000000000000000);
     address public constant CREATOR_ADDRESS_1 = 0xc109636a2b47f8b290cc134dd446Fcd7d7e0cC94;
-    address public constant PERMISSIONED_ADDRESS_1 = 0x016C8780e5ccB32E5CAA342a926794cE64d9C364;
-    address public constant PERMISSIONED_ADDRESS_2 = 0x185a4dc360CE69bDCceE33b3784B0282f7961aea;
-    address public constant UNPERMISSIONED_ADDRESS_1 = 0xd698e31229aB86334924ed9DFfd096a71C686900;
+    address public constant PERMISSIONED_ADDRESS_1 = 0xd698e31229aB86334924ed9DFfd096a71C686900;
+    address public constant PERMISSIONED_ADDRESS_2 = 0x5b45e296C06ab3dAD836BCBc0fBd7a4b75b83C02;
+    address public constant UNPERMISSIONED_ADDRESS_1 = 0x016C8780e5ccB32E5CAA342a926794cE64d9C364;
     bytes32[] public proof0 = [bytes32(0x0000000000000000000000000000000000000000000000000000000000000000)];
-    bytes32[] public proof1 = [bytes32(0x005a0033b5a1ac5c2872d7689e0f064ad6d2287ab98439e44c822e1c46530033)];
-    bytes32[] public proof2 = [bytes32(0xceeae64152a2deaf8c661fccd5645458ba20261b16d2f6e090fe908b0ac9ca88)];
-
+    bytes32[] public votingProof1 = [bytes32(0xf712e9f1bed1665ca7b426db8e09d438375a76fc5cf8052b6abae75233a117e7)];
+    bytes32[] public votingProof2 = [bytes32(0x3704b461c09457df5491016097977d5364e607b59049ca6d36dfb9c16d03a2bf)];
+    bytes32[] public submissionProof1 = [bytes32(0x3525e2aa1b921658191cfccf7e63bf6bcac64a0315ca9eb04f2bcc08975d431f)];
+    bytes32[] public submissionProof2 = [bytes32(0x3704b461c09457df5491016097977d5364e607b59049ca6d36dfb9c16d03a2bf)];
     address[] public safeSigners = [address(0)];
     uint8 public constant SAFE_THRESHOLD = 1;
 
@@ -81,14 +94,14 @@ contract ContestTest is Test {
 
         contest = new Contest("test",
                               "hello world",
-                              SUB_AND_VOTING_MERKLE_ROOT,
-                              SUB_AND_VOTING_MERKLE_ROOT,
+                              SUBMISSION_MERKLE_ROOT,
+                              VOTING_MERKLE_ROOT,
                               numParams);
 
         anyoneCanSubmitContest = new Contest("test",
                               "hello world",
                               SUB_ZERO_MERKLE_ROOT,
-                              SUB_AND_VOTING_MERKLE_ROOT,
+                              VOTING_MERKLE_ROOT,
                               numParams);
 
         vm.stopPrank();
@@ -136,9 +149,9 @@ contract ContestTest is Test {
     function testPropose() public {
         vm.warp(1681650001);
         vm.prank(PERMISSIONED_ADDRESS_1);
-        uint256 proposalId = contest.propose(firstProposalPA1, proof1);
+        uint256 proposalId = contest.propose(firstProposalPA1, submissionProof1);
 
-        assertEq(proposalId, 23908983303022564668190521243102426214381108252970480710578796525208030103048);
+        assertEq(proposalId, 49056523107705728825615382688395286440062072247511095534135796452139198417529);
     }
 
     function testProposeAnyone() public {
@@ -146,18 +159,18 @@ contract ContestTest is Test {
         vm.prank(UNPERMISSIONED_ADDRESS_1);
         uint256 proposalId = anyoneCanSubmitContest.propose(unpermissionedAuthorProposal1, proof0);
 
-        assertEq(proposalId, 82569039315138695914611829508911276316520611558309518279231235273641370615732);
+        assertEq(proposalId, 98473096201093600303872109595179192229910158899541901113356700720980320499920);
     }
 
     function testProposeWithoutProof() public {
         vm.warp(1681650001);
         vm.startPrank(PERMISSIONED_ADDRESS_1);
-        uint256 firstProposalId = contest.propose(firstProposalPA1, proof1);
+        uint256 firstProposalId = contest.propose(firstProposalPA1, submissionProof1);
         uint256 secondProposalId = contest.proposeWithoutProof(secondProposalPA1);
         vm.stopPrank();
 
-        assertEq(firstProposalId, 23908983303022564668190521243102426214381108252970480710578796525208030103048);
-        assertEq(secondProposalId, 69549311532485292444384863957802353874517660423894990781176389639772664791367);
+        assertEq(firstProposalId, 49056523107705728825615382688395286440062072247511095534135796452139198417529);
+        assertEq(secondProposalId, 54769785658820412218609810676735378376293272785081650547477539805570535635325);
     }
 
     function testProposeAnyoneWithoutProof() public {
@@ -165,20 +178,20 @@ contract ContestTest is Test {
         vm.prank(UNPERMISSIONED_ADDRESS_1);
         uint256 proposalId = anyoneCanSubmitContest.proposeWithoutProof(unpermissionedAuthorProposal1);
 
-        assertEq(proposalId, 82569039315138695914611829508911276316520611558309518279231235273641370615732);
+        assertEq(proposalId, 98473096201093600303872109595179192229910158899541901113356700720980320499920);
     }
 
     function testProposeAuthorIsntSender() public {
         vm.warp(1681650001);
         vm.prank(PERMISSIONED_ADDRESS_1);
         vm.expectRevert(bytes("Governor: the proposal author must be msg.sender"));
-        contest.propose(unpermissionedAuthorProposal1, proof1);
+        contest.propose(unpermissionedAuthorProposal1, submissionProof1);
     }
 
     function testProposeWithoutProofAuthorIsntSender() public {
         vm.warp(1681650001);
         vm.prank(PERMISSIONED_ADDRESS_1);
-        contest.propose(firstProposalPA1, proof1);
+        contest.propose(firstProposalPA1, submissionProof1);
         vm.prank(PERMISSIONED_ADDRESS_1);
         vm.expectRevert(bytes("Governor: the proposal author must be msg.sender"));
         contest.proposeWithoutProof(unpermissionedAuthorProposal1);
@@ -188,9 +201,9 @@ contract ContestTest is Test {
         vm.startPrank(PERMISSIONED_ADDRESS_1);
 
         vm.warp(1681650001);
-        uint256 proposalId = contest.propose(firstProposalPA1, proof1);
+        uint256 proposalId = contest.propose(firstProposalPA1, submissionProof1);
         vm.warp(1681660001);
-        uint256 totalVotes = contest.castVote(proposalId, 0, 10 ether, 1 ether, proof1);
+        uint256 totalVotes = contest.castVote(proposalId, 0, 10 ether, 1 ether, votingProof1);
 
         vm.stopPrank();
 
@@ -201,9 +214,9 @@ contract ContestTest is Test {
         vm.startPrank(PERMISSIONED_ADDRESS_1);
 
         vm.warp(1681650001);
-        uint256 proposalId = contest.propose(firstProposalPA1, proof1);
+        uint256 proposalId = contest.propose(firstProposalPA1, submissionProof1);
         vm.warp(1681660001);
-        contest.castVote(proposalId, 0, 10 ether, 1 ether, proof1);
+        contest.castVote(proposalId, 0, 10 ether, 1 ether, votingProof1);
         uint256 totalVotesWithoutProof = contest.castVoteWithoutProof(proposalId, 0, 1 ether);
 
         vm.stopPrank();

--- a/packages/react-app-revamp/hooks/useGenerateProof/index.ts
+++ b/packages/react-app-revamp/hooks/useGenerateProof/index.ts
@@ -41,6 +41,9 @@ export function useGenerateProof() {
   ) {
     const proofs = getProof(merkleTree, address, proofType, numVotes);
 
+    console.log("proofType: ", proofType)
+    console.log("proof: ", proofs)
+
     const { abi } = await getContestContractVersion(contestAddress, chainName);
 
     const contractConfig = {


### PR DESCRIPTION
Update tests to more fully flesh out the specifics of what we expect for submission and voting proofs.

Also super weird but for some reason the submission and voting proofs for `0x5b45e296C06ab3dAD836BCBc0fBd7a4b75b83C02` are the exact same even though they're for the values `10` and `100` respectively! But they work correctly!