### PR TITLE
bug: timeout fails if too many milliseconds, so just cap max timeout

### DIFF
--- a/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
@@ -34,7 +34,6 @@ import { useAccount, useNetwork } from "wagmi";
 import { getLayout as getBaseLayout } from "./../LayoutBase";
 import ContestTab from "./Contest";
 import ContestLayoutTabs, { Tab } from "./Tabs";
-import next from "next/types";
 
 const LayoutViewContest = (props: any) => {
   const { query, asPath, pathname, reload } = useRouter();
@@ -54,9 +53,11 @@ const LayoutViewContest = (props: any) => {
     state => state,
   );
 
-  const { contestStatus, setContestStatus } = useContestStatusStore(state => state);
+  const { setContestStatus } = useContestStatusStore(state => state);
   const { displayReloadBanner } = useContestEvents();
   const [tab, setTab] = useState<Tab>(Tab.Contest);
+
+  const MAX_MS_TIMEOUT: number = 100000000;
 
   useEffect(() => {
     const now = moment();
@@ -72,8 +73,7 @@ const LayoutViewContest = (props: any) => {
         const msUntilNext = nextTime.diff(now);
         timeoutId = setTimeout(() => {
           setContestStatus(nextStatus);
-          console.log("contest state just changed to ", nextStatus)
-        }, msUntilNext > 100000000 ? 100000000 : msUntilNext); // TODO: figure out what number we actually want here
+        }, msUntilNext > MAX_MS_TIMEOUT ? MAX_MS_TIMEOUT : msUntilNext);
       }
     };
 

--- a/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
@@ -34,6 +34,7 @@ import { useAccount, useNetwork } from "wagmi";
 import { getLayout as getBaseLayout } from "./../LayoutBase";
 import ContestTab from "./Contest";
 import ContestLayoutTabs, { Tab } from "./Tabs";
+import next from "next/types";
 
 const LayoutViewContest = (props: any) => {
   const { query, asPath, pathname, reload } = useRouter();
@@ -53,7 +54,7 @@ const LayoutViewContest = (props: any) => {
     state => state,
   );
 
-  const { setContestStatus } = useContestStatusStore(state => state);
+  const { contestStatus, setContestStatus } = useContestStatusStore(state => state);
   const { displayReloadBanner } = useContestEvents();
   const [tab, setTab] = useState<Tab>(Tab.Contest);
 
@@ -71,7 +72,8 @@ const LayoutViewContest = (props: any) => {
         const msUntilNext = nextTime.diff(now);
         timeoutId = setTimeout(() => {
           setContestStatus(nextStatus);
-        }, msUntilNext);
+          console.log("contest state just changed to ", nextStatus)
+        }, msUntilNext > 100000000 ? 100000000 : msUntilNext); // TODO: figure out what number we actually want here
       }
     };
 


### PR DESCRIPTION
The Submit button was not showing up on [this contest](https://jokerace.xyz/contest/optimism/0xA7C5d11Fd92c528665406471eC38B625D9a1F075) and it turns out that if the `msUntilNext` variable is too big, the timeout just executes immediately. And because there is a 1 month gap between the beginning and end of the submission period, the timeout was executing immediately, making the frontend think that voting was open!

Fixing for now by capping at 100,000,000 ms for max timeout, but we can change if we need to!