### PR TITLE
chore: update OP RPC to ankr so not being rate-limited, correct Arb testnet

### DIFF
--- a/packages/react-app-revamp/config/wagmi/custom-chains/arbitrumOneTestnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/arbitrumOneTestnet.ts
@@ -8,7 +8,7 @@ export const arbitrumOneTestnet = {
     symbol: 'ETH',
   },
   rpcUrls: {
-    public: '421613',
+    public: 'https://endpoints.omniatech.io/v1/arbitrum/goerli/public',
     default: `https://arb-goerli.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_KEY}`,
   },
   blockExplorers: {

--- a/packages/react-app-revamp/config/wagmi/custom-chains/optimism.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/optimism.ts
@@ -8,7 +8,7 @@ export const optimism = {
     symbol: 'ETH',
   },
   rpcUrls: {
-    public: 'https://mainnet.optimism.io',
+    public: 'https://rpc.ankr.com/optimism',
     default: `https://opt-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_KEY}`,
   },
   blockExplorers: {


### PR DESCRIPTION
- OP's self-hosted mainnet RPC sucks, moving to Ankr's for our public one
- Arbitrum One's testnet public RPC was just an incorrect copypasta so fixing that