### PR TITLE
chore: rename top voters to voters to avoid confusion

### DIFF
--- a/packages/react-app-revamp/components/_pages/ListProposalVotes/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListProposalVotes/index.tsx
@@ -67,7 +67,6 @@ export const ListProposalVotes: FC<ListProposalVotesProps> = ({ proposal, propos
                   if (!accountData?.address) return address;
                   if (address !== accountData?.address) return address;
                 })
-                .sort((a, b) => votesPerAddress[b].votes - votesPerAddress[a].votes) // Sorting here
                 .map((address: string, index, self) => (
                   <div
                     key={address}

--- a/packages/react-app-revamp/components/_pages/ListProposalVotes/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListProposalVotes/index.tsx
@@ -35,7 +35,7 @@ export const ListProposalVotes: FC<ListProposalVotesProps> = ({ proposal, propos
     totalPagesPaginationVotes,
     hasPaginationVotesNextPage,
   } = useProposalVotesStore(state => state);
-  const [isTopVotersOpen, setIsTopVotersOpen] = useState(true);
+  const [isVotersOpen, setIsVotersOpen] = useState(true);
   const [isLoadMoreOpen, setIsLoadMoreOpen] = useState(false);
 
   const onLoadMore = () => {
@@ -50,16 +50,16 @@ export const ListProposalVotes: FC<ListProposalVotesProps> = ({ proposal, propos
   return (
     <>
       <div className="flex gap-4 items-center mb-8">
-        <p className="text-[24px] text-neutral-11 font-bold">top voters</p>
+        <p className="text-[24px] text-neutral-11 font-bold">voters</p>
         <button
-          onClick={() => setIsTopVotersOpen(!isTopVotersOpen)}
-          className={`transition-transform duration-500 ease-in-out transform ${isTopVotersOpen ? "" : "rotate-180"}`}
+          onClick={() => setIsVotersOpen(!isVotersOpen)}
+          className={`transition-transform duration-500 ease-in-out transform ${isVotersOpen ? "" : "rotate-180"}`}
         >
           <ChevronUpIcon height={30} />
         </button>
       </div>
       {isSuccess && !isLoading && (
-        <Collapsible isOpen={isTopVotersOpen}>
+        <Collapsible isOpen={isVotersOpen}>
           <div className="flex flex-col gap-5">
             <div className="flex flex-col gap-4 md:w-[350px]">
               {Object.keys(votesPerAddress)


### PR DESCRIPTION
Think this would be helpful to change as it could be confusing because the first load does not, in fact, give the top voters, so people might be confused/make incorrect assumptions about who the top voter on a proposal is without loading more.

I also don't think we should sort proposal voters for the same reason: we don't want people to get the false impression that a person who happens to be the highest voter of the first batch pulled for a proposal is in fact the highest voter for then whole proposal (in the case that multiple loads are required to get all of the voters for a proposal).