### PR TITLE
chore: remove extra provider env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ You can also find v1 at [jokedao.jokedao.io](https://jokedao.jokedao.io)!
 - Create a `.env` file in `packages/react-app-revamp` (the frontend package) and paste the following values:
 
 ```
-NEXT_PUBLIC_POLYGON_ALCHEMY_KEY
-NEXT_PUBLIC_OPTIMISM_ALCHEMY_KEY
-NEXT_PUBLIC_ARBITRUM_ALCHEMY_KEY
+NEXT_PUBLIC_ALCHEMY_KEY=
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 NEXT_PUBLIC_LENS_API_URL=

--- a/packages/react-app-revamp/README.md
+++ b/packages/react-app-revamp/README.md
@@ -14,9 +14,7 @@ You can also find v1 at [jokedao.jokedao.io](https://jokedao.jokedao.io)!
 - Create a `.env` file in `packages/react-app-revamp` (the frontend package) and paste the following values:
 
 ```
-NEXT_PUBLIC_POLYGON_ALCHEMY_KEY
-NEXT_PUBLIC_OPTIMISM_ALCHEMY_KEY
-NEXT_PUBLIC_ARBITRUM_ALCHEMY_KEY
+NEXT_PUBLIC_ALCHEMY_KEY=
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 NEXT_PUBLIC_LENS_API_URL=

--- a/packages/react-app-revamp/config/wagmi/custom-chains/arbitrumOne.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/arbitrumOne.ts
@@ -9,7 +9,7 @@ export const arbitrumOne = {
   },
   rpcUrls: {
     public: 'https://rpc.ankr.com/arbitrum',
-    default: `https://arb-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ARBITRUM_ALCHEMY_KEY}`,
+    default: 'https://rpc.ankr.com/arbitrum',
   },
   blockExplorers: {
     etherscan: { name: 'Arbitrum Mainnet Etherscan', url: 'https://arbiscan.io/' },

--- a/packages/react-app-revamp/config/wagmi/custom-chains/optimism.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/optimism.ts
@@ -9,7 +9,7 @@ export const optimism = {
   },
   rpcUrls: {
     public: 'https://mainnet.optimism.io',
-    default: `https://opt-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_OPTIMISM_ALCHEMY_KEY}`,
+    default: 'https://mainnet.optimism.io',
   },
   blockExplorers: {
     etherscan: { name: 'Optimism Mainnet Etherscan', url: 'https://optimistic.etherscan.io/' },

--- a/packages/react-app-revamp/config/wagmi/custom-chains/polygon.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/polygon.ts
@@ -9,7 +9,7 @@ export const polygon = {
   },
   rpcUrls: {
     public: 'https://rpc.ankr.com/polygon',
-    default: `https://polygon-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_POLYGON_ALCHEMY_KEY}`,
+    default: 'https://rpc.ankr.com/polygon',
   },
   blockExplorers: {
     etherscan: { name: 'Polygon Mainnet Etherscan', url: 'https://polygonscan.com/' },

--- a/packages/react-app-revamp/config/wagmi/index.ts
+++ b/packages/react-app-revamp/config/wagmi/index.ts
@@ -28,12 +28,14 @@ import { nearAuroraTestnet } from "./custom-chains/nearAuroraTestnet";
 import { gnosisMainnet } from "./custom-chains/gnosisMainnet";
 import { gnosisTestnet } from "./custom-chains/gnosisTestnet";
 import { publicProvider } from "wagmi/providers/public";
-import { jsonRpcProvider } from "wagmi/providers/jsonRpc";
+import { alchemyProvider } from "wagmi/providers/alchemy";
 import { connectorsForWallets, getDefaultWallets, wallet } from "@rainbow-me/rainbowkit";
 
 type ChainImages = {
   [key: string]: string;
 };
+
+const alchemyId = process.env.NEXT_PUBLIC_ALCHEMY_KEY;
 
 const totalChains: Chain[] = [
   polygon,
@@ -68,8 +70,8 @@ const totalChains: Chain[] = [
 
 const providers =
   process.env.NODE_ENV === "development"
-    ? [publicProvider(), jsonRpcProvider({ rpc: (chain) => ({ http: `${chain.rpcUrls.default}`, }), })]  // if in dev, try public first in case there are no providers configured
-    : [jsonRpcProvider({ rpc: (chain) => ({ http: `${chain.rpcUrls.default}` }), }), publicProvider()];
+    ? [publicProvider(), alchemyProvider({ alchemyId })]  // if in dev, try public first in case there isn't an Alchemy key
+    : [alchemyProvider({ alchemyId }), publicProvider()];
 export const { chains, provider } = configureChains(totalChains, providers);
 
 const { wallets } = getDefaultWallets({


### PR DESCRIPTION
Because alchemy api key goes to all alchemy supported chains apparently.

Super weird Alchemy dashboard setup that makes you choose a chain to make your project on but then the API key it gives you works on all chains - I was confused by this and thought you needed one for each chain you wanted to use Alchemy for. Tis not the case.

So rolling back some of the changes in #402 bc it is apparently not that deep at least wrt how many env vars you need.