### PR TITLE
typo: remove incorrect .eth suffix

### DIFF
--- a/packages/react-app-revamp/components/UI/EtheuremAddress/index.tsx
+++ b/packages/react-app-revamp/components/UI/EtheuremAddress/index.tsx
@@ -19,7 +19,7 @@ const EthereumAddress = ({
   displayLensProfile,
   shortenOnFallback,
 }: EthereumAddressProps) => {
-  const shortAddress = `${ethereumAddress.substring(0, 6)}...${ethereumAddress.slice(-3)}.eth`;
+  const shortAddress = `${ethereumAddress.substring(0, 6)}...${ethereumAddress.slice(-3)}`;
 
   const [avatarUrl, setAvatarUrl] = useState<string>(DEFAULT_AVATAR_URL);
 


### PR DESCRIPTION
Fixes issue where .eth is appended to the end of addresses.

Example contest: contest/celotestnet/0x003dA13b325cBa4d4477207871d8E7C7F2F5AD8E.

Old:
<img width="278" alt="Screenshot 2023-07-03 at 10 43 46 PM" src="https://github.com/jk-labs-inc/jokerace/assets/27874039/53adf0e8-d2ad-4596-b5bc-969bbf717680">

New:
<img width="242" alt="Screenshot 2023-07-03 at 10 45 33 PM" src="https://github.com/jk-labs-inc/jokerace/assets/27874039/e5e8e3e4-ce8f-4e8c-bdea-9f2344fdccec">
