### PR TITLE
chore: refactor chains to be explicitly defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ You can also find v1 at [jokedao.jokedao.io](https://jokedao.jokedao.io)!
 - Create a `.env` file in `packages/react-app-revamp` (the frontend package) and paste the following values:
 
 ```
-NEXT_PUBLIC_INFURA_ID=
-NEXT_PUBLIC_ALCHEMY_KEY=
+NEXT_PUBLIC_POLYGON_ALCHEMY_KEY
+NEXT_PUBLIC_OPTIMISM_ALCHEMY_KEY
+NEXT_PUBLIC_ARBITRUM_ALCHEMY_KEY
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 NEXT_PUBLIC_LENS_API_URL=

--- a/packages/react-app-revamp/README.md
+++ b/packages/react-app-revamp/README.md
@@ -14,8 +14,9 @@ You can also find v1 at [jokedao.jokedao.io](https://jokedao.jokedao.io)!
 - Create a `.env` file in `packages/react-app-revamp` (the frontend package) and paste the following values:
 
 ```
-NEXT_PUBLIC_INFURA_ID=
-NEXT_PUBLIC_ALCHEMY_KEY=
+NEXT_PUBLIC_POLYGON_ALCHEMY_KEY
+NEXT_PUBLIC_OPTIMISM_ALCHEMY_KEY
+NEXT_PUBLIC_ARBITRUM_ALCHEMY_KEY
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 NEXT_PUBLIC_LENS_API_URL=

--- a/packages/react-app-revamp/config/wagmi/custom-chains/arbitrumOne.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/arbitrumOne.ts
@@ -1,0 +1,18 @@
+export const arbitrumOne = {
+  id: 42161,
+  name: 'arbitrumone',
+  network: 'arbitrumone',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'ETH',
+    symbol: 'ETH',
+  },
+  rpcUrls: {
+    public: 'https://rpc.ankr.com/arbitrum',
+    default: `https://arb-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ARBITRUM_ALCHEMY_KEY}`,
+  },
+  blockExplorers: {
+    etherscan: { name: 'Arbitrum Mainnet Etherscan', url: 'https://arbiscan.io/' },
+    default: { name: 'Arbitrum Mainnet Etherscan', url: 'https://arbiscan.io/' },
+  },
+}

--- a/packages/react-app-revamp/config/wagmi/custom-chains/goerli.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/goerli.ts
@@ -1,0 +1,18 @@
+export const goerli = {
+  id: 5,
+  name: 'goerli',
+  network: 'goerli',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'ETH',
+    symbol: 'ETH',
+  },
+  rpcUrls: {
+    public: 'https://rpc.ankr.com/eth_goerli',
+    default: 'https://rpc.ankr.com/eth_goerli',
+  },
+  blockExplorers: {
+    etherscan: { name: 'Goerli Etherscan', url: 'https://goerli.etherscan.io/' },
+    default: { name: 'Goerli Etherscan', url: 'https://goerli.etherscan.io/' },
+  },
+}

--- a/packages/react-app-revamp/config/wagmi/custom-chains/optimism.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/optimism.ts
@@ -1,0 +1,18 @@
+export const optimism = {
+  id: 10,
+  name: 'optimism',
+  network: 'optimism',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'ETH',
+    symbol: 'ETH',
+  },
+  rpcUrls: {
+    public: 'https://mainnet.optimism.io',
+    default: `https://opt-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_OPTIMISM_ALCHEMY_KEY}`,
+  },
+  blockExplorers: {
+    etherscan: { name: 'Optimism Mainnet Etherscan', url: 'https://optimistic.etherscan.io/' },
+    default: { name: 'Optimism Mainnet Etherscan', url: 'https://optimistic.etherscan.io/' },
+  },
+}

--- a/packages/react-app-revamp/config/wagmi/custom-chains/polygon.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/polygon.ts
@@ -1,0 +1,18 @@
+export const polygon = {
+  id: 137,
+  name: 'polygon',
+  network: 'polygon',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'MATIC',
+    symbol: 'MATIC',
+  },
+  rpcUrls: {
+    public: 'https://rpc.ankr.com/polygon',
+    default: `https://polygon-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_POLYGON_ALCHEMY_KEY}`,
+  },
+  blockExplorers: {
+    etherscan: { name: 'Polygon Mainnet Etherscan', url: 'https://polygonscan.com/' },
+    default: { name: 'Polygon Mainnet Etherscan', url: 'https://polygonscan.com/' },
+  },
+}

--- a/packages/react-app-revamp/config/wagmi/custom-chains/polygonMumbai.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/polygonMumbai.ts
@@ -1,0 +1,18 @@
+export const polygonMumbai = {
+  id: 80001,
+  name: 'polygonMumbai',
+  network: 'polygonMumbai',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'MATIC',
+    symbol: 'MATIC',
+  },
+  rpcUrls: {
+    public: 'https://rpc.ankr.com/polygon_mumbai',
+    default: 'https://rpc.ankr.com/polygon_mumbai',
+  },
+  blockExplorers: {
+    etherscan: { name: 'Polygon Mumbai Etherscan', url: 'https://mumbai.polygonscan.com/' },
+    default: { name: 'Polygon Mumbai Etherscan', url: 'https://mumbai.polygonscan.com/' },
+  },
+}

--- a/packages/react-app-revamp/config/wagmi/index.ts
+++ b/packages/react-app-revamp/config/wagmi/index.ts
@@ -1,4 +1,9 @@
-import { chain, configureChains, createClient } from "wagmi";
+import { Chain, configureChains, createClient } from "wagmi";
+import { polygon } from "./custom-chains/polygon";
+import { arbitrumOne } from "./custom-chains/arbitrumOne";
+import { optimism } from "./custom-chains/optimism";
+import { polygonMumbai } from "./custom-chains/polygonMumbai";
+import { goerli } from "./custom-chains/goerli";
 import { polygonZkTestnet } from "./custom-chains/polygonZkTestnet";
 import { polygonZkMainnet } from "./custom-chains/polygonZkMainnet";
 import { sepolia } from "./custom-chains/sepolia";
@@ -23,21 +28,20 @@ import { nearAuroraTestnet } from "./custom-chains/nearAuroraTestnet";
 import { gnosisMainnet } from "./custom-chains/gnosisMainnet";
 import { gnosisTestnet } from "./custom-chains/gnosisTestnet";
 import { publicProvider } from "wagmi/providers/public";
-import { infuraProvider } from "wagmi/providers/infura";
-import { alchemyProvider } from "wagmi/providers/alchemy";
+import { jsonRpcProvider } from "wagmi/providers/jsonRpc";
 import { connectorsForWallets, getDefaultWallets, wallet } from "@rainbow-me/rainbowkit";
 
 type ChainImages = {
   [key: string]: string;
 };
 
-const infuraId = process.env.NEXT_PUBLIC_INFURA_ID;
-const alchemyId = process.env.NEXT_PUBLIC_ALCHEMY_KEY;
-
-const otherChains = [
-  chain.polygonMumbai,
-  chain.goerli,
+const totalChains: Chain[] = [
+  polygon,
+  arbitrumOne,
+  optimism,
+  polygonMumbai,
   sepolia,
+  goerli,
   polygonZkTestnet,
   polygonZkMainnet,
   baseTestnet,
@@ -62,13 +66,11 @@ const otherChains = [
   gnosisMainnet,
 ];
 
-const defaultChains = [chain.polygon, chain.arbitrum, chain.optimism];
-const appChains = [...defaultChains, ...otherChains];
 const providers =
   process.env.NODE_ENV === "development"
-    ? [publicProvider(), alchemyProvider({ alchemyId })]
-    : [alchemyProvider({ alchemyId }), infuraProvider({ infuraId }), publicProvider()];
-export const { chains, provider } = configureChains(appChains, providers);
+    ? [publicProvider(), jsonRpcProvider({ rpc: (chain) => ({ http: `${chain.rpcUrls.default}`, }), })]  // if in dev, try public first in case there are no providers configured
+    : [jsonRpcProvider({ rpc: (chain) => ({ http: `${chain.rpcUrls.default}` }), }), publicProvider()];
+export const { chains, provider } = configureChains(totalChains, providers);
 
 const { wallets } = getDefaultWallets({
   appName: "jokerace",
@@ -109,6 +111,7 @@ export const chainsImages: ChainImages = {
   hardhat: "/hardhat.svg",
   rinkeby: "/ethereum.svg",
   ropsten: "/ethereum.svg",
+  sepolia: "/ethereum.svg",
   localhost: "/ethereum.svg",
   goerli: "/ethereum.svg",
   kovan: "/ethereum.svg",
@@ -118,4 +121,5 @@ export const chainsImages: ChainImages = {
   polygonzkmainnet: "/polygon.svg",
   scrollgoerli: "/scroll.png",
   basetestnet: "/base.svg",
+  gnosistestnet: "/gnosis.png"
 };


### PR DESCRIPTION
## This PR
This PR refactors how we implement RPC providers to allow us to be much more declarative and flexible in what providers we choose to use for which chains, and further, how we want to handle cases where environment variables aren't provided or RPC providers fail/fallback strategies.

I added in our Alchemy provider for Polygon, Optimism, and Arbitrum, and otherwise we just use public endpoints. I added these env vars in Vercel so when we merge it should all be good to go for a smooth transition.

Note: the naming of the networks is just lining up with what we had before and what we thus have in the db so that things are backwards compatible.

## Other Relevant PRs
We're going to make a way in #359 to set which chains we want to provide live updates for because trying to get live updates on a chain through a provider that doesn't support high throughput leads to us getting rate-limited and extremely degraded experience for the user.

## TODO after merge
- Once this is merged in we should remove the old `NEXT_PUBLIC_ALCHEMY_KEY` env vars from Vercel and our local setups.