### PR TITLE
bug: look at chain name in url for share links

### DIFF
--- a/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
@@ -329,7 +329,7 @@ const LayoutViewContest = (props: any) => {
                     <hr className="border-neutral-10" />
                     <ContestLayoutTabs
                       contestAddress={address}
-                      chain={chain?.name ?? ""}
+                      chain={chainName ?? ""}
                       contestName={contestName}
                       onChange={tab => setTab(tab)}
                     />


### PR DESCRIPTION
Closes #364 - @NakedFool does this look like the right (and more importantly comprehensive, don't want to change this and then other parts of the frontend rely on it to be something else) fix for this bug? 

The bug is when the user doesn't have a connected wallet, it doesn't include a chain name in the Twitter shared url - and even when people are connected, it capitalizes the first letter for some reason.