### PR TITLE
bug: contest title is not showing in the head of URL

### DIFF
--- a/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
@@ -10,7 +10,6 @@ import DialogModalSendProposal from "@components/_pages/DialogModalSendProposal"
 import ListProposals from "@components/_pages/ListProposals";
 import { ofacAddresses } from "@config/ofac-addresses/ofac-addresses";
 import { ROUTE_CONTEST_PROPOSAL, ROUTE_VIEW_CONTEST } from "@config/routes";
-import { chains } from "@config/wagmi";
 import { RefreshIcon } from "@heroicons/react/outline";
 import { ArrowLeftIcon } from "@heroicons/react/solid";
 import { CastVotesWrapper } from "@hooks/useCastVotes/store";
@@ -25,13 +24,12 @@ import { FundRewardsWrapper } from "@hooks/useFundRewards/store";
 import { ProposalWrapper, useProposalStore } from "@hooks/useProposal/store";
 import { RewardsWrapper } from "@hooks/useRewards/store";
 import { SubmitProposalWrapper, useSubmitProposalStore } from "@hooks/useSubmitProposal/store";
-import useUser from "@hooks/useUser";
 import { UserWrapper, useUserStore } from "@hooks/useUser/store";
 import { switchNetwork } from "@wagmi/core";
 import { isBefore } from "date-fns";
 import moment from "moment";
 import Link from "next/link";
-import router, { useRouter } from "next/router";
+import { useRouter } from "next/router";
 import { ReactNode, useEffect, useMemo, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { useAccount, useNetwork } from "wagmi";
@@ -348,6 +346,8 @@ const LayoutViewContest = (props: any) => {
                   )}
 
                   {renderTabs}
+
+                  {props.children}
 
                   <DialogModalSendProposal
                     isOpen={isSubmitProposalModalOpen}

--- a/packages/react-app-revamp/pages/contest/[chain]/[address]/index.tsx
+++ b/packages/react-app-revamp/pages/contest/[chain]/[address]/index.tsx
@@ -18,7 +18,6 @@ const Page: NextPage = (props: PageProps) => {
         <title>Contest {contestName ? contestName : address} - jokerace</title>
         <meta name="description" content="@TODO: change this" />
       </Head>
-      <h1 className="sr-only">Contest {contestName ? contestName : address} </h1>
     </>
   );
 };


### PR DESCRIPTION
Currently, the entire URL is displayed rather than just the contest name in the URL's head.

![image](https://github.com/jk-labs-inc/jokerace/assets/18723426/d6f82637-a845-4b30-b0fc-1c3f66f7da73)
