### PR TITLE
bug: remove public node fallback for alchemy chains for now

### DIFF
--- a/packages/react-app-revamp/config/wagmi/index.ts
+++ b/packages/react-app-revamp/config/wagmi/index.ts
@@ -89,13 +89,6 @@ const publicClients =
             };
           },
         }),
-        jsonRpcProvider({
-          rpc: chain => {
-            return {
-              http: `${chain.rpcUrls.public.http[0]}`,
-            };
-          },
-        }),
       ]
     : [
         jsonRpcProvider({


### PR DESCRIPTION
Public nodes are being used as a backup by the app, however they also cause a CORS problem, which stops production for chains with alchemy setup.