### PR TITLE
bug: fix totalVotesCast check

### DIFF
--- a/packages/react-app-revamp/hooks/useContest/index.ts
+++ b/packages/react-app-revamp/hooks/useContest/index.ts
@@ -330,7 +330,7 @@ export function useContest() {
 
       const { contractConfig } = result;
 
-      if (!contractConfig.contractInterface.name.includes("totalVotesCast")) {
+      if (!(contractConfig.contractInterface?.filter((el: { name: string }) => el.name === "totalVotesCast").length > 0)) {
         setTotalVotesCast(-1);
         return;
       }


### PR DESCRIPTION
Fixed the rendering of `totalVotesCast` on load, but for some reason it still doesn't work correctly on the vote event (I had to reload the page).

Update: nevermind, #393 fixed the issue with vote events not updating it! All is good!