### PR TITLE
bug: fix rank in proposals and do not floor vote number in formatNumber

### DIFF
--- a/packages/react-app-revamp/components/_pages/ListProposals/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListProposals/index.tsx
@@ -32,21 +32,21 @@ export const ListProposals = () => {
       <div className="flex flex-col gap-8">
         {(() => {
           let rank = 0;
-          let lastVotes = -1;
+          let lastVotes: number | null = null;
 
           return Object.keys(listProposalsData)
             .sort((a, b) => listProposalsData[b].votes - listProposalsData[a].votes)
-            .map((id, i) => {
-              const currentVotes = listProposalsData[id].votes;
+            .map(id => {
+              const votes = listProposalsData[id].votes;
 
-              if (currentVotes > 0 && currentVotes !== lastVotes) {
-                rank = i + 1;
-                lastVotes = currentVotes;
+              if (votes !== lastVotes) {
+                rank++;
+                lastVotes = votes;
               }
 
               return (
                 <div key={id} className="relative">
-                  {currentVotes > 0 && !now.isBefore(formattedVotingOpen) && (
+                  {votes > 0 && (
                     <div className="absolute -top-0 left-0 -mt-6 -ml-6 w-12 z-10 h-12 rounded-full bg-true-black flex items-center justify-center text-[24px] font-bold text-neutral-11 border border-neutral-11">
                       {rank}
                     </div>

--- a/packages/react-app-revamp/helpers/formatNumber.ts
+++ b/packages/react-app-revamp/helpers/formatNumber.ts
@@ -3,11 +3,10 @@
  * @param num - The number to format
  * @return A string representing the formatted number
  */
-export function formatNumber(num: number, decimal = 0): string {
-  let formattedNum = Math.floor(num);
-  let formatter = new Intl.NumberFormat("en-US", { maximumFractionDigits: decimal });
+export function formatNumber(num: number): string {
+  let formatter = new Intl.NumberFormat("en-US");
 
-  let formatted = formatter.format(+formattedNum.toFixed(decimal));
+  let formatted = formatter.format(+num);
 
   return formatted;
 }


### PR DESCRIPTION
This PR updates the ranking system for proposals to handle ties in vote counts more effectively. Previously, the rank was derived directly from the index in the sorted list, which resulted in incorrect rankings when there were ties in vote counts.

Additionally, our `formatNumber` fn was using floor so we do not round a number, but it impacted lower numbers. Since we are now rounding all votes to a 4 decimal, there isn't a need to format a number rather than to american numbers, since it will not affect UI.