### PR TITLE
chore: remove mainnet as an option

### DIFF
--- a/packages/react-app-revamp/config/wagmi/index.ts
+++ b/packages/react-app-revamp/config/wagmi/index.ts
@@ -46,7 +46,7 @@ const otherChains = [
   celoMainnet
 ];
 
-const defaultChains = [chain.polygon, chain.arbitrum, chain.mainnet, chain.optimism];
+const defaultChains = [chain.polygon, chain.arbitrum, chain.optimism];
 const appChains = [...defaultChains, ...otherChains];
 const providers =
   process.env.NODE_ENV === "development"


### PR DESCRIPTION
Removing because there's no real good reason you'd want to make a contest on mainnet but a ton of downside if people accidentally deploy to mainnet (costs hundreds of dollars), so removing option for now.