### PR TITLE
bug: catch when we don't get a version

### DIFF
--- a/packages/react-app-revamp/helpers/getContestContractVersion.ts
+++ b/packages/react-app-revamp/helpers/getContestContractVersion.ts
@@ -19,11 +19,13 @@ export async function getContestContractVersion(address: string, chainName: stri
   const chainId = chains.filter(chain => chain.name.toLowerCase().replace(" ", "") === chainName)?.[0]?.id;
   const provider = getProvider({ chainId: chainId });
   const contract = new ethers.Contract(address, NumberedVersioningContract.abi, provider);
+  const defaultReturn = { abi: null, version: null };
+
   const version: string = await contract.version().catch((error:any) => {
     return null;
   });
 
-  if (version == null) { return { abi: null, version }; }
+  if (version == null) { return defaultReturn; }
 
   if (version === "2.8") {
     return { abi: NumberedVersioningContract.abi, version };

--- a/packages/react-app-revamp/helpers/getContestContractVersion.ts
+++ b/packages/react-app-revamp/helpers/getContestContractVersion.ts
@@ -19,9 +19,11 @@ export async function getContestContractVersion(address: string, chainName: stri
   const chainId = chains.filter(chain => chain.name.toLowerCase().replace(" ", "") === chainName)?.[0]?.id;
   const provider = getProvider({ chainId: chainId });
   const contract = new ethers.Contract(address, NumberedVersioningContract.abi, provider);
-  const version: string = await contract.version();
+  const version: string = await contract.version().catch((error:any) => {
+    return null;
+  });
 
-  const defaultReturn = { abi: [], version: "unknown" };
+  if (version == null) { return { abi: null, version }; }
 
   if (version === "2.8") {
     return { abi: NumberedVersioningContract.abi, version };

--- a/packages/react-app-revamp/helpers/getContestContractVersion.ts
+++ b/packages/react-app-revamp/helpers/getContestContractVersion.ts
@@ -19,13 +19,13 @@ export async function getContestContractVersion(address: string, chainName: stri
   const chainId = chains.filter(chain => chain.name.toLowerCase().replace(" ", "") === chainName)?.[0]?.id;
   const provider = getProvider({ chainId: chainId });
   const contract = new ethers.Contract(address, NumberedVersioningContract.abi, provider);
-  const defaultReturn = { abi: null, version: null };
+  const defaultReturn = { abi: [], version: "unknown" };
 
   const version: string = await contract.version().catch((error:any) => {
-    return null;
+    return "unknown";
   });
 
-  if (version == null) { return defaultReturn; }
+  if (version == "unknown") { return defaultReturn; }
 
   if (version === "2.8") {
     return { abi: NumberedVersioningContract.abi, version };

--- a/packages/react-app-revamp/hooks/useContest/index.ts
+++ b/packages/react-app-revamp/hooks/useContest/index.ts
@@ -82,7 +82,7 @@ export function useContest() {
     try {
       const { abi, version } = await getContestContractVersion(address, chainName);
 
-      if (abi === null) {
+      if (abi.length == 0) {
         const errorMessage = `This contract doesn't exist on ${chain?.name ?? "this chain"}.`;
         toastError(errorMessage);
         setError({ message: errorMessage });

--- a/packages/react-app-revamp/hooks/useProposal/index.ts
+++ b/packages/react-app-revamp/hooks/useProposal/index.ts
@@ -54,7 +54,7 @@ export function useProposal() {
     try {
       const { abi, version } = await getContestContractVersion(address, chainName);
 
-      if (abi === null) {
+      if (abi.length == 0) {
         const errorMsg = `This contract doesn't exist on ${chain?.name ?? "this chain"}.`;
         toastError(errorMsg);
         setIsPageProposalsError({ message: errorMsg });

--- a/packages/react-app-revamp/hooks/useProposalVotes/index.ts
+++ b/packages/react-app-revamp/hooks/useProposalVotes/index.ts
@@ -60,7 +60,7 @@ export function useProposalVotes(id: number | string) {
 
     const { abi, version } = await getContestContractVersion(address, chainName);
 
-    if (abi === null) {
+    if (abi.length == 0) {
       const errorMessage = "This contract doesn't exist on this chain.";
       setIsListVotersLoading(false);
       setIsListVotersError(errorMessage);
@@ -153,7 +153,7 @@ export function useProposalVotes(id: number | string) {
     try {
       const { abi, version } = await getContestContractVersion(address, chainName);
 
-      if (abi === null) {
+      if (abi.length == 0) {
         const errorMessage = "This contract doesn't exist on this chain.";
         toastError(errorMessage);
         setIsPageVotesError({ message: errorMessage });

--- a/packages/react-app-revamp/hooks/useUser/index.ts
+++ b/packages/react-app-revamp/hooks/useUser/index.ts
@@ -35,7 +35,7 @@ export function useUser() {
   async function getContractConfig() {
     const { abi } = await getContestContractVersion(address, chainName);
 
-    if (abi === null) {
+    if (abi.length == 0) {
       toastError(`This contract doesn't exist on ${chain?.name ?? "this chain"}.`);
       setContestError({ message: `This contract doesn't exist on ${chain?.name ?? "this chain"}.` });
       setIsContestSuccess(false);

--- a/packages/react-app-revamp/lib/contests/index.ts
+++ b/packages/react-app-revamp/lib/contests/index.ts
@@ -15,7 +15,7 @@ export const ITEMS_PER_PAGE = 7;
 async function getContractConfig(address: string, chainName: string, chainId: number) {
   const { abi, version } = await getContestContractVersion(address, chainName);
 
-  if (abi === null) {
+  if (abi.length == 0) {
     return;
   }
 


### PR DESCRIPTION
Was getting a 405 error from PGN when trying to send an `eth_call` request and our site didn't catch the rejected Promise, it just kept spinning.

Is this comprehensive and/or should the be larger in scope for like make sure this doesn't happen anywhere else in the codebase as well?

<img width="303" alt="Screenshot 2023-07-13 at 7 39 30 PM" src="https://github.com/jk-labs-inc/jokerace/assets/27874039/a38acb35-e084-43ab-9eec-5a5f029611a9">
<img width="1082" alt="Screenshot 2023-07-13 at 7 41 48 PM" src="https://github.com/jk-labs-inc/jokerace/assets/27874039/a6437975-0496-4bf5-ad4a-f85446743dc1">
<img width="1064" alt="Screenshot 2023-07-13 at 7 43 07 PM" src="https://github.com/jk-labs-inc/jokerace/assets/27874039/9361f729-b8e7-4d86-a2da-51df01336cc6">

