### PR TITLE
feat: add workers to generate merkle tree and proof for submission/voting & create flow

### DIFF
--- a/packages/react-app-revamp/components/Parameters/index.tsx
+++ b/packages/react-app-revamp/components/Parameters/index.tsx
@@ -30,9 +30,11 @@ const ContestParameters = () => {
   const formattedVotesClosing = moment(votesClose).format("MMMM Do, h:mm a");
   const userMaxProposalCountBN = BigNumber.from(contestMaxNumberSubmissionsPerUser);
   const maxProposalsPerUserCapped = userMaxProposalCountBN.eq(UNLIMITED_PROPOSALS_PER_USER);
-  const processedSubmitters = submitters.map(submitter => ({
-    address: submitter.address,
-  }));
+  const processedSubmitters = useMemo(() => {
+    return submitters.map(submitter => ({
+      address: submitter.address,
+    }));
+  }, [submitters]);
 
   const qualifyToSubmitMessage = useMemo<string | JSX.Element>(() => {
     if (!submitters.length) return `anyone can submit`;

--- a/packages/react-app-revamp/components/Voting/index.tsx
+++ b/packages/react-app-revamp/components/Voting/index.tsx
@@ -14,14 +14,13 @@ interface VotingWidgetProps {
 }
 
 const VotingWidget: FC<VotingWidgetProps> = ({ amountOfVotes, downvoteAllowed, onVote }) => {
-  const isMerkleTreeInProgress = useContestStore(state => state.isMerkleTreeInProgress);
   const currentUserTotalVotesCast = useUserStore(state => state.currentUserTotalVotesCast);
   const isLoading = useCastVotesStore(state => state.isLoading);
   const [isUpvote, setIsUpvote] = useState(true);
   const [amount, setAmount] = useState(0);
   const [sliderValue, setSliderValue] = useState(0);
   const [isInvalid, setIsInvalid] = useState(false);
-  const voteDisabled = isMerkleTreeInProgress || isLoading || amount === 0 || isInvalid;
+  const voteDisabled = isLoading || amount === 0 || isInvalid;
 
   useEffect(() => {
     const handleEnterPress = (event: KeyboardEvent) => {

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestSubmission/components/SubmissionAllowlist/components/CSVEditor/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestSubmission/components/SubmissionAllowlist/components/CSVEditor/index.tsx
@@ -5,7 +5,7 @@ import CSVParseError, {
   ParseError,
 } from "@components/_pages/Create/pages/ContestVoting/components/VotingAllowlist/components/CSVEditor/CSVParseError";
 import { validateSubmissionFields } from "@components/_pages/Create/utils/csv";
-import { parseCsvSubmissions } from "@helpers/parseSubmissionsCsv";
+import { parseSubmissionCsv } from "@helpers/parseSubmissionsCsv";
 import { useDeployContestStore } from "@hooks/useDeployContest/store";
 import Image from "next/image";
 import React, { FC, useEffect, useState } from "react";
@@ -96,7 +96,7 @@ const CSVEditorSubmission: FC<CSVEditorProps> = ({ onChange }) => {
   };
 
   const onFileSelectHandler = async (file: File) => {
-    const results = await parseCsvSubmissions(file);
+    const results = await parseSubmissionCsv(file);
 
     switch (results.error?.kind) {
       case "missingColumns":

--- a/packages/react-app-revamp/components/_pages/DialogModalSendProposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalSendProposal/index.tsx
@@ -35,7 +35,7 @@ export const DialogModalSendProposal: FC<DialogModalSendProposalProps> = ({ isOp
   const { address } = useAccount();
   const { asPath } = useRouter();
   const { sendProposal, isLoading, isSuccess } = useSubmitProposal();
-  const { contestPrompt, votesOpen, isMerkleTreeInProgress } = useContestStore(state => state);
+  const { contestPrompt, votesOpen } = useContestStore(state => state);
   const contestId = asPath.split("/")[3];
   const savedProposal = loadSubmissionFromLocalStorage("submissions", contestId);
   const { contestStatus } = useContestStatusStore(state => state);
@@ -145,7 +145,7 @@ export const DialogModalSendProposal: FC<DialogModalSendProposalProps> = ({ isOp
             color="bg-gradient-create rounded-[40px]"
             size="large"
             onClick={onSubmitProposal}
-            disabled={isLoading || !proposal.length || isMerkleTreeInProgress}
+            disabled={isLoading || !proposal.length}
           >
             submit!
           </ButtonV3>

--- a/packages/react-app-revamp/helpers/parseVotingCsv.ts
+++ b/packages/react-app-revamp/helpers/parseVotingCsv.ts
@@ -111,6 +111,7 @@ export const parseCsvVoting = (file: File): Promise<ParseCsvResult> => {
     Papa.parse(file, {
       header: false,
       dynamicTyping: true,
+      worker: true,
       skipEmptyLines: true,
       complete: results => {
         resolve(processResults(results));

--- a/packages/react-app-revamp/helpers/parseVotingCsv.ts
+++ b/packages/react-app-revamp/helpers/parseVotingCsv.ts
@@ -1,5 +1,4 @@
 import Papa from "papaparse";
-import { getAddress } from "viem";
 
 export type InvalidEntry = {
   address: string;
@@ -22,101 +21,53 @@ export type ParseCsvResult = {
 };
 
 export const MAX_ROWS = 100000; // 100k for now
-const MAX_VOTES = 1e9; // 1 billion
-
-const processResults = (results: Papa.ParseResult<any>): ParseCsvResult => {
-  const data = results.data as Array<any>;
-  const votesData: Record<string, number> = {};
-  const invalidEntries: InvalidEntry[] = [];
-  const addresses: Set<string> = new Set();
-  let roundedToZeroCount = 0;
-
-  if (data.length > MAX_ROWS) {
-    return {
-      data: {},
-      invalidEntries,
-      error: { kind: "limitExceeded" },
-    };
-  }
-
-  const expectedColumns = 2;
-  const firstRow = data[0];
-  if (firstRow.length !== expectedColumns) {
-    return {
-      data: {},
-      invalidEntries,
-      error: { kind: "missingColumns" },
-    };
-  }
-
-  for (const row of data) {
-    let error: InvalidEntry["error"] | null = null;
-    const address = row[0];
-    let numberOfVotes = row[1];
-
-    if (typeof numberOfVotes === "number") {
-      numberOfVotes = parseFloat(row[1].toFixed(4));
-    } else {
-      numberOfVotes = parseFloat(parseFloat(row[1].toString().replaceAll(",", "")).toFixed(4));
-    }
-
-    if (addresses.has(address)) {
-      return {
-        data: {},
-        invalidEntries,
-        error: { kind: "duplicates" },
-      };
-    } else {
-      addresses.add(address);
-    }
-
-    try {
-      getAddress(address);
-    } catch (e) {
-      error = "address";
-    }
-
-    if (typeof numberOfVotes !== "number" || numberOfVotes >= MAX_VOTES) {
-      error = error ? "both" : "votes";
-    }
-
-    if (error) {
-      invalidEntries.push({ address: address, votes: numberOfVotes, error });
-    } else {
-      if (numberOfVotes !== 0) {
-        votesData[address] = numberOfVotes;
-      } else {
-        roundedToZeroCount++;
-      }
-    }
-  }
-
-  if (roundedToZeroCount === data.length) {
-    return {
-      data: {},
-      invalidEntries,
-      error: { kind: "allZero" },
-    };
-  }
-
-  return {
-    data: votesData,
-    invalidEntries,
-    roundedZeroCount: roundedToZeroCount,
-  };
-};
+export const MAX_VOTES = 1e9; // 1 billion
 
 export const parseCsvVoting = (file: File): Promise<ParseCsvResult> => {
-  return new Promise(resolve => {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(new URL("/workers/parseVotingCsv", import.meta.url));
+
+    worker.onmessage = (event: MessageEvent) => {
+      const payload: ParseCsvResult = event.data;
+
+      if (payload.error) {
+        resolve({
+          data: {},
+          invalidEntries: payload.invalidEntries,
+          error: payload.error,
+          roundedZeroCount: payload.roundedZeroCount,
+        });
+      } else {
+        resolve({
+          data: payload.data,
+          invalidEntries: payload.invalidEntries,
+          roundedZeroCount: payload.roundedZeroCount,
+        });
+      }
+
+      worker.terminate();
+    };
+
+    worker.onerror = err => {
+      reject({ data: {}, invalidEntries: [], error: { kind: "parseError", error: err } });
+
+      worker.terminate();
+    };
+
     Papa.parse(file, {
       header: false,
       dynamicTyping: true,
-      worker: true,
       skipEmptyLines: true,
       complete: results => {
-        resolve(processResults(results));
+        worker.postMessage({
+          data: results.data,
+        });
       },
-      error: error => resolve({ data: {}, invalidEntries: [], error: { kind: "parseError", error } }),
+      error: error => {
+        reject({ data: {}, invalidEntries: [], error: { kind: "parseError", error } });
+
+        worker.terminate();
+      },
     });
   });
 };

--- a/packages/react-app-revamp/hooks/useContest/store.tsx
+++ b/packages/react-app-revamp/hooks/useContest/store.tsx
@@ -1,4 +1,3 @@
-import MerkleTree from "merkletreejs";
 import { createContext, useContext, useRef } from "react";
 import { CustomError } from "types/error";
 import { createStore, useStore } from "zustand";
@@ -30,18 +29,15 @@ export interface ContestState {
   downvotingAllowed: boolean;
   canUpdateVotesInRealTime: boolean;
   supportsRewardsModule: boolean;
-  submissionMerkleTree: MerkleTree;
   submitters: {
     address: string;
   }[];
-  votingMerkleTree: MerkleTree;
   voters: {
     address: string;
     numVotes: number;
   }[];
   rewards: Reward | null;
   isReadOnly: boolean;
-  isMerkleTreeInProgress: boolean;
   isRewardsLoading: boolean;
   setSupportsRewardsModule: (value: boolean) => void;
   setCanUpdateVotesInRealTime: (value: boolean) => void;
@@ -56,16 +52,13 @@ export interface ContestState {
   setTotalVotesCast: (amount: number) => void;
   setTotalVotes: (amount: number) => void;
   setRewards: (rewards: Reward | null) => void;
-  setVotingMerkleTree: (merkleTree: MerkleTree) => void;
   setVoters: (voters: { address: string; numVotes: number }[]) => void;
-  setSubmissionMerkleTree: (merkleTree: MerkleTree) => void;
   setSubmitters: (submitters: { address: string }[]) => void;
   setIsLoading: (value: boolean) => void;
   setError: (value: CustomError | null) => void;
   setIsSuccess: (value: boolean) => void;
   setIsV3: (value: boolean) => void;
   setIsReadOnly: (value: boolean) => void;
-  setIsMerkleTreeInProgress: (value: boolean) => void;
   setIsRewardsLoading: (value: boolean) => void;
 }
 
@@ -78,9 +71,7 @@ export const createContestStore = () =>
     submissionsOpen: new Date(),
     votesOpen: new Date(),
     votesClose: new Date(),
-    submissionMerkleTree: new MerkleTree([]),
     submitters: [],
-    votingMerkleTree: new MerkleTree([]),
     voters: [],
     totalVotesCast: 0,
     rewards: null,
@@ -94,7 +85,6 @@ export const createContestStore = () =>
     isV3: false,
     isReadOnly: false,
     supportsRewardsModule: false,
-    isMerkleTreeInProgress: false,
     isRewardsLoading: false,
     setSupportsRewardsModule: value => set({ supportsRewardsModule: value }),
     setCanUpdateVotesInRealTime: value => set({ canUpdateVotesInRealTime: value }),
@@ -108,8 +98,6 @@ export const createContestStore = () =>
     setSubmissionsOpen: datetime => set({ submissionsOpen: datetime }),
     setVotesOpen: datetime => set({ votesOpen: datetime }),
     setVotesClose: datetime => set({ votesClose: datetime }),
-    setVotingMerkleTree: merkleTree => set({ votingMerkleTree: merkleTree }),
-    setSubmissionMerkleTree: merkleTree => set({ submissionMerkleTree: merkleTree }),
     setVoters: voters => set({ voters: voters }),
     setSubmitters: submitters => set({ submitters: submitters }),
     setTotalVotesCast: amount => set({ totalVotesCast: amount }),
@@ -118,7 +106,6 @@ export const createContestStore = () =>
     setIsLoading: value => set({ isLoading: value }),
     setError: value => set({ error: value }),
     setIsSuccess: value => set({ isSuccess: value }),
-    setIsMerkleTreeInProgress: value => set({ isMerkleTreeInProgress: value }),
     setIsRewardsLoading: value => set({ isRewardsLoading: value }),
   }));
 

--- a/packages/react-app-revamp/hooks/useContestsParticipantsIndexV3/index.tsx
+++ b/packages/react-app-revamp/hooks/useContestsParticipantsIndexV3/index.tsx
@@ -15,6 +15,8 @@ export function useContestParticipantsIndexV3() {
       const config = await import("@config/supabase");
       const supabase = config.supabase;
 
+      const votersMap = new Map(voters.map(voter => [voter.address, voter]));
+
       const data = participants.map(participant => {
         const isVoter = voterSet.has(participant);
         const isSubmitter = everyoneCanSubmit ? everyoneCanSubmit : submitterSet.has(participant);
@@ -22,7 +24,7 @@ export function useContestParticipantsIndexV3() {
         let num_votes = 0;
 
         if (isVoter) {
-          const voter = voters.find(v => v.address === participant);
+          const voter = votersMap.get(participant);
           if (voter) {
             num_votes = parseFloat(formatUnits(voter.numVotes, 18));
           }

--- a/packages/react-app-revamp/hooks/useProposalVotes/index.ts
+++ b/packages/react-app-revamp/hooks/useProposalVotes/index.ts
@@ -140,7 +140,6 @@ export function useProposalVotes(id: number | string) {
    * @param userAddress - wallet address
    */
   async function fetchVotesOfAddress(userAddress: string) {
-    console.count();
     try {
       const { abi } = await getContestContractVersion(address, chainId);
 

--- a/packages/react-app-revamp/workers/generateProof.ts
+++ b/packages/react-app-revamp/workers/generateProof.ts
@@ -1,0 +1,25 @@
+import { generateMerkleTree, generateProof, Recipient } from "lib/merkletree/generateMerkleTree";
+
+interface MerkleTreeProofPayload {
+  data: {
+    address: string;
+    numVotes: string;
+  }[];
+  address: string;
+  numVotes: string;
+}
+
+self.onmessage = (event: MessageEvent<MerkleTreeProofPayload>) => {
+  const { address, numVotes, data } = event.data;
+
+  const dataRecord = data.reduce((acc: Record<string, number>, vote: Recipient) => {
+    acc[vote.address] = Number(vote.numVotes);
+    return acc;
+  }, {});
+
+  const merkleTree = generateMerkleTree(18, dataRecord).merkleTree;
+
+  const proofs = generateProof(merkleTree, address, numVotes);
+
+  postMessage({ proofs });
+};

--- a/packages/react-app-revamp/workers/generateRootAndRecipients.ts
+++ b/packages/react-app-revamp/workers/generateRootAndRecipients.ts
@@ -1,0 +1,14 @@
+import { generateMerkleTree } from "lib/merkletree/generateMerkleTree";
+
+export interface MerkleTreeGenerationPayload {
+  decimals: number;
+  allowList: Record<string, number>;
+}
+
+self.onmessage = (event: MessageEvent<MerkleTreeGenerationPayload>) => {
+  const { allowList, decimals } = event.data;
+
+  const { merkleRoot, recipients } = generateMerkleTree(decimals, allowList);
+
+  postMessage({ merkleRoot, recipients });
+};

--- a/packages/react-app-revamp/workers/parseSubmissionCsv.ts
+++ b/packages/react-app-revamp/workers/parseSubmissionCsv.ts
@@ -1,0 +1,67 @@
+import { InvalidEntry, MAX_ROWS } from "@helpers/parseSubmissionsCsv";
+import { getAddress } from "viem";
+
+const processRowData = (row: any[]): { address: string; error: boolean } => {
+  const address = row[0];
+  let error = false;
+
+  try {
+    getAddress(address);
+  } catch (e) {
+    error = true;
+  }
+
+  return { address, error };
+};
+
+self.onmessage = (event: MessageEvent) => {
+  const data = event.data as Array<any>;
+  const addressData: string[] = [];
+  const invalidEntries: InvalidEntry[] = [];
+  const addresses: Set<string> = new Set();
+
+  if (data.length > MAX_ROWS) {
+    self.postMessage({
+      data: [],
+      invalidEntries,
+      error: { kind: "limitExceeded" },
+    });
+    return;
+  }
+
+  const expectedColumns = 1;
+  if (data[0].length !== expectedColumns) {
+    self.postMessage({
+      data: [],
+      invalidEntries,
+      error: { kind: "missingColumns" },
+    });
+    return;
+  }
+
+  for (const row of data) {
+    const { address, error } = processRowData(row);
+
+    if (addresses.has(address)) {
+      self.postMessage({
+        data: [],
+        invalidEntries,
+        error: { kind: "duplicates" },
+      });
+      return;
+    } else {
+      addresses.add(address);
+    }
+
+    if (error) {
+      invalidEntries.push({ address, error });
+    } else {
+      addressData.push(address);
+    }
+  }
+
+  self.postMessage({
+    data: addressData,
+    invalidEntries,
+  });
+};

--- a/packages/react-app-revamp/workers/parseVotingCsv.ts
+++ b/packages/react-app-revamp/workers/parseVotingCsv.ts
@@ -1,0 +1,69 @@
+import { InvalidEntry, MAX_ROWS, MAX_VOTES } from "@helpers/parseVotingCsv";
+import { getAddress } from "viem";
+
+interface ParseVotingCsvPayload {
+  data: any[];
+}
+
+const processRowData = (row: any[]) => {
+  let error: InvalidEntry["error"] | null = null;
+  const address = row[0];
+  let numberOfVotes =
+    typeof row[1] === "number"
+      ? parseFloat(row[1].toFixed(4))
+      : parseFloat(parseFloat(row[1].toString().replaceAll(",", "")).toFixed(4));
+  try {
+    getAddress(address);
+  } catch (e) {
+    error = "address";
+  }
+
+  if (typeof numberOfVotes !== "number" || numberOfVotes >= MAX_VOTES) {
+    error = error ? "both" : "votes";
+  }
+
+  return { address, numberOfVotes, error };
+};
+
+self.onmessage = (event: MessageEvent<ParseVotingCsvPayload>) => {
+  const { data } = event.data;
+  const votesData: Record<string, number> = {};
+  const invalidEntries: InvalidEntry[] = [];
+  const addresses: Set<string> = new Set();
+  let roundedZeroCount = 0;
+
+  if (data.length > MAX_ROWS) {
+    self.postMessage({ data: {}, invalidEntries, error: { kind: "limitExceeded" } });
+    return;
+  }
+
+  if (data[0].length !== 2) {
+    self.postMessage({ data: {}, invalidEntries, error: { kind: "missingColumns" } });
+    return;
+  }
+
+  data.forEach(row => {
+    if (addresses.has(row[0])) {
+      self.postMessage({ data: {}, invalidEntries, error: { kind: "duplicates" } });
+      return;
+    }
+
+    const { address, numberOfVotes, error } = processRowData(row);
+
+    addresses.add(address);
+    if (error) {
+      invalidEntries.push({ address, votes: numberOfVotes, error });
+    } else if (numberOfVotes !== 0) {
+      votesData[address] = numberOfVotes;
+    } else {
+      roundedZeroCount++;
+    }
+  });
+
+  if (roundedZeroCount === data.length) {
+    self.postMessage({ data: {}, invalidEntries, error: { kind: "allZero" } });
+    return;
+  }
+
+  self.postMessage({ data: votesData, invalidEntries, roundedZeroCount });
+};


### PR DESCRIPTION
Closes #455 

The following changes have been made as part of this PR, and i'll compare the before and after changes here:

**Before**
 - In the past, we generated a merkle tree as the contest loaded, specifically after the contest and after user qualifications, but loading in that way caused the browser to lag or freeze when we attempted to generate more than ~ 60k allowlists in the browser.
 - In the create flow, we have to generate a tree during a step for voting or submission ( in case allowlisted ) so in case of an error, user can't proceed to the next step, while this logic is good, we can't do it in browser in case of a bigger dataset.
 - Hook for generating a proof while it was simple, it needed a bit of refactor. 

**After**
 - We only generate the combined merkle tree and proof when a user votes or submits (in case allowlisted) for the first time, relieving the main thread from the computations that are carried out in the worker file `generateProof.ts`
 - In order to avoid freeze of the browser if a user uploads a large dataset, we are now leveraging workers at three points in the creation process. We are using them in the voting/submission csv steps as well as the submission criteria if a user chooses to allowlist voters as submitters, we are using here `generateRootAndRecipients.ts` worker
 - Hook for generating a proof is much simpler, we are now only relying on the proofs ( if empty or not ) and solve everything.
 
 
This all feels really good, only thing that can't be done at this moment, at least with web workers is the supabase part, so i'd leave that part in the separate PR and topic to discuss since we would either have to insert in chunks, or method different than `INSERT`, or build a small backend for it.

EDIT: Forgot to mention papaparse as well, i'm trying to solve that part, to remove additional lag when uploading a file, PR should be fine to review up to that changes that i'm working on, it should be more or less same logic we follow for other cases.

EDIT 2: Hell yeah, we are good to go! just managed to apply workers for parsing voting & submission csvs, everything is smooth and there isn't lag when it is being uploaded! 