### PR TITLE
feat: cosmetics updates

### DIFF
--- a/packages/react-app-revamp/components/Share/index.tsx
+++ b/packages/react-app-revamp/components/Share/index.tsx
@@ -32,7 +32,7 @@ const ShareDropdown: FC<ShareDropdownProps> = ({ contestName, contestAddress, ch
         leaveFrom="transform opacity-100 scale-100"
         leaveTo="transform opacity-0 scale-95"
       >
-        <Menu.Items className="absolute right-0 z-10 mt-2 w-56 origin-top-right rounded-md bg-neutral-0 shadow-lg ring-1 ring-inset ring-primary-9 ring-opacity-10 focus:outline-none">
+        <Menu.Items className="absolute right-0 z-10  mt-2 w-48 origin-top-right rounded-md bg-neutral-0 shadow-lg ring-1 ring-inset ring-primary-9 ring-opacity-10 focus:outline-none">
           <Menu.Item>
             {({ active }) => (
               <a
@@ -40,7 +40,7 @@ const ShareDropdown: FC<ShareDropdownProps> = ({ contestName, contestAddress, ch
                 href={generateLensShareUrl(contestName, contestAddress, chain)}
                 className={classNames(
                   active ? "bg-neutral-3 text-gray-900" : "text-gray-700",
-                  "flex items-center gap-1 px-4 py-2 text-sm hover:bg-gray-100 hover:text-gray-900 border-b border-neutral-3",
+                  "flex items-center text-[16px] gap-1 px-4 py-2  hover:bg-gray-100 hover:text-gray-900 border-b border-neutral-3",
                 )}
                 rel="noreferrer"
               >
@@ -56,7 +56,7 @@ const ShareDropdown: FC<ShareDropdownProps> = ({ contestName, contestAddress, ch
                 target="_blank"
                 className={classNames(
                   active ? "bg-neutral-3 text-gray-900" : "text-gray-700",
-                  "flex items-center gap-1 px-4 py-2 text-sm hover:bg-gray-100 hover:text-gray-900 border-b border-neutral-3",
+                  "flex items-center text-[16px] gap-1 px-4 py-2  hover:bg-gray-100 hover:text-gray-900 border-b border-neutral-3",
                 )}
                 rel="noreferrer"
               >
@@ -77,7 +77,7 @@ const ShareDropdown: FC<ShareDropdownProps> = ({ contestName, contestAddress, ch
                 onClick={() => generateUrlToCopy(contestAddress, chain)}
                 className={classNames(
                   active ? "bg-neutral-3 text-gray-900" : "text-gray-700",
-                  "flex items-center gap-1 px-4 py-2 text-sm hover:bg-gray-100 hover:text-gray-900 cursor-pointer",
+                  "flex items-center gap-1 px-4 py-2 text-[16px] hover:bg-gray-100 hover:text-gray-900 cursor-pointer",
                 )}
               >
                 <DuplicateIcon className="h-6 w-6 text-gray-400 mr-2" />

--- a/packages/react-app-revamp/components/UI/EtheuremAddress/index.tsx
+++ b/packages/react-app-revamp/components/UI/EtheuremAddress/index.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable @next/next/no-img-element */
+import { chains, provider } from "@config/wagmi";
 import { useAvatarStore } from "@hooks/useAvatar";
 import { getDefaultProfile } from "@services/lens/getDefaultProfile";
 import { useQuery } from "@tanstack/react-query";
+import { useRouter } from "next/router";
 import { chain, useEnsName } from "wagmi";
 
 const DEFAULT_AVATAR_URL = "/contest/avatar.svg";
@@ -20,8 +22,17 @@ const EthereumAddress = ({
   shortenOnFallback,
 }: EthereumAddressProps) => {
   const shortAddress = `${ethereumAddress.substring(0, 6)}...${ethereumAddress.slice(-3)}`;
+  const { asPath } = useRouter();
+  const chainName = asPath.split("/")[2];
   const { avatars, setAvatar } = useAvatarStore(state => state);
   const avatarUrl = avatars[ethereumAddress] || DEFAULT_AVATAR_URL;
+
+  const getExplorer = () => {
+    const chainExplorer = chains.filter(chain => chain.name.toLowerCase().replace(" ", "") === chainName)[0]
+      .blockExplorers?.default.url;
+
+    return `${chainExplorer}address/${ethereumAddress}`;
+  };
 
   const queryUserProfileLens = useQuery(
     ["lens-profile", ethereumAddress],
@@ -45,8 +56,9 @@ const EthereumAddress = ({
   );
 
   const queryEns = useEnsName({
-    chainId: 1,
+    chainId: chain.mainnet.id,
     address: ethereumAddress,
+    enabled: !displayLensProfile || queryUserProfileLens.isError || !queryUserProfileLens.data,
   });
 
   const isLoading = queryUserProfileLens?.status === "loading";
@@ -56,16 +68,20 @@ const EthereumAddress = ({
   const displayName =
     (isLensProfileAvailable && queryUserProfileLens.data.handle) ||
     ensName ||
-    (shortenOnFallback && !textualVersion && shortAddress) ||
+    (shortenOnFallback && shortAddress) ||
     ethereumAddress;
 
   if (textualVersion) {
-    return <span>{displayName}</span>;
+    return (
+      <a
+        target="_blank"
+        rel="noopener noreferrer"
+        href={isLensProfileAvailable ? `https://lensfrens.xyz/${displayName}` : getExplorer()}
+      >
+        {displayName}
+      </a>
+    );
   }
-
-  const handleAddressClick = () => {
-    window.open(`https://etherscan.io/address/${ethereumAddress}`, "_blank");
-  };
 
   return (
     <span className="flex gap-2 items-center text-[16px] text-neutral-11 font-bold">
@@ -85,12 +101,7 @@ const EthereumAddress = ({
           className="text-[16px] text-neutral-11 font-bold no-underline cursor-pointer"
           target="_blank"
           rel="noopener noreferrer"
-          href={
-            isLensProfileAvailable
-              ? `https://lensfrens.xyz/${displayName}`
-              : `https://etherscan.io/address/${ethereumAddress}`
-          }
-          onClick={handleAddressClick}
+          href={isLensProfileAvailable ? `https://lensfrens.xyz/${displayName}` : getExplorer()}
         >
           {displayName}
         </a>

--- a/packages/react-app-revamp/components/_pages/DialogModalProposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalProposal/index.tsx
@@ -25,7 +25,7 @@ const DialogModalProposal: FC<DialogModalProposalProps> = ({ isOpen, setIsOpen, 
   const contestStatus = useContestStatusStore(state => state.contestStatus);
   const { openConnectModal } = useConnectModal();
   const { isConnected } = useAccount();
-  const { castVotes, isLoading } = useCastVotes();
+  const { castVotes, isSuccess } = useCastVotes();
   const {
     currentUserAvailableVotesAmount,
     currentUserTotalVotesAmount,
@@ -47,8 +47,8 @@ const DialogModalProposal: FC<DialogModalProposalProps> = ({ isOpen, setIsOpen, 
   };
 
   useEffect(() => {
-    if (isLoading) setIsOpen(false);
-  }, [isLoading]);
+    if (isSuccess) setIsOpen(false);
+  }, [isSuccess]);
 
   return (
     <DialogModalV3 title="Proposal" isOpen={isOpen} setIsOpen={setIsOpen} className="xl:w-[1110px] 3xl:w-[1300px] ">

--- a/packages/react-app-revamp/components/_pages/DialogModalVoteForProposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalVoteForProposal/index.tsx
@@ -25,7 +25,7 @@ export const DialogModalVoteForProposal: FC<DialogModalVoteForProposalProps> = (
     decreaseCurrentUserTotalVotesCast,
   } = useUserStore(state => state);
 
-  const { castVotes, isLoading } = useCastVotes();
+  const { castVotes, isSuccess } = useCastVotes();
 
   const onSubmitCastVotes = (amount: number, isUpvote: boolean) => {
     decreaseCurrentUserAvailableVotesAmount(amount);
@@ -38,8 +38,8 @@ export const DialogModalVoteForProposal: FC<DialogModalVoteForProposalProps> = (
   };
 
   useEffect(() => {
-    if (isLoading) setIsOpen(false);
-  }, [isLoading]);
+    if (isSuccess) setIsOpen(false);
+  }, [isSuccess]);
 
   return (
     <DialogModalV3

--- a/packages/react-app-revamp/components/_pages/ListContests/Contest/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListContests/Contest/index.tsx
@@ -242,7 +242,7 @@ const Contest: FC<ContestProps> = ({ contest, compact, loading }) => {
           </div>
 
           <div className="flex items-center gap-4">
-            <div className={`flex items-start ${submissionClass} md:justify-between gap-3`}>
+            <div className={`flex items-center ${submissionClass} md:justify-between gap-3`}>
               <div className="min-w-[185px] min-h-[3rem] flex flex-col justify-center">
                 <p className="font-bold">
                   {loading ? (
@@ -284,7 +284,7 @@ const Contest: FC<ContestProps> = ({ contest, compact, loading }) => {
           </div>
 
           <div className="flex items-center gap-4">
-            <div className={`flex items-start ${votingClass} md:justify-between gap-3`}>
+            <div className={`flex items-center ${votingClass} md:justify-between gap-3`}>
               <div className="min-w-[185px] min-h-[3rem] flex flex-col justify-center">
                 <p className="font-bold">
                   {loading ? (

--- a/packages/react-app-revamp/hooks/useContest/store.tsx
+++ b/packages/react-app-revamp/hooks/useContest/store.tsx
@@ -3,6 +3,15 @@ import { createContext, useContext, useRef } from "react";
 import { CustomError } from "types/error";
 import { createStore, useStore } from "zustand";
 
+type Reward = {
+  token: {
+    symbol: string;
+    value: number;
+  };
+  winners: number;
+  numberOfTokens: number;
+};
+
 export interface ContestState {
   contestName: string;
   contestPrompt: string;
@@ -30,6 +39,7 @@ export interface ContestState {
     address: string;
     numVotes: number;
   }[];
+  rewards: Reward | null;
   setSupportsRewardsModule: (value: boolean) => void;
   setCanUpdateVotesInRealTime: (value: boolean) => void;
   setDownvotingAllowed: (isAllowed: boolean) => void;
@@ -42,6 +52,7 @@ export interface ContestState {
   setVotesClose: (datetime: Date) => void;
   setTotalVotesCast: (amount: number) => void;
   setTotalVotes: (amount: number) => void;
+  setRewards: (rewards: Reward | null) => void;
   setVotingMerkleTree: (merkleTree: MerkleTree) => void;
   setVoters: (voters: { address: string; numVotes: number }[]) => void;
   setSubmissionMerkleTree: (merkleTree: MerkleTree) => void;
@@ -66,6 +77,7 @@ export const createContestStore = () =>
     votingMerkleTree: new MerkleTree([]),
     voters: [],
     totalVotesCast: 0,
+    rewards: null,
     totalVotes: 0,
     isLoading: true,
     error: null,
@@ -92,6 +104,7 @@ export const createContestStore = () =>
     setSubmitters: submitters => set({ submitters: submitters }),
     setTotalVotesCast: amount => set({ totalVotesCast: amount }),
     setTotalVotes: amount => set({ totalVotes: amount }),
+    setRewards: rewards => set({ rewards: rewards }),
     setIsLoading: value => set({ isLoading: value }),
     setError: value => set({ error: value }),
     setIsSuccess: value => set({ isSuccess: value }),

--- a/packages/react-app-revamp/layouts/LayoutViewContest/StickyCards/components/Qualifier/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/StickyCards/components/Qualifier/index.tsx
@@ -6,6 +6,7 @@ import { useUserStore } from "@hooks/useUser/store";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import Image from "next/image";
 import { useEffect, useMemo, useState } from "react";
+import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
 import { ReactNode } from "react-markdown/lib/ast-to-react";
 import { useWindowScroll } from "react-use";
 import { useAccount } from "wagmi";
@@ -19,6 +20,7 @@ const LayoutContestQualifier = () => {
     currentUserProposalCount,
     currentUserTotalVotesAmount,
     contestMaxNumberSubmissionsPerUser,
+    isLoading,
   } = useUserStore(state => state);
   const { y } = useWindowScroll();
   const [isScrolled, setIsScrolled] = useState(false);
@@ -90,29 +92,40 @@ const LayoutContestQualifier = () => {
   }, [currentUserAvailableVotesAmount, isScrolled]);
 
   return (
-    <div className="w-full bg-true-black flex flex-col gap-1 border border-neutral-11 rounded-[10px] py-2 items-center shadow-timer-container">
-      <Image src="/contest/ballot.svg" width={33} height={33} alt="timer" />
+    <SkeletonTheme baseColor="#706f78" highlightColor="#FFE25B" duration={1}>
+      <div className="w-full bg-true-black flex flex-col gap-1 border border-neutral-11 rounded-[10px] py-2 items-center shadow-timer-container">
+        <Image src="/contest/ballot.svg" width={33} height={33} alt="timer" />
 
-      {isConnected ? (
-        <div className="flex flex-col">
-          {isScrolled ? (
-            <div className="text-[20px]  text-neutral-11">{qualifiedToVoteMessage}</div>
-          ) : (
-            <>
-              <div className="text-[16px] text-neutral-11">{qualifiedToSubmitMessage}</div>
-              <div className="text-[16px]  text-neutral-11">{qualifiedToVoteMessage}</div>
-            </>
-          )}
-        </div>
-      ) : (
-        <div className="text-[16px] font-bold text-neutral-11 mt-2">
-          <span className="text-positive-11 cursor-pointer" onClick={openConnectModal}>
-            connect wallet
-          </span>{" "}
-          to see if you qualify
-        </div>
-      )}
-    </div>
+        {isLoading ? (
+          <div className="flex flex-col w-[150px]">
+            <p className="m-0">
+              <Skeleton height={16} />
+            </p>
+            <p className="m-0">
+              <Skeleton height={16} />
+            </p>
+          </div>
+        ) : isConnected ? (
+          <div className="flex flex-col">
+            {isScrolled ? (
+              <div className="text-[20px]  text-neutral-11">{qualifiedToVoteMessage}</div>
+            ) : (
+              <>
+                <div className="text-[16px] text-neutral-11">{qualifiedToSubmitMessage}</div>
+                <div className="text-[16px]  text-neutral-11">{qualifiedToVoteMessage}</div>
+              </>
+            )}
+          </div>
+        ) : (
+          <div className="text-[16px] font-bold text-neutral-11 mt-2">
+            <span className="text-positive-11 cursor-pointer" onClick={openConnectModal}>
+              connect wallet
+            </span>{" "}
+            to see if you qualify
+          </div>
+        )}
+      </div>
+    </SkeletonTheme>
   );
 };
 

--- a/packages/react-app-revamp/layouts/LayoutViewContest/Tabs/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/Tabs/index.tsx
@@ -28,7 +28,7 @@ const ContestLayoutTabs: FC<ContestLayoutTabsProps> = ({ contestAddress, chain, 
         {Object.keys(Tab).map(tabKey => (
           <div
             key={tabKey}
-            className={`text-[16px] cursor-pointer  font-bold ${
+            className={`text-[16px] cursor-pointer font-bold transition-colors duration-300 ${
               tabKey === activeTab ? "text-primary-10" : "text-neutral-11"
             }`}
             onClick={() => onTabChange(Tab[tabKey as keyof typeof Tab])}

--- a/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
@@ -29,7 +29,6 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { ReactNode, useEffect, useMemo, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
-import { SkeletonTheme } from "react-loading-skeleton";
 import { useAccount, useNetwork } from "wagmi";
 import { getLayout as getBaseLayout } from "./../LayoutBase";
 import ContestTab from "./Contest";
@@ -46,12 +45,11 @@ const LayoutViewContest = (props: any) => {
   });
   const { chain } = useNetwork();
   const showRewards = useShowRewardsStore(state => state.showRewards);
-  const { isLoading, address, fetchContestInfo, isSuccess, error, retry, onSearch, chainId, chainName, setChainId } =
+  const { isLoading, address, fetchContestInfo, isSuccess, error, retry, chainId, chainName, setChainId } =
     useContest();
 
-  const { submissionsOpen, votesClose, votesOpen, contestAuthorEthereumAddress, contestName } = useContestStore(
-    state => state,
-  );
+  const { submissionsOpen, votesClose, votesOpen, contestAuthorEthereumAddress, contestName, rewards } =
+    useContestStore(state => state);
 
   const { setContestStatus } = useContestStatusStore(state => state);
   const { displayReloadBanner } = useContestEvents();
@@ -71,9 +69,12 @@ const LayoutViewContest = (props: any) => {
       setContestStatus(status);
       if (now.isBefore(nextTime)) {
         const msUntilNext = nextTime.diff(now);
-        timeoutId = setTimeout(() => {
-          setContestStatus(nextStatus);
-        }, msUntilNext > MAX_MS_TIMEOUT ? MAX_MS_TIMEOUT : msUntilNext);
+        timeoutId = setTimeout(
+          () => {
+            setContestStatus(nextStatus);
+          },
+          msUntilNext > MAX_MS_TIMEOUT ? MAX_MS_TIMEOUT : msUntilNext,
+        );
       }
     };
 
@@ -221,16 +222,26 @@ const LayoutViewContest = (props: any) => {
                   )}
 
                   <div className="flex flex-col mt-10">
-                    <p className="text-[40px] text-primary-10 font-sabo">{contestName}</p>
-                    <p className="text-[24px] text-primary-10 font-bold break-all">
-                      by{" "}
-                      <EthereumAddress
-                        ethereumAddress={contestAuthorEthereumAddress}
-                        shortenOnFallback
-                        displayLensProfile={false}
-                        textualVersion
-                      />
+                    <p className="text-[30px] md:text-[40px] text-primary-10 font-sabo break-all md:break-normal">
+                      {contestName}
                     </p>
+                    <div className="flex flex-col md:flex-row gap-3 md:gap-8 md:items-center">
+                      <p className="text-[20px] md:text-[24px] text-primary-10 font-bold break-all">
+                        by{" "}
+                        <EthereumAddress
+                          ethereumAddress={contestAuthorEthereumAddress}
+                          shortenOnFallback
+                          displayLensProfile={false}
+                          textualVersion
+                        />
+                      </p>
+                      {rewards && (
+                        <div className="shrink-0 p-1 border border-primary-10 rounded-[10px] text-[16px] font-bold text-primary-10">
+                          {rewards?.token.value} $<span className="uppercase">{rewards?.token.symbol}</span> to{" "}
+                          {rewards.winners} {rewards.winners > 1 ? "winners" : "winner"}
+                        </div>
+                      )}
+                    </div>
                   </div>
 
                   <div className="mt-4 gap-3 flex flex-col">

--- a/packages/react-app-revamp/lib/contests/index.ts
+++ b/packages/react-app-revamp/lib/contests/index.ts
@@ -28,9 +28,9 @@ async function getContractConfig(address: string, chainName: string, chainId: nu
   return contractConfig;
 }
 
-const fetchTokenBalances = async (contest: any, contestRewardModuleAddress: string) => {
+export const fetchTokenBalances = async (chainName: string, contestRewardModuleAddress: string) => {
   try {
-    const networkName = contest.network_name.toLowerCase() === "arbitrumone" ? "arbitrum" : contest.network_name;
+    const networkName = chainName.toLowerCase() === "arbitrumone" ? "arbitrum" : chainName;
     const alchemyRpc = Object.keys(alchemyRpcUrls).filter(url => url.toLowerCase() === networkName)[0];
     //@ts-ignore
     const alchemyAppUrl = `${alchemyRpcUrls[alchemyRpc]}/${process.env.NEXT_PUBLIC_ALCHEMY_KEY}`;
@@ -61,7 +61,7 @@ const fetchTokenBalances = async (contest: any, contestRewardModuleAddress: stri
   }
 };
 
-const fetchNativeBalance = async (contestRewardModuleAddress: string, chainId: number) => {
+export const fetchNativeBalance = async (contestRewardModuleAddress: string, chainId: number) => {
   try {
     const nativeBalance = await fetchBalance({
       addressOrName: contestRewardModuleAddress.toString(),
@@ -74,7 +74,7 @@ const fetchNativeBalance = async (contestRewardModuleAddress: string, chainId: n
   }
 };
 
-const fetchFirstToken = async (contestRewardModuleAddress: string, chainId: number, tokenAddress: string) => {
+export const fetchFirstToken = async (contestRewardModuleAddress: string, chainId: number, tokenAddress: string) => {
   try {
     const firstToken = await fetchBalance({
       addressOrName: contestRewardModuleAddress.toString(),
@@ -145,7 +145,7 @@ const processContestData = async (contest: any, userAddress: string) => {
 
             if (!rewardToken || rewardToken.value.eq(0)) {
               try {
-                erc20Tokens = await fetchTokenBalances(contest, contestRewardModuleAddress.toString());
+                erc20Tokens = await fetchTokenBalances(contest.network_name, contestRewardModuleAddress.toString());
 
                 if (erc20Tokens && erc20Tokens.length > 0) {
                   rewardToken = await fetchFirstToken(


### PR DESCRIPTION
This PR addresses the UI/UX issues on the contest page.

**UI/UX Issues fixed:**

- added rewards info next to contest creator address in contest page
- fixed voting popup to not close after you click on button, now we await for tx to be success and close it then ( this actually wasn't a bug but feature from me, i was initially thinking it is good to automatically close voting popup as you can move on and look at others, however it might be better for user to leave that option if they wanna close it or not )
- contest creator address in contest page wasn't shortened before, now we follow same pattern of shortening and added a click event to go to explorer
- When it comes to skeleton loading through all site, maybe it is not the best idea to load skeletons on the contest page as there is a lot of smaller info that would we need to cover with skeletons, which is not ideal imo. Therefore combination of our spinner + skeleton could be ideal combo but i'm open to discuss anytime!


**Codebase changes**

I've did small refactor of how we load stuff and added skeletons in those places, we have 2 phases of loading ( just like we did before ) 

1. We first load contest info
2. We then load user state info

Those 2 states should be separable and not promised in one take, therefore once contest info is fetched, we remove spinner and add 2 skeleton loaders in the qualify area ( where you see if you qualify to vote or submit ) so it does not wait for each other and reduce loading time overall.

 **Things that are missing** 

-  need to format the calendar integration with our text and colors (dark mode)
-  view all contests should default to showing them in order of most recently created, and that should be an option in sort as well ("recently created")
-  cosmetics: entries are scrolling up behind the two cards at top rather than fading out before they reach the top
- mismatch in timing: submissions say there’s 1 day left to submit, and voting says it opens in 2 days (2 days was correct)
- voting opens in: date — should say “voting opens on [date]” in case of date... or "voting opens is [x] [days/hrs/seconds]" (without the colon)
- timing for how much time is left in submissions/voting says “1 days” rather than “1 day”
-  on the allowlist page, there should be some sample text in grey showing what the fields look like: so it should show a random address (like 0xd56e3E325133EFEd6B1687C88571b8a91e517ab0) for the address and then 100 for the votes
- visibility for the submission being voted on should be as long as it is on the main contest page (right now when you vote, only the first line of the submission is visible--we should show at least a couple)
- when manually typing in number of votes, the cursor currently points at the end of the word "votes." instead, "votes" should be in white, and the number (0) should be in grey, and the cursor should be on the number to edit, not the word "votes"
 when tapping a default number to edit (for example "0" in the percents in the rewards pool), the number should disappear completely so just the cursor is visible and the user can type in whatever number they want without dealing with the 0
 voting/submission times are reporting 1 minute behind (if you set voting to open at 11:30am, it will say that it's set to open at 11:29am)

**Things that need more time**

Markdown issues are mostly these ones, i'll need a day or two to dedicate for it so our preview box for proposals + rich text editor for writing can be perfect.
