### PR TITLE
bug: fix broken images

### DIFF
--- a/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
@@ -139,7 +139,21 @@ const ProposalContent: FC<ProposalContentProps> = ({ id, proposal, votingOpen, p
         <ReactMarkdown
           className="markdown max-w-full overflow-x-hidden"
           components={{
-            img: ({ node, ...props }) => <img {...props} className="w-[170px] h-[130px]" alt="image" />,
+            img: ({ node, ...props }) => {
+              const [error, setError] = useState(false);
+
+              if (error) {
+                return (
+                  <p>
+                    <a href={props.src} target="_blank" rel="noopener noreferrer">
+                      {props.src}
+                    </a>
+                  </p>
+                );
+              }
+
+              return <img {...props} className="w-[170px] h-[130px]" alt="image" onError={() => setError(true)} />;
+            },
             div: ({ node, children, ...props }) => (
               <div {...props} className="flex gap-5 items-center markdown">
                 {children}

--- a/packages/react-app-revamp/layouts/LayoutViewContest/Proposal/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/Proposal/index.tsx
@@ -61,7 +61,21 @@ const LayoutContestProposal: FC<LayoutContestProposalProps> = ({ proposal, conte
         <ReactMarkdown
           className="markdown"
           components={{
-            img: ({ node, ...props }) => <img {...props} className="w-[350px]" alt="image" />,
+            img: ({ node, ...props }) => {
+              const [error, setError] = useState(false);
+
+              if (error) {
+                return (
+                  <p>
+                    <a href={props.src} target="_blank" rel="noopener noreferrer">
+                      {props.src}
+                    </a>
+                  </p>
+                );
+              }
+
+              return <img {...props} className="w-[350px]" alt="image" onError={() => setError(true)} />;
+            },
             p: ({ node, children, ...props }) => (
               <p {...props} className="m-0 text-[16px]">
                 {children}
@@ -95,7 +109,21 @@ const LayoutContestProposal: FC<LayoutContestProposalProps> = ({ proposal, conte
         <ReactMarkdown
           className="markdown"
           components={{
-            img: ({ node, ...props }) => <img {...props} className="w-[350px]" alt="image" />,
+            img: ({ node, ...props }) => {
+              const [error, setError] = useState(false);
+
+              if (error) {
+                return (
+                  <p>
+                    <a href={props.src} target="_blank" rel="noopener noreferrer">
+                      {props.src}
+                    </a>
+                  </p>
+                );
+              }
+
+              return <img {...props} className="w-[350px]" alt="image" onError={() => setError(true)} />;
+            },
             p: ({ node, children, ...props }) => (
               <p {...props} className="m-0 text-[16px]">
                 {children}
@@ -126,7 +154,21 @@ const LayoutContestProposal: FC<LayoutContestProposalProps> = ({ proposal, conte
         <ReactMarkdown
           className="markdown"
           components={{
-            img: ({ node, ...props }) => <img {...props} className="w-[350px]" alt="image" />,
+            img: ({ node, ...props }) => {
+              const [error, setError] = useState(false);
+
+              if (error) {
+                return (
+                  <p>
+                    <a href={props.src} target="_blank" rel="noopener noreferrer">
+                      {props.src}
+                    </a>
+                  </p>
+                );
+              }
+
+              return <img {...props} className="w-[350px]" alt="image" onError={() => setError(true)} />;
+            },
           }}
           rehypePlugins={[rehypeRaw, rehypeSanitize]}
         >
@@ -196,7 +238,21 @@ const LayoutContestProposal: FC<LayoutContestProposalProps> = ({ proposal, conte
             <ReactMarkdown
               className="markdown"
               components={{
-                img: ({ node, ...props }) => <img {...props} className="w-[350px]" alt="image" />,
+                img: ({ node, ...props }) => {
+                  const [error, setError] = useState(false);
+
+                  if (error) {
+                    return (
+                      <p>
+                        <a href={props.src} target="_blank" rel="noopener noreferrer">
+                          {props.src}
+                        </a>
+                      </p>
+                    );
+                  }
+
+                  return <img {...props} className="w-[350px]" alt="image" onError={() => setError(true)} />;
+                },
                 p: ({ node, children, ...props }) => (
                   <p {...props} className="m-0 text-[16px]">
                     {children}


### PR DESCRIPTION
Users are reporting broken images over at https://jokerace.xyz/contest/polygon/0x8F99798D17c9DF10fd205E5D696f1F327Ce3DabF

Some of these broken images aren't actually a valid source as they provided a folder link, however, let's make a small adjustment and whenever link is broken, show source in the paragraph so at least it can lead user to a either img or folder like it was a case with some.