### PR TITLE
feat: cosmetics update

### DIFF
--- a/packages/react-app-revamp/components/Voting/index.tsx
+++ b/packages/react-app-revamp/components/Voting/index.tsx
@@ -4,7 +4,7 @@ import { formatNumber } from "@helpers/formatNumber";
 import { ChevronRightIcon } from "@heroicons/react/outline";
 import { useCastVotesStore } from "@hooks/useCastVotes/store";
 import { useUserStore } from "@hooks/useUser/store";
-import { FC, useState } from "react";
+import { FC, useEffect, useState } from "react";
 
 interface VotingWidgetProps {
   amountOfVotes: number;
@@ -19,6 +19,20 @@ const VotingWidget: FC<VotingWidgetProps> = ({ amountOfVotes, downvoteAllowed, o
   const [amount, setAmount] = useState(0);
   const [sliderValue, setSliderValue] = useState(0);
   const [isInvalid, setIsInvalid] = useState(false);
+
+  useEffect(() => {
+    const handleEnterPress = (event: KeyboardEvent) => {
+      if (event.key === "Enter") {
+        onVote?.(amount, isUpvote);
+      }
+    };
+
+    window.addEventListener("keydown", handleEnterPress);
+
+    return () => {
+      window.removeEventListener("keydown", handleEnterPress);
+    };
+  }, [onVote]);
 
   const handleClick = (value: boolean) => {
     if (!downvoteAllowed) {

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestSubmission/components/SubmissionAllowlist/components/CSVEditor/TableRow/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestSubmission/components/SubmissionAllowlist/components/CSVEditor/TableRow/index.tsx
@@ -15,7 +15,8 @@ const TableRow: FC<TableRowProps> = ({ address, error, index, handlePaste, handl
       <div className="flex justify-between items-center">
         <input
           type="text"
-          className="w-full bg-transparent outline-none border-none p-0"
+          placeholder={index === 0 ? "0xd56e3E325133EFEd6B1687C88571b8a91e517ab0" : ""}
+          className="w-full bg-transparent outline-none border-none p-0 placeholder-neutral-10"
           value={address}
           onPaste={event => handlePaste(index, event)}
           onChange={event => handleChange(index, event.target.value)}

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestTiming/components/SubmissionDate/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestTiming/components/SubmissionDate/index.tsx
@@ -1,6 +1,5 @@
 import CreateDatePicker from "@components/_pages/Create/components/DatePicker";
 import { useDeployContestStore } from "@hooks/useDeployContest/store";
-import { useEffect } from "react";
 
 const CreateSubmissionsOpenDate = () => {
   const { submissionOpen, setSubmissionOpen } = useDeployContestStore(state => state);
@@ -15,7 +14,7 @@ const CreateSubmissionsOpenDate = () => {
       tip="we recommend opening them now—because why not?"
       onChange={onSubmissionDateChange}
       defaultDate={submissionOpen}
-      minDate={submissionOpen}
+      minDate={new Date()}
     />
   );
 };

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestTiming/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestTiming/index.tsx
@@ -32,7 +32,7 @@ const CreateContestTiming = () => {
   }, [onNextStep]);
 
   return (
-    <div className="mt-12 lg:mt-[50px] flex flex-col lg:flex-row gap-5 animate-swingInLeft">
+    <div className="mt-12 lg:mt-[50px] flex flex-col lg:flex-row gap-5 animate-swingInLeft opacity-5">
       <StepCircle step={step + 1} />
       <div className="flex flex-col gap-10">
         <CreateSubmissionsOpenDate />

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingAllowlist/components/CSVEditor/TableBody/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingAllowlist/components/CSVEditor/TableBody/index.tsx
@@ -11,7 +11,7 @@ type TableBodyProps = {
 
 const ScrollableTableBody: FC<TableBodyProps> = ({ fields, handlePaste, handleChange, handleDelete }) => {
   return (
-    <div className="overflow-y-auto w-[300px] md:w-[650px]" style={{ maxHeight: "calc(15 * 2rem)" }}>
+    <div className="overflow-y-auto w-[300px] md:w-[600px]" style={{ maxHeight: "calc(15 * 2rem)" }}>
       <table className="table-fixed border-collapse border-b border-dotted border-neutral-9 w-full text-left">
         <tbody>
           {fields.map((field, index) => (

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingAllowlist/components/CSVEditor/TableBody/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingAllowlist/components/CSVEditor/TableBody/index.tsx
@@ -11,7 +11,7 @@ type TableBodyProps = {
 
 const ScrollableTableBody: FC<TableBodyProps> = ({ fields, handlePaste, handleChange, handleDelete }) => {
   return (
-    <div className="overflow-y-auto w-[300px] md:w-[600px]" style={{ maxHeight: "calc(15 * 2rem)" }}>
+    <div className="overflow-y-auto w-[300px] md:w-[650px]" style={{ maxHeight: "calc(15 * 2rem)" }}>
       <table className="table-fixed border-collapse border-b border-dotted border-neutral-9 w-full text-left">
         <tbody>
           {fields.map((field, index) => (

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingAllowlist/components/CSVEditor/TableRow/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingAllowlist/components/CSVEditor/TableRow/index.tsx
@@ -18,7 +18,8 @@ const TableRow: FC<TableRowProps> = ({ address, votes, error, index, handlePaste
     >
       <input
         type="text"
-        className="w-full bg-transparent outline-none border-none p-0"
+        placeholder={index === 0 ? "0xd56e3E325133EFEd6B1687C88571b8a91e517ab0" : ""}
+        className="w-full bg-transparent outline-none border-none p-0 placeholder-neutral-10"
         value={address}
         onPaste={event => handlePaste(index, event)}
         onChange={event => handleChange(index, "address", event.target.value)}
@@ -32,7 +33,8 @@ const TableRow: FC<TableRowProps> = ({ address, votes, error, index, handlePaste
       <div className="flex justify-between items-center">
         <input
           type="text"
-          className="w-full bg-transparent outline-none border-none pl-2"
+          placeholder={index === 0 ? "69" : ""}
+          className="w-full bg-transparent outline-none border-none pl-2 placeholder-neutral-10"
           value={votes}
           onChange={event => handleChange(index, "votes", event.target.value)}
         />

--- a/packages/react-app-revamp/components/_pages/DialogModalSendProposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalSendProposal/index.tsx
@@ -3,6 +3,7 @@ import ButtonV3 from "@components/UI/ButtonV3";
 import DialogModalV3 from "@components/UI/DialogModalV3";
 import EtheuremAddress from "@components/UI/EtheuremAddress";
 import TipTapEditorControls from "@components/UI/TipTapEditorControls";
+import { DisableEnter, ShiftEnterCreateExtension } from "@helpers/editor";
 import {
   loadSubmissionFromLocalStorage,
   removeSubmissionFromLocalStorage,
@@ -42,6 +43,8 @@ export const DialogModalSendProposal: FC<DialogModalSendProposalProps> = ({ isOp
   const editorProposal = useEditor({
     extensions: [
       StarterKit,
+      ShiftEnterCreateExtension,
+      DisableEnter,
       Image,
       TiptapExtensionLink,
       Placeholder.configure({
@@ -71,6 +74,27 @@ export const DialogModalSendProposal: FC<DialogModalSendProposalProps> = ({ isOp
     },
   });
 
+  const onSubmitProposal = () => {
+    sendProposal(proposal.trim());
+  };
+
+  useEffect(() => {
+    const handleEnterPress = (event: KeyboardEvent) => {
+      if (event.shiftKey) {
+        return;
+      }
+      if (event.key === "Enter") {
+        onSubmitProposal();
+      }
+    };
+
+    window.addEventListener("keydown", handleEnterPress);
+
+    return () => {
+      window.removeEventListener("keydown", handleEnterPress);
+    };
+  }, [onSubmitProposal]);
+
   useEffect(() => {
     if (isSuccess) {
       setIsOpen(false);
@@ -89,10 +113,6 @@ export const DialogModalSendProposal: FC<DialogModalSendProposalProps> = ({ isOp
         to make a line break.
       </p>
     );
-  };
-
-  const onSubmitProposal = () => {
-    sendProposal(proposal.trim());
   };
 
   return (

--- a/packages/react-app-revamp/components/_pages/ListProposalVotes/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListProposalVotes/index.tsx
@@ -1,15 +1,12 @@
-import Button from "@components/UI/Button";
 import Collapsible from "@components/UI/Collapsible";
 import EtheuremAddress from "@components/UI/EtheuremAddress";
-import Loader from "@components/UI/Loader";
-import { ofacAddresses } from "@config/ofac-addresses/ofac-addresses";
 import { formatNumber } from "@helpers/formatNumber";
 import { ChevronUpIcon } from "@heroicons/react/outline";
 import { useProposalStore } from "@hooks/useProposal/store";
 import useProposalVotes from "@hooks/useProposalVotes";
 import { useProposalVotesStore } from "@hooks/useProposalVotes/store";
 import { FC, useState } from "react";
-import { useAccount } from "wagmi";
+import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
 import { Proposal } from "../ProposalContent";
 
 interface ListProposalVotesProps {
@@ -18,20 +15,13 @@ interface ListProposalVotesProps {
 }
 
 export const ListProposalVotes: FC<ListProposalVotesProps> = ({ proposal, proposalId }) => {
-  const accountData = useAccount({
-    onConnect({ address }) {
-      if (address != undefined && ofacAddresses.includes(address?.toString())) {
-        location.href = "https://www.google.com/search?q=what+are+ofac+sanctions";
-      }
-    },
-  });
-  const { isLoading, isSuccess, isError, retry, fetchVotesPage } = useProposalVotes(proposalId);
+  const { isLoading, fetchVotesPage } = useProposalVotes(proposalId);
   const { listProposalsData } = useProposalStore(state => state);
+  const placeholders = new Array(5).fill(null);
   const {
     votesPerAddress,
     isPageVotesLoading,
     currentPagePaginationVotes,
-    isPageVotesError,
     indexPaginationVotes,
     totalPagesPaginationVotes,
     hasPaginationVotesNextPage,
@@ -49,7 +39,7 @@ export const ListProposalVotes: FC<ListProposalVotesProps> = ({ proposal, propos
   };
 
   return (
-    <>
+    <SkeletonTheme baseColor="#706f78" highlightColor="#FFE25B" duration={1}>
       <div className="flex gap-4 items-center mb-8">
         <p className="text-[24px] text-neutral-11 font-bold">voters</p>
         <button
@@ -59,56 +49,57 @@ export const ListProposalVotes: FC<ListProposalVotesProps> = ({ proposal, propos
           <ChevronUpIcon height={30} />
         </button>
       </div>
-      {isSuccess && !isLoading && (
-        <Collapsible isOpen={isVotersOpen}>
-          <div className="flex flex-col gap-5">
-            <div className="flex flex-col gap-4 md:w-[350px]">
-              {Object.keys(votesPerAddress).map((address: string, index, self) => (
+      <Collapsible isOpen={isVotersOpen}>
+        <div className="flex flex-col gap-5">
+          <div className="flex flex-col gap-4 md:w-[350px]">
+            {isLoading || (isPageVotesLoading && Object.keys(listProposalsData)?.length > 1) ? (
+              placeholders.map((_, index, self) => (
                 <div
-                  key={address}
-                  className={`flex justify-between items-end text-[16px] font-bold pb-3 ${
+                  className={`flex justify-between items-center pb-3 ${
                     index !== self.length - 1 ? "border-b border-neutral-10" : ""
                   }`}
                 >
-                  <EtheuremAddress ethereumAddress={address} shortenOnFallback={true} displayLensProfile={true} />
-                  <p>{formatNumber(votesPerAddress[address].votes)} votes</p>
+                  <div className="flex items-center gap-2">
+                    <Skeleton circle height={32} width={32} />
+                    <Skeleton width={100} height={16} className="mt-2" />
+                  </div>
+
+                  <Skeleton width={50} height={16} />
                 </div>
-              ))}
-            </div>
-
-            {isPageVotesLoading && Object.keys(listProposalsData)?.length > 1 && (
-              <div className="mr-auto mt-0">
-                <Loader scale="component" classNameWrapper="my-3">
-                  Loading votes...
-                </Loader>
-              </div>
-            )}
-
-            {hasPaginationVotesNextPage && !isPageVotesLoading && (
-              <div className="flex gap-2 items-center mb-8">
-                <p className="text-[16px] text-positive-11 font-bold uppercase">load more</p>
-                <button
-                  onClick={onLoadMore}
-                  className={`transition-transform duration-500 ease-in-out transform ${
-                    isLoadMoreOpen ? "" : "rotate-180"
-                  }`}
-                >
-                  <ChevronUpIcon height={20} className="text-positive-11" />
-                </button>
-              </div>
+              ))
+            ) : (
+              <>
+                {Object.keys(votesPerAddress).map((address: string, index, self) => (
+                  <div
+                    key={address}
+                    className={`flex justify-between items-end text-[16px] font-bold pb-3 ${
+                      index !== self.length - 1 ? "border-b border-neutral-10" : ""
+                    }`}
+                  >
+                    <EtheuremAddress ethereumAddress={address} shortenOnFallback={true} displayLensProfile={true} />
+                    <p>{formatNumber(votesPerAddress[address].votes)} votes</p>
+                  </div>
+                ))}
+              </>
             )}
           </div>
-        </Collapsible>
-      )}
 
-      {isLoading && (
-        <div className="animate-appear md:w-[350px]">
-          <Loader classNameWrapper={!isLoading ? "hidden" : ""} scale="component">
-            Loading votes, one moment please...{" "}
-          </Loader>
+          {hasPaginationVotesNextPage && !isPageVotesLoading && (
+            <div className="flex gap-2 items-center mb-8">
+              <p className="text-[16px] text-positive-11 font-bold uppercase">load more</p>
+              <button
+                onClick={onLoadMore}
+                className={`transition-transform duration-500 ease-in-out transform ${
+                  isLoadMoreOpen ? "" : "rotate-180"
+                }`}
+              >
+                <ChevronUpIcon height={20} className="text-positive-11" />
+              </button>
+            </div>
+          )}
         </div>
-      )}
-    </>
+      </Collapsible>
+    </SkeletonTheme>
   );
 };
 

--- a/packages/react-app-revamp/components/_pages/Rewards/components/Create/components/Recipients/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Rewards/components/Create/components/Recipients/index.tsx
@@ -61,7 +61,7 @@ const CreateRewardsPoolRecipients: React.FC = () => {
 
   const handleProportionChange = (event: React.ChangeEvent<HTMLInputElement>, id: number) => {
     let { value } = event.target;
-    let updatedProportion = value === "" ? 0 : parseFloat(value);
+    let updatedProportion = parseFloat(value);
 
     if (updatedProportion > 100) {
       updatedProportion = 100;
@@ -82,7 +82,10 @@ const CreateRewardsPoolRecipients: React.FC = () => {
     );
   };
 
-  const totalProportion = recipients.reduce((sum, recipient) => sum + recipient.proportion, 0);
+  const totalProportion = recipients.reduce(
+    (sum, recipient) => sum + (isNaN(recipient.proportion) ? 0 : recipient.proportion),
+    0,
+  );
   const proportionError = totalProportion > 100 ? "over" : totalProportion < 100 ? "under" : null;
 
   return (

--- a/packages/react-app-revamp/hooks/useContest/index.ts
+++ b/packages/react-app-revamp/hooks/useContest/index.ts
@@ -150,7 +150,7 @@ export function useContest() {
         await fetchProposalsIdsList(contractConfig.contractInterface);
 
         //@ts-ignore
-        const closingVoteDate = new Date(parseInt(results[5]) * 1000);
+        const closingVoteDate = new Date(parseInt(results[5] * 1000) + 1000);
 
         setContestName(results[0].toString());
         setContestAuthor(results[1].toString(), results[1].toString());
@@ -158,11 +158,12 @@ export function useContest() {
         const contestMaxNumberSubmissionsPerUser = parseFloat(results[2].toString());
         setContestMaxNumberSubmissionsPerUser(contestMaxNumberSubmissionsPerUser);
         setContestMaxProposalCount(parseFloat(results[3].toString()));
+
         //@ts-ignore
-        setSubmissionsOpen(new Date(parseInt(results[4]) * 1000));
+        setSubmissionsOpen(new Date(parseInt(results[4]) * 1000 + 1000));
         setVotesClose(closingVoteDate);
         //@ts-ignore
-        setVotesOpen(new Date(parseInt(results[6]) * 1000));
+        setVotesOpen(new Date(parseInt(results[6]) * 1000 + 1000));
 
         setContestPrompt(results[8].toString());
 

--- a/packages/react-app-revamp/layouts/LayoutViewContest/Prompt/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/Prompt/index.tsx
@@ -30,7 +30,7 @@ const LayoutContestPrompt: FC<LayoutContestPromptProps> = ({ prompt, hidePrompt 
         <div className="flex flex-col gap-4">
           <div className="flex gap-4 items-center">
             <p className="text-[24px] text-neutral-11 font-bold">{title}</p>
-            <div className="flex items-center px-2 h-4 leading-tight pb-1 mt-1 bg-neutral-9 rounded-[5px] border-0 text-true-black text-[16px] font-bold">
+            <div className="flex items-center px-4 leading-tight py-[1px] bg-neutral-10 rounded-[5px] text-true-black text-[16px] font-bold">
               {type}
             </div>
             <button

--- a/packages/react-app-revamp/styles/globals.css
+++ b/packages/react-app-revamp/styles/globals.css
@@ -89,6 +89,70 @@ li {
   box-sizing: border-box;
 }
 
+/* Edit react-datepicker styles */
+
+@keyframes fadeIn {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+.react-datepicker {
+  background-color: black !important;
+  font-size: 14px !important;
+  font-family: "Lato" !important;
+  animation: fadeIn 0.3s ease-in-out;
+}
+
+.react-datepicker__month-container {
+  background-color: black !important;
+  width: 300px;
+}
+.react-datepicker__header {
+  background-color: black !important;
+  color: white !important;
+  font-family: sabo, sans-serif !important;
+}
+
+.react-datepicker__current-month,
+.react-datepicker__day-name,
+.react-datepicker-time__header,
+.react-datepicker__day {
+  color: white !important;
+}
+
+.react-datepicker__day--disabled {
+  opacity: 0.5 !important;
+}
+
+.react-datepicker__day--selected {
+  background-color: #ffe25b !important;
+  color: black !important;
+}
+
+.react-datepicker__day:hover {
+  background-color: #ffe25b !important;
+  color: black !important;
+}
+
+.react-datepicker__time-box {
+  background-color: black !important;
+  color: white !important;
+}
+
+.react-datepicker__time-list-item--selected {
+  background-color: #ffe25b !important;
+  color: black !important;
+}
+
+.react-datepicker__time-list-item:hover {
+  background-color: #ffe25b !important;
+  color: black !important;
+}
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
**UI/UX cosmetics included in this PR**

- keyboard events for voting & submission popup are now active
- calendar dark mode format is done
- on the allowlist pages in create flow, we now have placeholders for voting & submission preview box
- voting/submission times were 1 min behind, not 1 minute specifically but 1s
- when you interact with input when setting percentages during creation of reward pool, 0 was always there and was messing up with UX.

**Separate issues**
- resolving ENS, is this something that we still have to configure from alchemy dashboard so it doesn't use polygon always? @seanmc9 
- sort all proposals for a filter (live, upcoming) and not just the ones on the current page ( this should be it's own PR as it needs small refactor )
-  view all contests should default to showing them in order of most recently created, and that should be an option in sort as well ("recently created")
- can’t select which text to format with rich text — have to select all of it (also this would be better if we just had the rich text bar instead of it appearing when text is selected)   - markdown issue
 submissions that are too long to preview are getting cut off 1) without an ellipsis ("..." is important to show entry is not complete), 2) halfway across the line (instead of 3/4ths), 3) at the second line (should at least preview three lines) - markdown issue
 
 
I'm left with a just a few cosmetics which if you agree i can take in the next week, it's prolly gonna take 30 mins - 1 hour.