### PR TITLE
bug: add optimistic approach for voting popup cast votes and available amount

### DIFF
--- a/packages/react-app-revamp/components/_pages/DialogModalProposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalProposal/index.tsx
@@ -24,12 +24,25 @@ interface DialogModalProposalProps {
 const DialogModalProposal: FC<DialogModalProposalProps> = ({ isOpen, setIsOpen, prompt, proposal, proposalId }) => {
   const contestStatus = useContestStatusStore(state => state.contestStatus);
   const { castVotes, isLoading } = useCastVotes();
-  const { currentUserAvailableVotesAmount, currentUserTotalVotesAmount } = useUserStore(state => state);
+  const {
+    currentUserAvailableVotesAmount,
+    currentUserTotalVotesAmount,
+    decreaseCurrentUserAvailableVotesAmount,
+    increaseCurrentUserAvailableVotesAmount,
+    increaseCurrentUserTotalVotesCast,
+    decreaseCurrentUserTotalVotesCast,
+  } = useUserStore(state => state);
   const outOfVotes = currentUserAvailableVotesAmount === 0 && currentUserTotalVotesAmount > 0;
 
-  function onSubmitCastVotes(amount: number, isPositive: boolean) {
-    castVotes(amount, isPositive);
-  }
+  const onSubmitCastVotes = (amount: number, isUpvote: boolean) => {
+    decreaseCurrentUserAvailableVotesAmount(amount);
+    increaseCurrentUserTotalVotesCast(amount);
+
+    castVotes(amount, isUpvote).catch(error => {
+      increaseCurrentUserAvailableVotesAmount(amount);
+      decreaseCurrentUserTotalVotesCast(amount);
+    });
+  };
 
   useEffect(() => {
     if (isLoading) setIsOpen(false);

--- a/packages/react-app-revamp/components/_pages/DialogModalVoteForProposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalVoteForProposal/index.tsx
@@ -17,13 +17,25 @@ interface DialogModalVoteForProposalProps {
 
 export const DialogModalVoteForProposal: FC<DialogModalVoteForProposalProps> = ({ isOpen, setIsOpen, proposal }) => {
   const { downvotingAllowed, contestPrompt } = useContestStore(state => state);
-  const { currentUserAvailableVotesAmount } = useUserStore(state => state);
+  const {
+    currentUserAvailableVotesAmount,
+    decreaseCurrentUserAvailableVotesAmount,
+    increaseCurrentUserTotalVotesCast,
+    increaseCurrentUserAvailableVotesAmount,
+    decreaseCurrentUserTotalVotesCast,
+  } = useUserStore(state => state);
 
-  const { castVotes, isLoading, error, isSuccess } = useCastVotes();
+  const { castVotes, isLoading } = useCastVotes();
 
-  function onSubmitCastVotes(amount: number, isPositive: boolean) {
-    castVotes(amount, isPositive);
-  }
+  const onSubmitCastVotes = (amount: number, isUpvote: boolean) => {
+    decreaseCurrentUserAvailableVotesAmount(amount);
+    increaseCurrentUserTotalVotesCast(amount);
+
+    castVotes(amount, isUpvote).catch(error => {
+      increaseCurrentUserAvailableVotesAmount(amount);
+      decreaseCurrentUserTotalVotesCast(amount);
+    });
+  };
 
   useEffect(() => {
     if (isLoading) setIsOpen(false);

--- a/packages/react-app-revamp/hooks/useCastVotes/index.ts
+++ b/packages/react-app-revamp/hooks/useCastVotes/index.ts
@@ -102,7 +102,7 @@ export function useCastVotes() {
       if (customError.code === ErrorCodes.USER_REJECTED_TX) {
         toastDismiss();
         setIsLoading(false);
-        return;
+        throw customError;
       }
 
       toastError(`Something went wrong while casting your votes`, customError.message);
@@ -111,6 +111,7 @@ export function useCastVotes() {
         message: customError.message,
       });
       setIsLoading(false);
+      throw customError;
     }
   }
 

--- a/packages/react-app-revamp/hooks/useUser/store.tsx
+++ b/packages/react-app-revamp/hooks/useUser/store.tsx
@@ -20,6 +20,10 @@ interface UserState {
   setCurrentUserAvailableVotesAmount: (amount: number) => void;
   setCurrentUserTotalVotesAmount: (amount: number) => void;
   setContestMaxNumberSubmissionsPerUser: (amount: number) => void;
+  decreaseCurrentUserAvailableVotesAmount: (amount: number) => void;
+  increaseCurrentUserAvailableVotesAmount: (amount: number) => void;
+  increaseCurrentUserTotalVotesCast: (amount: number) => void;
+  decreaseCurrentUserTotalVotesCast: (amount: number) => void;
   setCurrentUserProposalCount: (amount: number) => void;
   increaseCurrentUserProposalCount: () => void;
   setIsLoading: (value: boolean) => void;
@@ -47,6 +51,14 @@ export const createUserStore = () =>
     setCurrentUserTotalVotesAmount: amount => set({ currentUserTotalVotesAmount: amount }),
     setContestMaxNumberSubmissionsPerUser: amount => set({ contestMaxNumberSubmissionsPerUser: amount }),
     setCurrentUserProposalCount: amount => set({ currentUserProposalCount: amount }),
+    decreaseCurrentUserAvailableVotesAmount: (amount: number) =>
+      set(state => ({ currentUserAvailableVotesAmount: state.currentUserAvailableVotesAmount - amount })),
+    increaseCurrentUserAvailableVotesAmount: (amount: number) =>
+      set(state => ({ currentUserAvailableVotesAmount: state.currentUserAvailableVotesAmount + amount })),
+    increaseCurrentUserTotalVotesCast: (amount: number) =>
+      set(state => ({ currentUserTotalVotesCast: state.currentUserTotalVotesCast + amount })),
+    decreaseCurrentUserTotalVotesCast: (amount: number) =>
+      set(state => ({ currentUserTotalVotesCast: state.currentUserTotalVotesCast - amount })),
     increaseCurrentUserProposalCount: () =>
       set(state => ({ currentUserProposalCount: state.currentUserProposalCount + 1 })),
     setIsLoading: value => set({ isLoading: value }),


### PR DESCRIPTION
First i've wanted to disable voting widget until votes has been deployed successfully or caught in error, but not ideal UI/UX approach.

We shouldn't really disable slider and input in voting widget when votes are deploying, in case you want to prepare yourself at other proposal to vote, only button should be disabled! 