### PR TITLE
bug: remove alchemy rpc hook, just use custom configs

### DIFF
--- a/packages/react-app-revamp/config/wagmi/custom-chains/arbitrumOne.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/arbitrumOne.ts
@@ -9,7 +9,7 @@ export const arbitrumOne = {
   },
   rpcUrls: {
     public: 'https://rpc.ankr.com/arbitrum',
-    default: 'https://rpc.ankr.com/arbitrum',
+    default: `https://arb-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_KEY}`,
   },
   blockExplorers: {
     etherscan: { name: 'Arbitrum Mainnet Etherscan', url: 'https://arbiscan.io/' },

--- a/packages/react-app-revamp/config/wagmi/custom-chains/arbitrumOneTestnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/arbitrumOneTestnet.ts
@@ -1,0 +1,18 @@
+export const arbitrumOneTestnet = {
+  id: 42161,
+  name: 'arbitrumoneTestnet',
+  network: 'arbitrumoneTestnet',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'ETH',
+    symbol: 'ETH',
+  },
+  rpcUrls: {
+    public: '421613',
+    default: `https://arb-goerli.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_KEY}`,
+  },
+  blockExplorers: {
+    etherscan: { name: 'Arbitrum Testnet Etherscan', url: 'https://goerli-rollup-explorer.arbitrum.io' },
+    default: { name: 'Arbitrum Testnet Etherscan', url: 'https://goerli-rollup-explorer.arbitrum.io' },
+  },
+}

--- a/packages/react-app-revamp/config/wagmi/custom-chains/goerli.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/goerli.ts
@@ -9,7 +9,7 @@ export const goerli = {
   },
   rpcUrls: {
     public: 'https://rpc.ankr.com/eth_goerli',
-    default: 'https://rpc.ankr.com/eth_goerli',
+    default: `https://eth-goerli.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_KEY}`,
   },
   blockExplorers: {
     etherscan: { name: 'Goerli Etherscan', url: 'https://goerli.etherscan.io/' },

--- a/packages/react-app-revamp/config/wagmi/custom-chains/optimism.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/optimism.ts
@@ -9,7 +9,7 @@ export const optimism = {
   },
   rpcUrls: {
     public: 'https://mainnet.optimism.io',
-    default: 'https://mainnet.optimism.io',
+    default: `https://opt-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_KEY}`,
   },
   blockExplorers: {
     etherscan: { name: 'Optimism Mainnet Etherscan', url: 'https://optimistic.etherscan.io/' },

--- a/packages/react-app-revamp/config/wagmi/custom-chains/optimismTestnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/optimismTestnet.ts
@@ -1,0 +1,18 @@
+export const optimismTestnet = {
+  id: 420,
+  name: 'optimismTestnet',
+  network: 'optimismTestnet',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'ETH',
+    symbol: 'ETH',
+  },
+  rpcUrls: {
+    public: 'https://optimism-goerli.publicnode.com',
+    default: `https://opt-goerli.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_KEY}`,
+  },
+  blockExplorers: {
+    etherscan: { name: 'Optimism Testnet Etherscan', url: 'https://goerli-optimism.etherscan.io/' },
+    default: { name: 'Optimism Testnet Etherscan', url: 'https://goerli-optimism.etherscan.io/' },
+  },
+}

--- a/packages/react-app-revamp/config/wagmi/custom-chains/polygon.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/polygon.ts
@@ -9,7 +9,7 @@ export const polygon = {
   },
   rpcUrls: {
     public: 'https://rpc.ankr.com/polygon',
-    default: 'https://rpc.ankr.com/polygon',
+    default: `https://polygon-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_KEY}`,
   },
   blockExplorers: {
     etherscan: { name: 'Polygon Mainnet Etherscan', url: 'https://polygonscan.com/' },

--- a/packages/react-app-revamp/config/wagmi/custom-chains/polygonMumbai.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/polygonMumbai.ts
@@ -9,7 +9,7 @@ export const polygonMumbai = {
   },
   rpcUrls: {
     public: 'https://rpc.ankr.com/polygon_mumbai',
-    default: 'https://rpc.ankr.com/polygon_mumbai',
+    default: `https://polygon-mumbai.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_KEY}`,
   },
   blockExplorers: {
     etherscan: { name: 'Polygon Mumbai Etherscan', url: 'https://mumbai.polygonscan.com/' },

--- a/packages/react-app-revamp/config/wagmi/custom-chains/polygonZkMainnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/polygonZkMainnet.ts
@@ -9,7 +9,7 @@ export const polygonZkMainnet = {
   },
   rpcUrls: {
     public: 'https://zkevm-rpc.com',
-    default: 'https://zkevm-rpc.com',
+    default: `https://polygonzkevm-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_KEY}`,
   },
   blockExplorers: {
     etherscan: { name: 'Polygon zkEvm Mainnet Scan', url: 'https://zkevm.polygonscan.com/' },

--- a/packages/react-app-revamp/config/wagmi/custom-chains/polygonZkTestnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/polygonZkTestnet.ts
@@ -9,7 +9,7 @@ export const polygonZkTestnet = {
   },
   rpcUrls: {
     public: 'https://rpc.public.zkevm-test.net',
-    default: 'https://rpc.public.zkevm-test.net',
+    default: `https://polygonzkevm-testnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_KEY}`,
   },
   blockExplorers: {
     etherscan: { name: 'Polygon zkEvm Testnet Scan', url: 'https://explorer.public.zkevm-test.net' },

--- a/packages/react-app-revamp/config/wagmi/index.ts
+++ b/packages/react-app-revamp/config/wagmi/index.ts
@@ -73,14 +73,20 @@ const totalChains: Chain[] = [
   mantleTestnet
 ];
 
-const providers = [
-  jsonRpcProvider({rpc: (chain) => ({
-    http: `${chain.rpcUrls.default}`
-  })}),
+const providers = (process.env.NEXT_PUBLIC_ALCHEMY_KEY !== "" && process.env.NEXT_PUBLIC_ALCHEMY_KEY) ? 
+  [
+    jsonRpcProvider({rpc: (chain) => ({
+      http: `${chain.rpcUrls.default}`
+    })}),
+    jsonRpcProvider({rpc: (chain) => ({
+      http: `${chain.rpcUrls.public}`
+    })}),
+  ] :
+  [
   jsonRpcProvider({rpc: (chain) => ({
     http: `${chain.rpcUrls.public}`
   })}),
-];
+  ];
 export const { chains, provider } = configureChains(totalChains, providers);
 
 const { wallets } = getDefaultWallets({

--- a/packages/react-app-revamp/config/wagmi/index.ts
+++ b/packages/react-app-revamp/config/wagmi/index.ts
@@ -31,6 +31,7 @@ import { mantleMainnet } from "./custom-chains/mantleMainnet";
 import { mantleTestnet } from "./custom-chains/mantleTestnet";
 import { publicProvider } from "wagmi/providers/public";
 import { alchemyProvider } from "wagmi/providers/alchemy";
+import { jsonRpcProvider } from "wagmi/providers/jsonRpc";
 import { connectorsForWallets, getDefaultWallets, wallet } from "@rainbow-me/rainbowkit";
 
 type ChainImages = {
@@ -72,10 +73,14 @@ const totalChains: Chain[] = [
   mantleTestnet
 ];
 
-const providers =
-  process.env.NODE_ENV === "development"
-    ? [publicProvider(), alchemyProvider({ alchemyId })]  // if in dev, try public first in case there isn't an Alchemy key
-    : [alchemyProvider({ alchemyId }), publicProvider()];
+const providers = [
+  jsonRpcProvider({rpc: (chain) => ({
+    http: `${chain.rpcUrls.default}`
+  })}),
+  jsonRpcProvider({rpc: (chain) => ({
+    http: `${chain.rpcUrls.public}`
+  })}),
+];
 export const { chains, provider } = configureChains(totalChains, providers);
 
 const { wallets } = getDefaultWallets({


### PR DESCRIPTION
Wagmi's Alchemy RPC hook wasn't working correctly for some reason, so just moved us to custom chain configs and stuff's working now (not routing to public rpc endpoints which ratelimit us when they should go to Alchemy ones).