### PR TITLE
feat: rewards module ui/ux & code polish

### DIFF
--- a/packages/react-app-revamp/components/_pages/DialogCheckBalanceRewardsModule/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogCheckBalanceRewardsModule/index.tsx
@@ -1,62 +1,76 @@
+import ButtonV3 from "@components/UI/ButtonV3";
 import DialogModalV3 from "@components/UI/DialogModalV3";
 import CheckmarkIcon from "@components/UI/Icons/Checkmark";
 import CrossIcon from "@components/UI/Icons/Cross";
-import { chains } from "@config/wagmi";
-import { ExclamationIcon } from "@heroicons/react/outline";
+import { useContestStore } from "@hooks/useContest/store";
 import { useRewardsStore } from "@hooks/useRewards/store";
-import { useRouter } from "next/router";
+import { useTokenBalance } from "@hooks/useTokenBalance";
+import { useWithdrawReward } from "@hooks/useWithdrawRewards";
 import { FC, useEffect, useState } from "react";
-import { useBalance } from "wagmi";
+import { useAccount } from "wagmi";
 import CreateTextInput from "../Create/components/TextInput";
 
 interface DialogCheckBalanceRewardsModuleProps {
   isOpen: boolean;
   setIsOpen: (value: boolean) => void;
 }
+
 export const DialogCheckBalanceRewardsModule: FC<DialogCheckBalanceRewardsModuleProps> = ({ isOpen, setIsOpen }) => {
   const rewardsStore = useRewardsStore(state => state);
-  const { asPath } = useRouter();
+  const { contestAuthorEthereumAddress } = useContestStore(state => state);
+  const { address, isConnected } = useAccount();
+  const creator = isConnected && address ? contestAuthorEthereumAddress === address : false;
   const [inputRewardsModuleBalanceCheck, setInputRewardsModuleBalanceCheck] = useState("");
-  const queryTokenBalance = useBalance({
-    addressOrName: rewardsStore?.rewards?.contractAddress,
-    chainId: chains.filter(chain => chain.name.toLowerCase().replace(" ", "") === asPath.split("/")?.[2])?.[0]?.id,
-    token: inputRewardsModuleBalanceCheck,
-    //@ts-ignore
-    enabled: inputRewardsModuleBalanceCheck !== "" && inputRewardsModuleBalanceCheck?.match(/^0x[a-fA-F0-9]{40}$/),
-    onSuccess(data) {
-      if (parseFloat(data?.formatted) > 0) {
-        const newBalance = {
-          contractAddress: inputRewardsModuleBalanceCheck,
-          tokenBalance: data?.formatted,
-        };
-
-        if (!rewardsStore.rewards.balance) {
-          rewardsStore.setRewards({
-            ...rewardsStore.rewards,
-            balance: [newBalance],
-          });
-        } else {
-          const existingBalance = rewardsStore.rewards.balance.find(
-            (bal: any) => bal.contractAddress === inputRewardsModuleBalanceCheck,
-          );
-
-          if (!existingBalance) {
-            rewardsStore.setRewards({
-              ...rewardsStore.rewards,
-              balance: [...rewardsStore.rewards.balance, newBalance],
-            });
-          }
-        }
-      }
-    },
-  });
+  const { contractWriteWithdrawReward, txWithdraw } = useWithdrawReward(
+    rewardsStore?.rewards?.contractAddress,
+    rewardsStore?.rewards?.abi,
+    "erc20",
+    inputRewardsModuleBalanceCheck,
+  );
+  const { queryTokenBalance, error } = useTokenBalance(inputRewardsModuleBalanceCheck);
+  const [tokenAlreadyAdded, setTokenAlreadyAdded] = useState(false);
 
   useEffect(() => {
-    // reset state when modal closes
+    if (!inputRewardsModuleBalanceCheck) return;
+
+    const existingBalance = rewardsStore.rewards.balance.find(
+      (bal: any) => bal.contractAddress.toLowerCase() == inputRewardsModuleBalanceCheck.toLowerCase(),
+    );
+
+    if (existingBalance) {
+      setTokenAlreadyAdded(true);
+    } else {
+      setTokenAlreadyAdded(false);
+    }
+  }, [inputRewardsModuleBalanceCheck]);
+
+  useEffect(() => {
     if (!isOpen) {
       setInputRewardsModuleBalanceCheck("");
+      setTokenAlreadyAdded(false);
     }
   }, [isOpen]);
+
+  const addReward = () => {
+    if (!queryTokenBalance) return;
+
+    const newBalance = {
+      contractAddress: inputRewardsModuleBalanceCheck,
+      tokenBalance: queryTokenBalance.formatted,
+    };
+
+    if (!rewardsStore.rewards.balance) {
+      rewardsStore.setRewards({
+        ...rewardsStore.rewards,
+        balance: [newBalance],
+      });
+    } else {
+      rewardsStore.setRewards({
+        ...rewardsStore.rewards,
+        balance: [...rewardsStore.rewards.balance, newBalance],
+      });
+    }
+  };
 
   return (
     <DialogModalV3
@@ -77,26 +91,42 @@ export const DialogCheckBalanceRewardsModule: FC<DialogCheckBalanceRewardsModule
             onChange={setInputRewardsModuleBalanceCheck}
           />
 
-          {queryTokenBalance?.isError && (
-            <div className="pt-2 flex items-center">
-              <CrossIcon />
-              <p className="text-negative-11 text-2xs">{queryTokenBalance?.error?.message}</p>{" "}
+          {error && (
+            <div className="pt-2 gap-2 flex items-center">
+              <CrossIcon color="#FF78A9" />
+              <p className="text-negative-11 text-2xs">{error}</p>{" "}
             </div>
           )}
-          {queryTokenBalance?.isSuccess && (
+          {queryTokenBalance && tokenAlreadyAdded && (
             <div className="pt-2 flex items-center gap-1">
               <CheckmarkIcon color="#78FFC6" />
-              <p className="text-positive-11 text-[16px] uppercase">${queryTokenBalance?.data?.symbol}</p>{" "}
+              <p className="text-positive-11 text-[16px]">
+                <span className="uppercase">${queryTokenBalance?.symbol}</span> has already been added to your rewards
+              </p>
             </div>
           )}
         </div>
-        {queryTokenBalance?.data?.formatted && (
-          <div className="flex gap-2 animate-appear text-[16px] pt-6 font-bold">
-            <p>balance:</p>
-            <p className="uppercase text-positive-11">
-              {queryTokenBalance?.data?.formatted} ${queryTokenBalance?.data?.symbol}
-            </p>
-          </div>
+        {queryTokenBalance?.formatted && !tokenAlreadyAdded && (
+          <ul className="flex gap-6 text-[16px] pt-6 font-bold list-explainer animate-appear">
+            <li className="flex items-center uppercase">
+              {queryTokenBalance?.formatted} ${queryTokenBalance?.symbol}
+            </li>
+            <div className="flex gap-2">
+              <ButtonV3 size="extraSmall" color="bg-gradient-distribute" onClick={addReward}>
+                add
+              </ButtonV3>
+              {creator && (
+                <ButtonV3
+                  disabled={txWithdraw.isLoading}
+                  size="extraSmall"
+                  color="bg-gradient-withdraw"
+                  onClick={() => contractWriteWithdrawReward.write()}
+                >
+                  Withdraw
+                </ButtonV3>
+              )}
+            </div>
+          </ul>
         )}
       </div>
     </DialogModalV3>

--- a/packages/react-app-revamp/components/_pages/DialogWithdrawFundsFromRewardsModule/ButtonWithdraw.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogWithdrawFundsFromRewardsModule/ButtonWithdraw.tsx
@@ -1,5 +1,6 @@
 import ButtonV3 from "@components/UI/ButtonV3";
 import { toastLoading } from "@components/UI/Toast";
+import { utils } from "ethers";
 
 interface ButtonWithdrawErc20RewardProps {
   queryTokenBalance: any;
@@ -11,23 +12,25 @@ export const ButtonWithdraw = (props: ButtonWithdrawErc20RewardProps) => {
   const { queryTokenBalance, contractWriteWithdraw, txWithdraw } = props;
 
   return (
-    <>
+    <section className="flex justify-between w-[350px] animate-appear">
+      <p className="animate-appear">
+        {queryTokenBalance.data?.decimals <= 18
+          ? parseFloat(utils.formatEther(queryTokenBalance.data?.value))
+          : parseFloat(utils.formatUnits(queryTokenBalance.data?.value, queryTokenBalance.data.decimals))}{" "}
+        <span className="uppercase">${queryTokenBalance?.data?.symbol}</span>
+      </p>
       <ButtonV3
-        disabled={contractWriteWithdraw.isLoading || txWithdraw.isLoading}
-        size="large"
-        color="bg-gradient-distribute"
+        disabled={contractWriteWithdraw.isLoadi1ng || txWithdraw.isLoading}
+        size="extraSmall"
+        color="bg-gradient-withdraw"
         onClick={() => {
           toastLoading("withdrawing funds...");
           contractWriteWithdraw.write();
         }}
       >
-        Withdraw all ${queryTokenBalance.data?.symbol}
+        Withdraw
       </ButtonV3>
-      <p className="pt-2 text-2xs text-neutral-11 font-bold flex flex-wrap items-start">
-        Rewards module {queryTokenBalance.data?.symbol} balance:{" "}
-        {parseFloat(queryTokenBalance?.data?.formatted).toFixed(4)}
-      </p>
-    </>
+    </section>
   );
 };
 

--- a/packages/react-app-revamp/components/_pages/DialogWithdrawFundsFromRewardsModule/ButtonWithdrawERC20Reward.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogWithdrawFundsFromRewardsModule/ButtonWithdrawERC20Reward.tsx
@@ -1,7 +1,4 @@
-import { toastDismiss, toastError, toastSuccess } from "@components/UI/Toast";
-import { toast } from "react-toastify";
-import { CustomError, ErrorCodes } from "types/error";
-import { useBalance, useContractWrite, useNetwork, useWaitForTransaction } from "wagmi";
+import { useWithdrawReward } from "@hooks/useWithdrawRewards";
 import ButtonWithdraw from "./ButtonWithdraw";
 interface ButtonWithdrawErc20RewardProps {
   contractRewardsModuleAddress: string;
@@ -11,52 +8,18 @@ interface ButtonWithdrawErc20RewardProps {
 
 export const ButtonWithdrawERC20Reward = (props: ButtonWithdrawErc20RewardProps) => {
   const { contractRewardsModuleAddress, tokenAddress, abiRewardsModule } = props;
-  const { chain } = useNetwork();
-  const queryTokenBalance = useBalance({
-    token: tokenAddress,
-    chainId: chain?.id,
-    addressOrName: contractRewardsModuleAddress,
-  });
-  const contractWriteWithdrawERC20Reward = useContractWrite({
-    addressOrName: contractRewardsModuleAddress,
-    contractInterface: abiRewardsModule,
-    functionName: "withdrawRewards(address)",
-    chainId: chain?.id,
-    args: [tokenAddress],
-    onError(e) {
-      const customError = e as CustomError;
-      if (!customError) return;
-
-      if (customError.code === ErrorCodes.USER_REJECTED_TX) {
-        toastDismiss();
-        return;
-      }
-      toastError(`something went wrong and the funds couldn't be withdrawn`, customError.message);
-    },
-  });
-
-  const txWithdrawERC20 = useWaitForTransaction({
-    hash: contractWriteWithdrawERC20Reward?.data?.hash,
-    onError(e) {
-      const customError = e as CustomError;
-      if (!customError) return;
-
-      if (customError.code === ErrorCodes.USER_REJECTED_TX) {
-        toastDismiss();
-        return;
-      }
-      toastError(`something went wrong and the funds couldn't be withdrawn`, customError.message);
-    },
-    onSuccess() {
-      toastSuccess("Funds withdrawn successfully !");
-    },
-  });
+  const { queryTokenBalance, contractWriteWithdrawReward, txWithdraw } = useWithdrawReward(
+    contractRewardsModuleAddress,
+    abiRewardsModule,
+    "erc20",
+    tokenAddress,
+  );
 
   return (
     <ButtonWithdraw
-      contractWriteWithdraw={contractWriteWithdrawERC20Reward}
+      contractWriteWithdraw={contractWriteWithdrawReward}
       queryTokenBalance={queryTokenBalance}
-      txWithdraw={txWithdrawERC20}
+      txWithdraw={txWithdraw}
     />
   );
 };

--- a/packages/react-app-revamp/components/_pages/DialogWithdrawFundsFromRewardsModule/ButtonWithdrawNativeReward.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogWithdrawFundsFromRewardsModule/ButtonWithdrawNativeReward.tsx
@@ -1,7 +1,4 @@
-import { toastDismiss, toastError, toastSuccess } from "@components/UI/Toast";
-import { toast } from "react-toastify";
-import { CustomError, ErrorCodes } from "types/error";
-import { useBalance, useContractWrite, useNetwork, useWaitForTransaction } from "wagmi";
+import { useWithdrawReward } from "@hooks/useWithdrawRewards";
 import ButtonWithdraw from "./ButtonWithdraw";
 interface ButtonWithdrawNativeRewardProps {
   contractRewardsModuleAddress: string;
@@ -10,51 +7,17 @@ interface ButtonWithdrawNativeRewardProps {
 
 export const ButtonWithdrawNativeReward = (props: ButtonWithdrawNativeRewardProps) => {
   const { contractRewardsModuleAddress, abiRewardsModule } = props;
-  const { chain } = useNetwork();
-  const queryTokenBalance = useBalance({
-    addressOrName: contractRewardsModuleAddress,
-    chainId: chain?.id,
-  });
-  const contractWriteWithdrawNativeReward = useContractWrite({
-    addressOrName: contractRewardsModuleAddress,
-    contractInterface: abiRewardsModule,
-    functionName: "withdrawRewards()",
-    chainId: chain?.id,
-    onError(e) {
-      const customError = e as CustomError;
-      if (!customError) return;
-
-      if (customError.code === ErrorCodes.USER_REJECTED_TX) {
-        toastDismiss();
-        return;
-      }
-
-      toastError(`something went wrong and the funds couldn't be withdrawn`, customError.message);
-    },
-  });
-
-  const txWithdrawNative = useWaitForTransaction({
-    hash: contractWriteWithdrawNativeReward?.data?.hash,
-    onError(e) {
-      const customError = e as CustomError;
-      if (!customError) return;
-
-      if (customError.code === ErrorCodes.USER_REJECTED_TX) {
-        toastDismiss();
-        return;
-      }
-      toastError(`something went wrong and the funds couldn't be withdrawn`, customError.message);
-    },
-    onSuccess() {
-      toastSuccess("Funds withdrawn successfully !");
-    },
-  });
+  const { queryTokenBalance, contractWriteWithdrawReward, txWithdraw } = useWithdrawReward(
+    contractRewardsModuleAddress,
+    abiRewardsModule,
+    "native",
+  );
 
   return (
     <ButtonWithdraw
-      contractWriteWithdraw={contractWriteWithdrawNativeReward}
+      contractWriteWithdraw={contractWriteWithdrawReward}
       queryTokenBalance={queryTokenBalance}
-      txWithdraw={txWithdrawNative}
+      txWithdraw={txWithdraw}
     />
   );
 };

--- a/packages/react-app-revamp/components/_pages/DialogWithdrawFundsFromRewardsModule/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogWithdrawFundsFromRewardsModule/index.tsx
@@ -1,4 +1,3 @@
-import DialogModal from "@components/UI/DialogModal";
 import DialogModalV3 from "@components/UI/DialogModalV3";
 
 interface DialogWithdrawFundsFromRewardsModuleProps {
@@ -11,7 +10,7 @@ export const DialogWithdrawFundsFromRewardsModule = (props: DialogWithdrawFundsF
   const { children, ...dialogProps } = props;
 
   return (
-    <DialogModalV3 title="Withdraw rewards from module" {...dialogProps} className="xl:w-[1110px] 3xl:w-[1300px]">
+    <DialogModalV3 title="Withdraw rewards from module" {...dialogProps} className="w-full md:w-[700px]">
       <p className="font-bold mb-4 animate-appear">Withdraw funds from the rewards module</p>
       {children}
     </DialogModalV3>

--- a/packages/react-app-revamp/components/_pages/ListContests/Contest/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListContests/Contest/index.tsx
@@ -332,8 +332,7 @@ const Contest: FC<ContestProps> = ({ contest, compact, loading }) => {
                   <Skeleton />
                 ) : (
                   <>
-                    {parseInt(contest.rewards.token.value, 10)}{" "}
-                    <span className="uppercase">${contest.rewards.token.symbol}</span>
+                    {contest.rewards.token.value} <span className="uppercase">${contest.rewards.token.symbol}</span>
                   </>
                 )}
               </p>
@@ -414,7 +413,7 @@ const Contest: FC<ContestProps> = ({ contest, compact, loading }) => {
                         <Skeleton />
                       ) : (
                         <>
-                          {parseInt(contest.rewards.token.value, 10)}{" "}
+                          {contest.rewards.token.value}{" "}
                           <span className="uppercase">${contest.rewards.token.symbol}</span>
                         </>
                       )}

--- a/packages/react-app-revamp/components/_pages/Rewards/components/Withdraw/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Rewards/components/Withdraw/index.tsx
@@ -2,7 +2,7 @@ import ButtonWithdrawERC20Reward from "@components/_pages/DialogWithdrawFundsFro
 import ButtonWithdrawNativeReward from "@components/_pages/DialogWithdrawFundsFromRewardsModule/ButtonWithdrawNativeReward";
 import { Tab } from "@headlessui/react";
 import { FC, Fragment } from "react";
-import { useNetwork } from "wagmi";
+import { useBalance, useNetwork } from "wagmi";
 
 interface ContestWithdrawRewardsProps {
   rewardsStore: any;
@@ -10,11 +10,15 @@ interface ContestWithdrawRewardsProps {
 
 const ContestWithdrawRewards: FC<ContestWithdrawRewardsProps> = ({ rewardsStore }) => {
   const { chain } = useNetwork();
+  const nativeTokenBalance = useBalance({
+    addressOrName: rewardsStore?.rewards?.contractAddress,
+    chainId: chain?.id,
+  });
 
   return (
-    <div className="w-1/2">
+    <div className="w-full">
       <Tab.Group>
-        <Tab.List className="animate-appear overflow-hidden text-xs font-medium mb-6 divide-i divide-neutral-4 flex rounded-full border-solid border border-neutral-4">
+        <Tab.List className="animate-appear w-[400px] overflow-hidden text-[16px] font-medium mb-6 divide-neutral-4 flex rounded-full border-solid border border-neutral-4">
           {["ERC20", chain?.nativeCurrency?.symbol].map(tab => (
             <Tab key={tab} as={Fragment}>
               {({ selected }) => (
@@ -31,9 +35,9 @@ const ContestWithdrawRewards: FC<ContestWithdrawRewardsProps> = ({ rewardsStore 
         <Tab.Panels>
           <Tab.Panel>
             {rewardsStore?.rewards?.balance?.length ? (
-              <ul className="flex flex-col items-start space-y-6">
-                {rewardsStore?.rewards?.balance?.map((token: { contractAddress: string }) => (
-                  <li className="flex flex-col items-start" key={`withdraw-erc20-${token.contractAddress}`}>
+              <ul className="flex flex-col gap-3 pl-4 text-[16px] font-bold list-explainer">
+                {rewardsStore?.rewards?.balance?.map((token: { contractAddress: string }, index: number) => (
+                  <li className="flex items-center" key={index}>
                     <ButtonWithdrawERC20Reward
                       contractRewardsModuleAddress={rewardsStore.rewards.contractAddress}
                       abiRewardsModule={rewardsStore.rewards.abi}
@@ -44,15 +48,25 @@ const ContestWithdrawRewards: FC<ContestWithdrawRewardsProps> = ({ rewardsStore 
               </ul>
             ) : (
               <>
-                <p className="italic animate-appear text-neutral-11">No balance found for ERC20 tokens.</p>
+                <p className="italic text-[16px] animate-appear text-neutral-11">No balance found for ERC20 tokens.</p>
               </>
             )}
           </Tab.Panel>
-          <Tab.Panel className="flex flex-col items-start">
-            <ButtonWithdrawNativeReward
-              contractRewardsModuleAddress={rewardsStore.rewards.contractAddress}
-              abiRewardsModule={rewardsStore.rewards.abi}
-            />
+          <Tab.Panel>
+            {nativeTokenBalance.data?.value.gt(0) ? (
+              <ul className="flex flex-col gap-3 pl-4 text-[16px] font-bold list-explainer">
+                <li className="flex items-center">
+                  <ButtonWithdrawNativeReward
+                    contractRewardsModuleAddress={rewardsStore.rewards.contractAddress}
+                    abiRewardsModule={rewardsStore.rewards.abi}
+                  />
+                </li>
+              </ul>
+            ) : (
+              <p className="italic text-[16px] animate-appear text-neutral-11">
+                No balance found for $<span className="uppercase">{nativeTokenBalance.data?.symbol}</span>.
+              </p>
+            )}
           </Tab.Panel>
         </Tab.Panels>
       </Tab.Group>

--- a/packages/react-app-revamp/components/_pages/RewardsDistributionTable/components/ERC20Reward/index.tsx
+++ b/packages/react-app-revamp/components/_pages/RewardsDistributionTable/components/ERC20Reward/index.tsx
@@ -1,8 +1,4 @@
-import { toastDismiss, toastError, toastSuccess } from "@components/UI/Toast";
-import { utils } from "ethers";
-import { toast } from "react-toastify";
-import { CustomError, ErrorCodes } from "types/error";
-import { useBalance, useContractRead, useContractWrite, useNetwork, useToken, useWaitForTransaction } from "wagmi";
+import { useDistributeRewards } from "@hooks/useDistributeRewards";
 import Reward from "../Reward";
 
 interface PayeeERC20RewardProps {
@@ -16,87 +12,21 @@ interface PayeeERC20RewardProps {
 
 export const PayeeERC20Reward = (props: PayeeERC20RewardProps) => {
   const { payee, tokenAddress, share, contractRewardsModuleAddress, abiRewardsModule, chainId } = props;
-
-  const queryTokenBalance = useBalance({
-    addressOrName: contractRewardsModuleAddress,
+  const {
+    queryTokenBalance,
+    queryRankRewardsReleasable,
+    queryRankRewardsReleased,
+    contractWriteReleaseToken,
+    txRelease,
+  } = useDistributeRewards(
+    payee,
+    share,
+    contractRewardsModuleAddress,
+    abiRewardsModule,
     chainId,
-    token: tokenAddress,
-  });
-  const queryRankRewardsReleasable = useContractRead({
-    addressOrName: contractRewardsModuleAddress,
-    contractInterface: abiRewardsModule,
-    chainId,
-    functionName: "releasable(address,uint256)",
-    args: [tokenAddress, parseInt(`${payee}`)],
-    //@ts-ignore
-    select: data => {
-      return parseFloat(utils.formatEther(data)).toFixed(4);
-    },
-    onError(e) {
-      const customError = e as CustomError;
-      if (!customError) return;
-
-      if (customError.code === ErrorCodes.USER_REJECTED_TX) {
-        toastDismiss();
-        return;
-      }
-
-      toastError(`something went wrong and the the transaction failed`, customError.message);
-    },
-  });
-
-  const queryRankRewardsReleased = useContractRead({
-    addressOrName: contractRewardsModuleAddress,
-    contractInterface: abiRewardsModule,
-    chainId,
-    functionName: "released(address,uint256)",
-    args: [tokenAddress, parseInt(`${payee}`)],
-    //@ts-ignore
-    select: data => {
-      return parseFloat(utils.formatEther(data)).toFixed(4);
-    },
-    onError(e) {
-      const customError = e as CustomError;
-      if (!customError) return;
-
-      if (customError.code === ErrorCodes.USER_REJECTED_TX) {
-        toastDismiss();
-        return;
-      }
-
-      toastError(`something went wrong and the the transaction failed`, customError.message);
-    },
-  });
-
-  const contractWriteReleaseToken = useContractWrite({
-    addressOrName: contractRewardsModuleAddress,
-    contractInterface: abiRewardsModule,
-    functionName: "release(address,uint256)",
-    args: [tokenAddress, parseInt(`${payee}`)],
-    chainId,
-  });
-
-  const txRelease = useWaitForTransaction({
-    hash: contractWriteReleaseToken?.data?.hash,
-    chainId,
-    onError(e) {
-      const customError = e as CustomError;
-      if (!customError) return;
-
-      if (customError.code === ErrorCodes.USER_REJECTED_TX) {
-        toastDismiss();
-        return;
-      }
-
-      toastError(`something went wrong and the the transaction failed`, customError.message);
-    },
-    async onSuccess() {
-      await queryTokenBalance.refetch();
-      await queryRankRewardsReleased.refetch();
-      await queryRankRewardsReleasable.refetch();
-      toastSuccess("funds distributed successfully !");
-    },
-  });
+    "erc20",
+    tokenAddress,
+  );
 
   return (
     <Reward

--- a/packages/react-app-revamp/components/_pages/RewardsDistributionTable/components/NativeReward/index.tsx
+++ b/packages/react-app-revamp/components/_pages/RewardsDistributionTable/components/NativeReward/index.tsx
@@ -1,8 +1,4 @@
-import { toastDismiss, toastError, toastSuccess } from "@components/UI/Toast";
-import { utils } from "ethers";
-import { toast } from "react-toastify";
-import { CustomError, ErrorCodes } from "types/error";
-import { useBalance, useContractRead, useContractWrite, useWaitForTransaction } from "wagmi";
+import { useDistributeRewards } from "@hooks/useDistributeRewards";
 import Reward from "../Reward";
 
 interface PayeeNativeRewardProps {
@@ -15,67 +11,13 @@ interface PayeeNativeRewardProps {
 
 export const PayeeNativeReward = (props: PayeeNativeRewardProps) => {
   const { payee, share, contractRewardsModuleAddress, abiRewardsModule, chainId } = props;
-  const queryTokenBalance = useBalance({
-    addressOrName: contractRewardsModuleAddress,
-    chainId,
-  });
-  const queryRankRewardsReleasable = useContractRead({
-    addressOrName: contractRewardsModuleAddress,
-    contractInterface: abiRewardsModule,
-    functionName: "releasable(uint256)",
-    chainId,
-    args: [payee],
-    //@ts-ignore
-    select: data => parseFloat(utils.formatEther(data)).toFixed(4),
-  });
-
-  const queryRankRewardsReleased = useContractRead({
-    addressOrName: contractRewardsModuleAddress,
-    contractInterface: abiRewardsModule,
-    functionName: "released(uint256)",
-    chainId,
-    args: [payee],
-    //@ts-ignore
-    select: data => parseFloat(utils.formatEther(data)).toFixed(4),
-  });
-
-  const contractWriteReleaseToken = useContractWrite({
-    addressOrName: contractRewardsModuleAddress,
-    contractInterface: abiRewardsModule,
-    functionName: "release(uint256)",
-    chainId,
-    args: [payee],
-    onError(e) {
-      const customError = e as CustomError;
-      if (!customError) return;
-
-      if (customError.code === ErrorCodes.USER_REJECTED_TX) {
-        toastDismiss();
-        return;
-      }
-
-      toastError(`something went wrong and the the transaction failed`, customError.message);
-    },
-  });
-
-  const txRelease = useWaitForTransaction({
-    hash: contractWriteReleaseToken?.data?.hash,
-    chainId,
-    onError(e) {
-      const customError = e as CustomError;
-      if (!customError) return;
-
-      if (customError.code === ErrorCodes.USER_REJECTED_TX) {
-        toastDismiss();
-        return;
-      }
-
-      toastError(`something went wrong and the the transaction failed`, customError.message);
-    },
-    onSuccess() {
-      toastSuccess("funds distributed successfully !");
-    },
-  });
+  const {
+    queryTokenBalance,
+    queryRankRewardsReleasable,
+    queryRankRewardsReleased,
+    contractWriteReleaseToken,
+    txRelease,
+  } = useDistributeRewards(payee, share, contractRewardsModuleAddress, abiRewardsModule, chainId, "native");
 
   return (
     <Reward

--- a/packages/react-app-revamp/components/_pages/RewardsDistributionTable/components/Reward/index.tsx
+++ b/packages/react-app-revamp/components/_pages/RewardsDistributionTable/components/Reward/index.tsx
@@ -1,8 +1,8 @@
-import Button from "@components/UI/Button";
 import ButtonV3 from "@components/UI/ButtonV3";
 import Loader from "@components/UI/Loader";
 import { toastLoading } from "@components/UI/Toast";
 import { ContestStatus, useContestStatusStore } from "@hooks/useContestStatus/store";
+import { Tooltip } from "react-tooltip";
 
 interface RewardProps {
   share: any;
@@ -21,17 +21,15 @@ export const Reward = (props: RewardProps) => {
   if (queryTokenBalance.isLoading) return <Loader scale="component">Loading ERC20 token info...</Loader>;
 
   return (
-    <section className="flex justify-between animate-appear">
+    <section className="flex justify-between w-full animate-appear">
       {(queryRankRewardsReleased.isLoading || queryRankRewardsReleasable.isLoading) && (
         <Loader scale="component">Loading info...</Loader>
       )}
-      <div className="mb-2">
-        <p className="animate-appear">
-          {queryRankRewardsReleasable.data} <span className="normal-case">${queryTokenBalance?.data?.symbol}</span>
-        </p>
-      </div>
+      <p className="animate-appear">
+        {queryRankRewardsReleasable.data} <span className="uppercase">${queryTokenBalance?.data?.symbol}</span>
+      </p>
       {queryRankRewardsReleased.isSuccess && (
-        <>
+        <div data-tooltip-id={`tooltip-${queryTokenBalance?.data?.symbol}`}>
           {queryRankRewardsReleasable.data && (
             <ButtonV3
               disabled={contestStatus !== ContestStatus.VotingClosed || contractWriteRelease.isLoading}
@@ -45,7 +43,12 @@ export const Reward = (props: RewardProps) => {
               distribute
             </ButtonV3>
           )}
-        </>
+        </div>
+      )}
+      {contestStatus !== ContestStatus.VotingClosed && (
+        <Tooltip id={`tooltip-${queryTokenBalance?.data?.symbol}`}>
+          <p className="text-[16px]">funds cannot be distributed until voting has ended!</p>
+        </Tooltip>
       )}
     </section>
   );

--- a/packages/react-app-revamp/helpers/tokens.ts
+++ b/packages/react-app-revamp/helpers/tokens.ts
@@ -59,7 +59,7 @@ const CHAIN_CONFIGS: ChainConfigs = {
       {
         name: "USD Coin",
         shorthand: "usdc",
-        address: "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+        address: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       },
     ],
   },
@@ -139,7 +139,7 @@ const CHAIN_CONFIGS: ChainConfigs = {
       {
         name: "USD Coin",
         shorthand: "usdc",
-        address: "0x07865c6E87B9F70255377e024ace6630C1Eaa37F",
+        address: "0xda9d4f9b69ac6C22e444eD9aF0CfC043b7a7f53f",
       },
     ],
   },

--- a/packages/react-app-revamp/hooks/useDistributeRewards/index.tsx
+++ b/packages/react-app-revamp/hooks/useDistributeRewards/index.tsx
@@ -1,0 +1,91 @@
+import { toastDismiss, toastError, toastSuccess } from "@components/UI/Toast";
+import { utils } from "ethers";
+import { CustomError, ErrorCodes } from "types/error";
+import { useBalance, useContractRead, useContractWrite, useToken, useWaitForTransaction } from "wagmi";
+
+type TokenType = "erc20" | "native";
+
+export const useDistributeRewards = (
+  payee: number,
+  share: any,
+  contractRewardsModuleAddress: string,
+  abiRewardsModule: any,
+  chainId: number,
+  tokenType: TokenType,
+  tokenAddress?: string,
+) => {
+  const { data: tokenData } = tokenType === "erc20" ? useToken({ address: tokenAddress, chainId }) : { data: null };
+
+  const queryTokenBalance = useBalance({
+    addressOrName: contractRewardsModuleAddress,
+    chainId,
+    token: tokenType === "erc20" ? tokenAddress : undefined,
+  });
+
+  const queryRankRewardsReleasable = useContractRead({
+    addressOrName: contractRewardsModuleAddress,
+    contractInterface: abiRewardsModule,
+    chainId,
+    functionName: tokenType === "erc20" ? "releasable(address,uint256)" : "releasable(uint256)",
+    args: tokenType === "erc20" ? [tokenAddress, payee] : [payee],
+    //@ts-ignore
+    select: data =>
+      tokenType === "erc20"
+        ? parseFloat(utils.formatUnits(data, tokenData?.decimals))
+        : parseFloat(utils.formatEther(data)),
+  });
+
+  const queryRankRewardsReleased = useContractRead({
+    addressOrName: contractRewardsModuleAddress,
+    contractInterface: abiRewardsModule,
+    chainId,
+    functionName: tokenType === "erc20" ? "released(address,uint256)" : "released(uint256)",
+    args: tokenType === "erc20" ? [tokenAddress, payee] : [payee],
+    //@ts-ignore
+
+    select: data =>
+      tokenType === "erc20"
+        ? parseFloat(utils.formatUnits(data, tokenData?.decimals))
+        : parseFloat(utils.formatEther(data)),
+  });
+
+  const contractWriteReleaseToken = useContractWrite({
+    addressOrName: contractRewardsModuleAddress,
+    contractInterface: abiRewardsModule,
+    functionName: tokenType === "erc20" ? "release(address,uint256)" : "release(uint256)",
+    args: tokenType === "erc20" ? [tokenAddress, payee] : [payee],
+    chainId,
+  });
+
+  const txRelease = useWaitForTransaction({
+    hash: contractWriteReleaseToken?.data?.hash,
+    chainId,
+    async onError(e) {
+      const customError = e as CustomError;
+      if (!customError) return;
+
+      if (customError.code === ErrorCodes.USER_REJECTED_TX) {
+        toastDismiss();
+        return;
+      }
+
+      toastError(`something went wrong and the the transaction failed`, customError.message);
+    },
+    async onSuccess() {
+      await queryTokenBalance.refetch();
+      await queryRankRewardsReleased.refetch();
+      await queryRankRewardsReleasable.refetch();
+      toastSuccess("funds distributed successfully !");
+    },
+  });
+
+  return {
+    share,
+    chainId,
+    queryTokenBalance,
+    queryRankRewardsReleasable,
+    queryRankRewardsReleased,
+    contractWriteReleaseToken,
+    txRelease,
+  };
+};

--- a/packages/react-app-revamp/hooks/useFundRewards/index.ts
+++ b/packages/react-app-revamp/hooks/useFundRewards/index.ts
@@ -108,6 +108,8 @@ export function useFundRewardsModule() {
   }
 
   const sendFundsToRewardsModuleV3 = ({ rewards }: any) => {
+    setIsLoading(true);
+    setIsSuccess(false);
     if (rewards.length > 3) {
       toast.warning("number of rewards cannot be more than 4 in one take.");
       return;
@@ -117,6 +119,7 @@ export function useFundRewardsModule() {
         sendFundsToSingleReward(reward)
           .then(result => {
             setTransactionData((prevData: any) => [...prevData, result]);
+            setIsLoading(false);
             setIsSuccess(true);
           })
           .catch(e => {
@@ -127,6 +130,7 @@ export function useFundRewardsModule() {
               code: customError.code,
               message,
             });
+            setIsSuccess(false);
             setIsLoading(false);
             throw e; // This will stop the execution of the promises in case of error
           });

--- a/packages/react-app-revamp/hooks/useRewards/index.ts
+++ b/packages/react-app-revamp/hooks/useRewards/index.ts
@@ -2,7 +2,8 @@ import { toastError } from "@components/UI/Toast";
 import { chains } from "@config/wagmi";
 import getContestContractVersion from "@helpers/getContestContractVersion";
 import getRewardsModuleContractVersion from "@helpers/getRewardsModuleContractVersion";
-import { alchemyRpcUrls, readContract, readContracts } from "@wagmi/core";
+import { alchemyRpcUrls, fetchToken, readContract, readContracts } from "@wagmi/core";
+import { ethers } from "ethers";
 import { useRouter } from "next/router";
 import { CustomError } from "types/error";
 import { useNetwork, useQuery } from "wagmi";
@@ -40,15 +41,17 @@ export function useRewardsModule() {
           redirect: "follow",
         });
         const asJson = await response.json();
-        // Remove tokens with zero balance
-        const balance = asJson.result?.tokenBalances?.filter((token: any) => {
-          return token["tokenBalance"] !== "0";
+
+        const balances = asJson.result?.tokenBalances?.filter((token: any) => {
+          const tokenBalance = ethers.BigNumber.from(token["tokenBalance"]);
+          return tokenBalance.gt(0);
         });
+
         setRewards({
           ...rewards,
-          balance: balance,
+          balance: balances,
         });
-        return balance;
+        return balances;
       } catch (e) {
         console.error(e);
       }

--- a/packages/react-app-revamp/hooks/useTokenBalance/index.tsx
+++ b/packages/react-app-revamp/hooks/useTokenBalance/index.tsx
@@ -1,0 +1,49 @@
+import { chains } from "@config/wagmi";
+import { useRewardsStore } from "@hooks/useRewards/store";
+import { fetchBalance, FetchBalanceResult } from "@wagmi/core";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { CustomError } from "types/error";
+
+export const useTokenBalance = (inputToken: string) => {
+  const rewardsStore = useRewardsStore(state => state);
+  const { asPath } = useRouter();
+  const [queryTokenBalance, setQueryTokenBalance] = useState<FetchBalanceResult>();
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (inputToken === "") {
+      setQueryTokenBalance(undefined);
+      setError("");
+      return;
+    }
+
+    const fetchTokenBalance = async () => {
+      if (inputToken?.match(/^0x[a-fA-F0-9]{40}$/)) {
+        const chainId = chains.filter(
+          chain => chain.name.toLowerCase().replace(" ", "") === asPath.split("/")?.[2],
+        )?.[0]?.id;
+        try {
+          const balance = await fetchBalance({
+            chainId,
+            addressOrName: rewardsStore?.rewards?.contractAddress,
+            token: inputToken,
+          });
+          setQueryTokenBalance(balance);
+          setError("");
+        } catch (error) {
+          const customError = error as CustomError;
+          setError(customError.message);
+          setQueryTokenBalance(undefined);
+        }
+      } else {
+        setError("Invalid address!");
+        setQueryTokenBalance(undefined);
+      }
+    };
+
+    fetchTokenBalance();
+  }, [inputToken]);
+
+  return { queryTokenBalance, error };
+};

--- a/packages/react-app-revamp/hooks/useWithdrawRewards/index.tsx
+++ b/packages/react-app-revamp/hooks/useWithdrawRewards/index.tsx
@@ -1,0 +1,57 @@
+import { toastDismiss, toastError, toastSuccess } from "@components/UI/Toast";
+import { CustomError, ErrorCodes } from "types/error";
+import { useBalance, useContractWrite, useNetwork, useWaitForTransaction } from "wagmi";
+
+type TokenType = "erc20" | "native";
+
+export const useWithdrawReward = (
+  contractRewardsModuleAddress: string,
+  abiRewardsModule: any,
+  tokenType: TokenType,
+  tokenAddress?: string,
+) => {
+  const { chain } = useNetwork();
+
+  const queryTokenBalance = useBalance({
+    token: tokenType === "erc20" ? tokenAddress : undefined,
+    chainId: chain?.id,
+    addressOrName: contractRewardsModuleAddress,
+  });
+
+  const contractWriteWithdrawReward = useContractWrite({
+    addressOrName: contractRewardsModuleAddress,
+    contractInterface: abiRewardsModule,
+    functionName: tokenType === "erc20" ? "withdrawRewards(address)" : "withdrawRewards()",
+    chainId: chain?.id,
+    args: tokenType === "erc20" ? [tokenAddress] : [],
+    onError(e) {
+      const customError = e as CustomError;
+      if (!customError) return;
+
+      if (customError.code === ErrorCodes.USER_REJECTED_TX) {
+        toastDismiss();
+        return;
+      }
+      toastError(`something went wrong and the funds couldn't be withdrawn`, customError.message);
+    },
+  });
+
+  const txWithdraw = useWaitForTransaction({
+    hash: contractWriteWithdrawReward?.data?.hash,
+    onError(e) {
+      const customError = e as CustomError;
+      if (!customError) return;
+
+      if (customError.code === ErrorCodes.USER_REJECTED_TX) {
+        toastDismiss();
+        return;
+      }
+      toastError(`something went wrong and the funds couldn't be withdrawn`, customError.message);
+    },
+    onSuccess() {
+      toastSuccess("Funds withdrawn successfully !");
+    },
+  });
+
+  return { queryTokenBalance, contractWriteWithdrawReward, txWithdraw };
+};

--- a/packages/react-app-revamp/lib/contests/index.ts
+++ b/packages/react-app-revamp/lib/contests/index.ts
@@ -4,7 +4,7 @@ import getContestContractVersion from "@helpers/getContestContractVersion";
 import getPagination from "@helpers/getPagination";
 import getRewardsModuleContractVersion from "@helpers/getRewardsModuleContractVersion";
 import { alchemyRpcUrls, fetchBalance, FetchBalanceResult, readContract, readContracts } from "@wagmi/core";
-import { BigNumber } from "ethers";
+import { BigNumber, ethers, utils } from "ethers";
 import { fetchUserBalance } from "lib/fetchUserBalance";
 import { Recipient } from "lib/merkletree/generateMerkleTree";
 import moment from "moment";
@@ -48,9 +48,10 @@ const fetchTokenBalances = async (contest: any, contestRewardModuleAddress: stri
       redirect: "follow",
     });
     const asJson = await response.json();
-    // Remove tokens with zero balance
+
     const balance = asJson.result?.tokenBalances?.filter((token: any) => {
-      return token["tokenBalance"] !== "0";
+      const tokenBalance = ethers.BigNumber.from(token["tokenBalance"]);
+      return tokenBalance.gt(0);
     });
 
     return balance;
@@ -163,7 +164,7 @@ const processContestData = async (contest: any, userAddress: string) => {
               contest.rewards = {
                 token: {
                   symbol: rewardToken.symbol,
-                  value: rewardToken.formatted,
+                  value: parseFloat(utils.formatUnits(rewardToken.value, rewardToken.decimals)),
                 },
                 winners: winners.length,
                 numberOfTokens: erc20Tokens?.length ?? 1,

--- a/packages/react-app-revamp/styles/globals.css
+++ b/packages/react-app-revamp/styles/globals.css
@@ -85,6 +85,10 @@ input[type="number"]::-webkit-outer-spin-button {
   font-size: 0 !important;
 }
 
+li {
+  box-sizing: border-box;
+}
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/packages/react-app-revamp/tailwind.config.js
+++ b/packages/react-app-revamp/tailwind.config.js
@@ -316,6 +316,7 @@ module.exports = {
         "gradient-create": "linear-gradient(90deg, #BB65FF 0%, #FFE25B 96.62%)",
         "gradient-vote": "linear-gradient(93.06deg, #78FFC6 0%, #BB65FF 100%)",
         "gradient-distribute": "linear-gradient(180deg, #B0FED4 0%, #78FFC6 50%, #4A9575 100%)",
+        "gradient-withdraw": "linear-gradient(180deg, #FF78A9 0%, #f04f88 50%, #e93d82 100%)",
       },
       boxShadow: {
         "create-header": "0 3px 4px 0 rgba(255, 226, 91, 0.6)",


### PR DESCRIPTION
Closes #380
Closes #379
Closes #372

This PR addresses the UI/UX and codebase polishing of a rewards module.

**UI/UX changes:**

-  We had an error with resolving tokens that are any decimal besides standard 18 decimals, we now successfully distribute and withdraw them. Reading those values is now different as well, we are now displaying exact amount of decimals if needed ( for example 0.00069 $ETH ) 
- We are no longer showing erc20 tokens in contests table if there are no rewards, example was on polygon we would show 0 $WMATIC if there isn't any token in a pool.
- Modal for checking balances is now more intuitive, if token is already in a list we do not proceed with adding it, otherwise we have 2 options, 'add' and other one is 'withdraw' that only applies to the creator.
- Previously in rewards tab we were always showing amount of native tokens in the pool even if it is zero balance, we are now just showing what tokens actually exists in the pool.
- Withdraw modal is now updated to match style of overall rewards module.
- Bunch of minor UI issues that were present in a rewards module.

**Code:**

I was mostly removing business logic out of components into a hooks, so now we have reusable hooks like `useDistributeRewards` and `useWithdrawRewards` that we can use easily in different components.

**Things that are left:**

We are only left with updating list of tokens during adding / withdrawing from a pool and prettifying UI/UX of loading stuff in there, right now it is refreshed if you switch tabs. This should take just a little bit of time, i plan to implement it with cosmetics updates that are left in the morning so we can take library upgrades from tomorrow.

