### PR TITLE
bug: allow opt out of deploy rewards modal and query rewards address when funding pool

### DIFF
--- a/packages/react-app-revamp/components/Rewards/index.tsx
+++ b/packages/react-app-revamp/components/Rewards/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 import ButtonV3 from "@components/UI/ButtonV3";
 import DialogModalV3 from "@components/UI/DialogModalV3";
 import Loader from "@components/UI/Loader";
@@ -21,7 +20,7 @@ import { useAccount } from "wagmi";
 
 const ContestRewards = () => {
   const { isSuccess, isLoading, supportsRewardsModule, contestAuthorEthereumAddress } = useContestStore(state => state);
-  const displayCreatePool = useDeployRewardsStore(state => state.displayCreatePool);
+  const { displayCreatePool, isLoading: isRewardsPoolDeploying } = useDeployRewardsStore(state => state);
   const [isDeployRewardsOpen, setIsDeployRewardsOpen] = useState(false);
   const [isFundRewardsOpen, setIsFundRewardsOpen] = useState(false);
   const [isWithdrawRewardsOpen, setIsWithdrawRewardsOpen] = useState(false);
@@ -41,6 +40,8 @@ const ContestRewards = () => {
   useEffect(() => {
     if (rewardsStore?.isSuccess) return;
     if (supportsRewardsModule) getContestRewardsModule();
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rewardsStore?.isSuccess, supportsRewardsModule]);
 
   if (!supportsRewardsModule && !creator) {
@@ -48,6 +49,8 @@ const ContestRewards = () => {
   }
 
   if (!supportsRewardsModule && creator) {
+    if (isRewardsPoolDeploying) return <Loader scale="page">Deploying rewards pool...</Loader>;
+
     return (
       <div className="flex flex-col gap-12">
         <p className="text-[24px] font-bold text-neutral-11">create a rewards pool</p>

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestRewards/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestRewards/index.tsx
@@ -43,7 +43,6 @@ const CreateContestRewards = () => {
       isOpen={isOpen}
       setIsOpen={value => setIsOpen(value)}
       onClose={handleModalClose}
-      disableClose={isRewardsModuleDeploying || isFundingRewardsDeploying}
       title="rewards"
       className="xl:w-[1110px] 3xl:w-[1300px] h-[850px]"
     >

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestRewards/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestRewards/index.tsx
@@ -11,12 +11,10 @@ const CreateContestRewards = () => {
   const { reset: clearContestData, isSuccess: contestDeployed } = useDeployContestStore(state => state);
   const {
     displayCreatePool,
-    isLoading: isRewardsModuleDeploying,
     cancel: cancelCreateRewardsPool,
     reset: clearRewardsData,
   } = useDeployRewardsStore(state => state);
   const { setShowRewards } = useShowRewardsStore(state => state);
-  const { isLoading: isFundingRewardsDeploying } = useFundRewardsStore(state => state);
   const { cancel: cancelFundingPool } = useFundRewardsStore(state => state);
 
   const [isOpen, setIsOpen] = useState(true);

--- a/packages/react-app-revamp/hooks/useDeployRewards/index.ts
+++ b/packages/react-app-revamp/hooks/useDeployRewards/index.ts
@@ -70,6 +70,8 @@ export function useDeployRewardsPool() {
           stateContestDeployment.setIsSuccess(false);
           stateContestDeployment.setError(error as CustomError);
           setIsError(true);
+          setIsLoading(false);
+          setIsSuccess(false);
           setDisplayCreatePool(true);
           throw error;
         }
@@ -82,6 +84,8 @@ export function useDeployRewardsPool() {
           stateContestDeployment.setIsSuccess(false);
           stateContestDeployment.setError(error as CustomError);
           setIsError(true);
+          setIsLoading(false);
+          setIsSuccess(false);
           setDisplayCreatePool(true);
           throw error;
         }

--- a/packages/react-app-revamp/hooks/useDeployRewards/store.tsx
+++ b/packages/react-app-revamp/hooks/useDeployRewards/store.tsx
@@ -1,5 +1,4 @@
-import { createContext, useContext, useRef } from "react";
-import { createStore, useStore } from "zustand";
+import { create } from "zustand";
 
 interface DeployRewardsState {
   ranks: number[];
@@ -31,58 +30,38 @@ interface DeployRewardsState {
   reset: () => void;
 }
 
-export const createDeployRewardsStore = () =>
-  createStore<DeployRewardsState>(set => {
-    const initialState = {
-      ranks: [],
-      shares: [],
-      isLoading: false,
-      isSuccess: false,
-      isError: false,
-      cancel: false,
-      validationError: {
-        uniqueRanks: undefined,
-        zeroProportion: undefined,
-        invalidTotal: undefined,
-        duplicateRank: undefined,
-      },
-      displayCreatePool: true,
-      deployRewardsData: {
-        hash: "",
-        address: "",
-      },
-    };
+export const useDeployRewardsStore = create<DeployRewardsState>(set => {
+  const initialState = {
+    ranks: [],
+    shares: [],
+    isLoading: false,
+    isSuccess: false,
+    isError: false,
+    cancel: false,
+    validationError: {
+      uniqueRanks: undefined,
+      zeroProportion: undefined,
+      invalidTotal: undefined,
+      duplicateRank: undefined,
+    },
+    displayCreatePool: true,
+    deployRewardsData: {
+      hash: "",
+      address: "",
+    },
+  };
 
-    return {
-      ...initialState,
-      setValidationError: error => set({ validationError: error }),
-      setIsLoading: isLoading => set({ isLoading }),
-      setIsSuccess: isSuccess => set({ isSuccess }),
-      setIsError: isError => set({ isError }),
-      setCancel: cancel => set({ cancel: cancel }),
-      setDeployRewardsData: (hash, address) => set(state => ({ deployRewardsData: { hash, address } })),
-      setRanks: ranks => set({ ranks }),
-      setShares: shares => set({ shares }),
-      setDisplayCreatePool: displayCreatePool => set({ displayCreatePool }),
-      reset: () => set({ ...initialState }),
-    };
-  });
-
-export const DeployRewardsContext = createContext<ReturnType<typeof createDeployRewardsStore> | null>(null);
-
-export function DeployRewardsWrapper({ children }: { children: React.ReactNode }) {
-  const storeRef = useRef<ReturnType<typeof createDeployRewardsStore>>();
-  if (!storeRef.current) {
-    storeRef.current = createDeployRewardsStore();
-  }
-  return <DeployRewardsContext.Provider value={storeRef.current}>{children}</DeployRewardsContext.Provider>;
-}
-
-export function useDeployRewardsStore<T>(selector: (state: DeployRewardsState) => T) {
-  const store = useContext(DeployRewardsContext);
-  if (store === null) {
-    throw new Error("Missing DeployRewards in the tree");
-  }
-  const value = useStore(store, selector);
-  return value;
-}
+  return {
+    ...initialState,
+    setValidationError: error => set({ validationError: error }),
+    setIsLoading: isLoading => set({ isLoading }),
+    setIsSuccess: isSuccess => set({ isSuccess }),
+    setIsError: isError => set({ isError }),
+    setCancel: cancel => set({ cancel: cancel }),
+    setDeployRewardsData: (hash, address) => set(state => ({ deployRewardsData: { hash, address } })),
+    setRanks: ranks => set({ ranks }),
+    setShares: shares => set({ shares }),
+    setDisplayCreatePool: displayCreatePool => set({ displayCreatePool }),
+    reset: () => set({ ...initialState }),
+  };
+});

--- a/packages/react-app-revamp/hooks/useFundRewards/store.tsx
+++ b/packages/react-app-revamp/hooks/useFundRewards/store.tsx
@@ -1,6 +1,5 @@
-import { createContext, useContext, useRef } from "react";
 import { CustomError } from "types/error";
-import { createStore, useStore } from "zustand";
+import { create } from "zustand";
 
 export type Reward = {
   address: string;
@@ -26,41 +25,21 @@ interface FundRewardsState {
   setTransactionData: (data: any) => void;
 }
 
-export const createFundRewardsStore = () =>
-  createStore<FundRewardsState>(set => ({
-    isLoading: false,
-    error: null,
-    rewards: [],
-    cancel: false,
-    isSuccess: false,
-    transactionData: null,
-    isModalOpen: false,
-    validationError: [],
-    setValidationError: errors => set({ validationError: errors }),
-    setRewards: rewards => set({ rewards: rewards }),
-    setIsModalOpen: isOpen => set({ isModalOpen: isOpen }),
-    setIsLoading: value => set({ isLoading: value }),
-    setIsSuccess: value => set({ isSuccess: value }),
-    setCancel: value => set({ cancel: value }),
-    setError: value => set({ error: value }),
-    setTransactionData: data => set({ transactionData: data }),
-  }));
-
-export const FundRewardsContext = createContext<ReturnType<typeof createFundRewardsStore> | null>(null);
-
-export function FundRewardsWrapper({ children }: { children: React.ReactNode }) {
-  const storeRef = useRef<ReturnType<typeof createFundRewardsStore>>();
-  if (!storeRef.current) {
-    storeRef.current = createFundRewardsStore();
-  }
-  return <FundRewardsContext.Provider value={storeRef.current}>{children}</FundRewardsContext.Provider>;
-}
-
-export function useFundRewardsStore<T>(selector: (state: FundRewardsState) => T) {
-  const store = useContext(FundRewardsContext);
-  if (store === null) {
-    throw new Error("Missing FundRewardsWrapper in the tree");
-  }
-  const value = useStore(store, selector);
-  return value;
-}
+export const useFundRewardsStore = create<FundRewardsState>(set => ({
+  isLoading: false,
+  error: null,
+  rewards: [],
+  cancel: false,
+  isSuccess: false,
+  transactionData: null,
+  isModalOpen: false,
+  validationError: [],
+  setValidationError: errors => set({ validationError: errors }),
+  setRewards: rewards => set({ rewards: rewards }),
+  setIsModalOpen: isOpen => set({ isModalOpen: isOpen }),
+  setIsLoading: value => set({ isLoading: value }),
+  setIsSuccess: value => set({ isSuccess: value }),
+  setCancel: value => set({ cancel: value }),
+  setError: value => set({ error: value }),
+  setTransactionData: data => set({ transactionData: data }),
+}));

--- a/packages/react-app-revamp/hooks/useRewards/index.ts
+++ b/packages/react-app-revamp/hooks/useRewards/index.ts
@@ -82,7 +82,7 @@ export function useRewardsModule() {
         chainId,
         functionName: "officialRewardsModule",
       })) as string;
-      //@ts-ignore
+
       const abiRewardsModule = await getRewardsModuleContractVersion(contestRewardModuleAddress, chainId);
       if (abiRewardsModule === null) {
         if (contestRewardModuleAddress == "0x0000000000000000000000000000000000000000") {

--- a/packages/react-app-revamp/hooks/useRewards/index.ts
+++ b/packages/react-app-revamp/hooks/useRewards/index.ts
@@ -11,6 +11,7 @@ import { useRewardsStore } from "./store";
 
 export function useRewardsModule() {
   const { asPath } = useRouter();
+  const contestAddress = asPath.split("/")[3];
   const contestChainName = asPath.split("/")[2];
   const { chain } = useNetwork();
   const { rewards, setRewards, setIsLoading, setError, setIsSuccess } = useRewardsStore(state => state);
@@ -49,7 +50,7 @@ export function useRewardsModule() {
 
         return balances;
       } catch (e) {
-        console.error(e);
+        setIsLoading(false);
       }
     },
     {
@@ -57,31 +58,18 @@ export function useRewardsModule() {
     },
   );
 
-  async function getContestRewardsModule(address?: string, chainName?: string) {
+  async function getContestRewardsModule() {
     setIsLoading(true);
     setError(null);
     setIsSuccess(false);
 
     try {
-      const contestAddress = address ?? asPath.split("/")[3];
-      const contestChainName = chainName ?? asPath.split("/")[2];
-      const { abi: abiContest } = await getContestContractVersion(address ?? contestAddress, chainId);
+      const contestRewardModuleAddress = await getContestRewardsAddress();
 
-      if (abiContest === null) {
-        setIsLoading(false);
-        setError({
-          message: `This contract doesn't exist on ${chain?.name ?? "this chain"}.`,
-        });
-        setIsSuccess(false);
-        toastError(`This contract doesn't exist on ${chain?.name ?? "this chain"}.`);
+      if (!contestRewardModuleAddress || contestRewardModuleAddress === "0x0000000000000000000000000000000000000000") {
+        toastError("there is no rewards module for this contest!");
         return;
       }
-      const contestRewardModuleAddress = (await readContract({
-        address: contestAddress as `0x${string}`,
-        abi: abiContest as unknown as Abi,
-        chainId,
-        functionName: "officialRewardsModule",
-      })) as string;
 
       const abiRewardsModule = await getRewardsModuleContractVersion(contestRewardModuleAddress, chainId);
       if (abiRewardsModule === null) {
@@ -118,7 +106,6 @@ export function useRewardsModule() {
         contracts: contractsRewardsModule,
       });
 
-      setIsLoading(false);
       setRewards({
         abi: abiRewardsModule,
         contractAddress: contestRewardModuleAddress,
@@ -128,6 +115,7 @@ export function useRewardsModule() {
         blockExplorers: chains.filter(chain => chain.name.toLowerCase().replace(" ", "") === contestChainName)?.[0]
           ?.blockExplorers?.default,
       });
+      setIsLoading(false);
       setIsSuccess(true);
     } catch (e) {
       const customError = e as CustomError;
@@ -140,11 +128,38 @@ export function useRewardsModule() {
         message: customError.message,
       });
       setIsLoading(false);
+      setIsSuccess(false);
+    }
+  }
+
+  async function getContestRewardsAddress() {
+    const { abi: abiContest } = await getContestContractVersion(contestAddress, chainId);
+
+    if (abiContest === null) {
+      setIsLoading(false);
+      setIsSuccess(false);
+      toastError(`This contract doesn't exist on ${contestChainName}.`);
+      return;
+    }
+
+    try {
+      const contestRewardModuleAddress = (await readContract({
+        address: contestAddress as `0x${string}`,
+        abi: abiContest as unknown as Abi,
+        chainId,
+        functionName: "officialRewardsModule",
+      })) as string;
+
+      return contestRewardModuleAddress;
+    } catch (error) {
+      toastError("failed to fetch rewards module address");
+      return;
     }
   }
 
   return {
     getContestRewardsModule,
+    getContestRewardsAddress,
     refetchBalanceRewardsModule,
   };
 }

--- a/packages/react-app-revamp/hooks/useRewards/store.tsx
+++ b/packages/react-app-revamp/hooks/useRewards/store.tsx
@@ -14,7 +14,7 @@ interface RewardsState {
 
 export const createRewardsStore = () =>
   createStore<RewardsState>(set => ({
-    isLoading: true,
+    isLoading: false,
     isSuccess: false,
     error: null,
     rewards: {},

--- a/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
@@ -8,7 +8,6 @@ import { useShowRewardsStore } from "@components/_pages/Create/pages/ContestDepl
 import CreateContestRewards from "@components/_pages/Create/pages/ContestRewards";
 import { ofacAddresses } from "@config/ofac-addresses/ofac-addresses";
 import { ROUTE_CONTEST_PROPOSAL, ROUTE_VIEW_CONTEST } from "@config/routes";
-import { isSupabaseConfigured } from "@helpers/database";
 import { ArrowLeftIcon } from "@heroicons/react/solid";
 import { CastVotesWrapper } from "@hooks/useCastVotes/store";
 import { useContest } from "@hooks/useContest";
@@ -16,8 +15,6 @@ import { ContestWrapper, useContestStore } from "@hooks/useContest/store";
 import useContestEvents from "@hooks/useContestEvents";
 import { ContestStatus, useContestStatusStore } from "@hooks/useContestStatus/store";
 import { ContractFactoryWrapper } from "@hooks/useContractFactory";
-import { DeployRewardsWrapper } from "@hooks/useDeployRewards/store";
-import { FundRewardsWrapper } from "@hooks/useFundRewards/store";
 import { ProposalWrapper } from "@hooks/useProposal/store";
 import { RewardsWrapper } from "@hooks/useRewards/store";
 import { SubmitProposalWrapper } from "@hooks/useSubmitProposal/store";
@@ -319,13 +316,9 @@ export const getLayout = (page: any) => {
             <SubmitProposalWrapper>
               <CastVotesWrapper>
                 <ContractFactoryWrapper>
-                  <DeployRewardsWrapper>
-                    <RewardsWrapper>
-                      <FundRewardsWrapper>
-                        <LayoutViewContest>{page}</LayoutViewContest>
-                      </FundRewardsWrapper>
-                    </RewardsWrapper>
-                  </DeployRewardsWrapper>
+                  <RewardsWrapper>
+                    <LayoutViewContest>{page}</LayoutViewContest>
+                  </RewardsWrapper>
                 </ContractFactoryWrapper>
               </CastVotesWrapper>
             </SubmitProposalWrapper>

--- a/packages/react-app-revamp/pages/contest/new/index.tsx
+++ b/packages/react-app-revamp/pages/contest/new/index.tsx
@@ -1,7 +1,5 @@
 import CreateFlow from "@components/_pages/Create";
 import { ContractFactoryWrapper } from "@hooks/useContractFactory";
-import { DeployRewardsWrapper } from "@hooks/useDeployRewards/store";
-import { FundRewardsWrapper } from "@hooks/useFundRewards/store";
 import { RewardsWrapper } from "@hooks/useRewards/store";
 import type { NextPage } from "next";
 import Head from "next/head";
@@ -15,13 +13,9 @@ const Page: NextPage = () => {
       </Head>
 
       <ContractFactoryWrapper>
-        <DeployRewardsWrapper>
-          <RewardsWrapper>
-            <FundRewardsWrapper>
-              <CreateFlow />
-            </FundRewardsWrapper>
-          </RewardsWrapper>
-        </DeployRewardsWrapper>
+        <RewardsWrapper>
+          <CreateFlow />
+        </RewardsWrapper>
       </ContractFactoryWrapper>
     </>
   );


### PR DESCRIPTION
Closes #460

- We are now allowing users to opt out of rewards modal during deployment after contests is created.
- When user is funding pool, we are always getting rewards address directly from chain.