### PR TITLE
chain: update sepolia rpc provider

### DIFF
--- a/packages/react-app-revamp/config/wagmi/custom-chains/sepolia.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/sepolia.ts
@@ -11,10 +11,10 @@ export const sepolia: Chain = {
   },
   rpcUrls: {
     public: {
-      http: ["https://rpc.sepolia.org/"],
+      http: ["https://gateway.tenderly.co/public/sepolia"],
     },
     default: {
-      http: ["https://rpc.sepolia.org/"],
+      http: ["https://gateway.tenderly.co/public/sepolia"],
     },
   },
   blockExplorers: {


### PR DESCRIPTION
https://rpc.sepolia.org/ was erroring out, this new one works though!