### PR TITLE
bug: add csv validations for 0 addresses, duplicates or 18 decimals, …

### DIFF
--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestSubmission/components/SubmissionAllowlist/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestSubmission/components/SubmissionAllowlist/index.tsx
@@ -73,9 +73,6 @@ const CreateSubmissionAllowlist = () => {
         <p className="text-[16px] text-neutral-11">
           copy-paste allowlist into preview box (up to 100 line items) or upload a csv below <br />
         </p>
-        <p className="text-[16px] text-neutral-11">
-          Please note: there must be no duplicate addresses in the allowlist <br />
-        </p>
       </div>
       <CSVEditorSubmission onChange={onAllowListChange} />
 

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingAllowlist/components/CSVEditor/CSVParseError/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingAllowlist/components/CSVEditor/CSVParseError/index.tsx
@@ -1,0 +1,79 @@
+import { FC, ReactNode, useMemo } from "react";
+
+export type ParseError = "missingColumns" | "limitExceeded" | "duplicates" | "over18Decimal" | "";
+
+interface CSVParseErrorProps {
+  step: "voting" | "submission";
+  type: ParseError;
+}
+
+const CSVParseError: FC<CSVParseErrorProps> = ({ type, step }) => {
+  const errorContent = useMemo<ReactNode>(() => {
+    if (!type) return null;
+
+    switch (type) {
+      case "missingColumns":
+        return (
+          <div className="flex flex-col text-[16px] animate-fadeIn">
+            {step === "voting" ? (
+              <p className=" text-negative-11">
+                Ruh-roh! CSV couldn’t be imported.{" "}
+                <span className="font-bold">
+                  Make sure there are no headers or additional <br />
+                  columns.
+                </span>{" "}
+                CSV should have 1) only two columns, 2) a first column containing <span className="italic">
+                  only
+                </span>{" "}
+                valid <br />
+                EVM addresses, and 3) a second column containing number of votes.
+              </p>
+            ) : (
+              <p className=" text-negative-11">
+                ruh-roh! csv couldn’t be imported.{" "}
+                <span className="font-bold">
+                  make sure there are no headers or additional <br />
+                  columns.
+                </span>{" "}
+                csv should have 1) only one column, 2) a column containing <span className="italic">only</span> valid
+                <br /> EVM addresses
+              </p>
+            )}
+          </div>
+        );
+      case "limitExceeded":
+        return (
+          <div className="flex flex-col text-[16px] animate-fadeIn">
+            <p className=" text-negative-11">
+              Ruh-roh! CSV file has too many rows.{" "}
+              <span className="font-bold">The maximum number of rows allowed is 10,000</span>
+            </p>
+          </div>
+        );
+      case "duplicates":
+        return (
+          <div className="flex flex-col text-[16px] animate-fadeIn">
+            <p className=" text-negative-11">
+              Ruh-roh! CSV file has duplicated addresses.{" "}
+              <span className="font-bold">CSV should have distinct addresses</span>
+            </p>
+          </div>
+        );
+      case "over18Decimal":
+        return (
+          <div className="flex flex-col text-[16px] animate-fadeIn">
+            <p className=" text-negative-11">
+              Ruh-roh! CSV file has some votes with over 18 decimals{" "}
+              <span className="font-bold">CSV should have vote values with less decimals</span>
+            </p>
+          </div>
+        );
+      default:
+        return null;
+    }
+  }, [type]);
+
+  return <>{errorContent}</>;
+};
+
+export default CSVParseError;

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingAllowlist/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingAllowlist/index.tsx
@@ -65,9 +65,6 @@ const CreateVotingAllowlist = () => {
         <p className="text-[16px] text-neutral-11">
           copy-paste allowlist into preview box (up to 100 line items) or upload a csv below <br />
         </p>
-        <p className="text-[16px] text-neutral-11">
-          Please note: there must be no duplicate addresses in the allowlist <br />
-        </p>
       </div>
       <CSVEditorVoting onChange={handleAllowListChange} />
       <div className="mt-8">

--- a/packages/react-app-revamp/helpers/parseVotingCsv.ts
+++ b/packages/react-app-revamp/helpers/parseVotingCsv.ts
@@ -7,12 +7,17 @@ export type InvalidEntry = {
   error: "address" | "votes" | "both";
 };
 
+export type ValidationError =
+  | { kind: "missingColumns" }
+  | { kind: "limitExceeded" }
+  | { kind: "duplicates" }
+  | { kind: "over18Decimal" }
+  | { kind: "parseError"; error: Error };
+
 export type ParseCsvResult = {
   data: Record<string, number>;
   invalidEntries: InvalidEntry[];
-  missingColumns?: boolean;
-  limitExceeded?: boolean;
-  parseError?: Error;
+  error?: ValidationError;
 };
 
 const MAX_ROWS = 10000; // 10k for now
@@ -21,23 +26,23 @@ const processResults = (results: Papa.ParseResult<any>): ParseCsvResult => {
   const data = results.data as Array<any>;
   const votesData: Record<string, number> = {};
   const invalidEntries: InvalidEntry[] = [];
+  const addresses: Set<string> = new Set();
 
   if (data.length > MAX_ROWS) {
     return {
       data: {},
-      invalidEntries: [],
-      limitExceeded: true,
+      invalidEntries,
+      error: { kind: "limitExceeded" },
     };
   }
 
-  // Ensure that the CSV has the correct number of columns (2)
   const expectedColumns = 2;
   const firstRow = data[0];
   if (firstRow.length !== expectedColumns) {
     return {
       data: {},
-      invalidEntries: [],
-      missingColumns: true,
+      invalidEntries,
+      error: { kind: "missingColumns" },
     };
   }
 
@@ -46,13 +51,32 @@ const processResults = (results: Papa.ParseResult<any>): ParseCsvResult => {
     const address = row[0];
     const numberOfVotes = row[1];
 
+    if (addresses.has(address)) {
+      return {
+        data: {},
+        invalidEntries,
+        error: { kind: "duplicates" },
+      };
+    } else {
+      addresses.add(address);
+    }
+
+    const decimalIndex = numberOfVotes.toString().indexOf(".");
+    if (decimalIndex !== -1 && numberOfVotes.toString().length - decimalIndex - 1 > 18) {
+      return {
+        data: {},
+        invalidEntries,
+        error: { kind: "over18Decimal" },
+      };
+    }
+
     try {
       getAddress(address);
     } catch (e) {
       error = "address";
     }
 
-    if (typeof numberOfVotes !== "number" || numberOfVotes < 0) {
+    if (typeof numberOfVotes !== "number" || numberOfVotes <= 0) {
       error = error ? "both" : "votes";
     }
 
@@ -78,7 +102,7 @@ export const parseCsvVoting = (file: File): Promise<ParseCsvResult> => {
       complete: results => {
         resolve(processResults(results));
       },
-      error: error => resolve({ data: {}, invalidEntries: [], parseError: error }),
+      error: error => resolve({ data: {}, invalidEntries: [], error: { kind: "parseError", error } }),
     });
   });
 };


### PR DESCRIPTION
Closes #333

In this PR we are doing following, let's say that we have 2 types of errors while parsing CSV:

1.  Invalid entries such as invalid address, invalid vote number ( zero or negative ) or both, this is considered as a successful parse from our end and we display those errors in the preview.
2.  Validation errors such as duplicates, missing columns, limit exceeded or votes over 18 decimal, this is not a successful parse and we display those errors below preview.

We are now also distinguishing those 2 as different and can easily move forward and add more conditionals to either first or second option of type of an error.


EDIT: I've also removed notes for duplicates now as they are being handled by errors after uploading a CSV