### PR TITLE
bug: fix formatting issues, refactor and organize markdown code, prevent more than 3 list items in a preview box and add custom order numbers

### DIFF
--- a/packages/react-app-revamp/components/UI/Markdown/components/MarkdownImage/index.tsx
+++ b/packages/react-app-revamp/components/UI/Markdown/components/MarkdownImage/index.tsx
@@ -1,0 +1,30 @@
+/* eslint-disable @next/next/no-img-element */
+import { FC, useState } from "react";
+
+interface MarkdownImageProps {
+  imageSize: "compact" | "full";
+  src: string;
+}
+
+const MarkdownImage: FC<MarkdownImageProps> = ({ src, imageSize }) => {
+  const [error, setError] = useState(false);
+  const size = imageSize === "compact" ? "w-[170px]" : "w-[350px]";
+
+  if (!src) {
+    return <p>No image available</p>;
+  }
+
+  if (error) {
+    return (
+      <p>
+        <a href={src} target="_blank" rel="noopener noreferrer">
+          {src}
+        </a>
+      </p>
+    );
+  }
+
+  return <img src={src} className={`${size}`} alt="image" onError={() => setError(true)} />;
+};
+
+export default MarkdownImage;

--- a/packages/react-app-revamp/components/UI/Markdown/components/MarkdownList/index.tsx
+++ b/packages/react-app-revamp/components/UI/Markdown/components/MarkdownList/index.tsx
@@ -1,0 +1,14 @@
+import { FC, ReactNode } from "react";
+
+interface MarkdownListProps {
+  children: ReactNode & ReactNode[];
+  props: any;
+}
+
+const MarkdownList: FC<MarkdownListProps> = ({ children, props }) => (
+  <li {...props} className="flex items-center">
+    {children}
+  </li>
+);
+
+export default MarkdownList;

--- a/packages/react-app-revamp/components/UI/Markdown/components/MarkdownOrderedList/index.tsx
+++ b/packages/react-app-revamp/components/UI/Markdown/components/MarkdownOrderedList/index.tsx
@@ -1,0 +1,10 @@
+import { FC, ReactNode } from "react";
+
+interface MarkdownOrderedListProps {
+  children: ReactNode & ReactNode[];
+  props: any;
+}
+
+const MarkdownOrderedList: FC<MarkdownOrderedListProps> = ({ children, props }) => <ol {...props}>{children}</ol>;
+
+export default MarkdownOrderedList;

--- a/packages/react-app-revamp/components/UI/Markdown/components/MarkdownText/index.tsx
+++ b/packages/react-app-revamp/components/UI/Markdown/components/MarkdownText/index.tsx
@@ -1,0 +1,14 @@
+import { FC, ReactNode } from "react";
+
+interface MarkdownTextProps {
+  children: ReactNode & ReactNode[];
+  props: any;
+}
+
+const MarkdownText: FC<MarkdownTextProps> = ({ children, props }) => (
+  <p {...props} className="m-0 text-[16px]">
+    {children}
+  </p>
+);
+
+export default MarkdownText;

--- a/packages/react-app-revamp/components/UI/Markdown/components/MarkdownUnorderedList/index.tsx
+++ b/packages/react-app-revamp/components/UI/Markdown/components/MarkdownUnorderedList/index.tsx
@@ -1,0 +1,14 @@
+import { FC, ReactNode } from "react";
+
+interface MarkdownUnorderedListProps {
+  children: ReactNode & ReactNode[];
+  props: any;
+}
+
+const MarkdownUnorderedList: FC<MarkdownUnorderedListProps> = ({ children, props }) => (
+  <ul {...props} className="list-disc list-inside list-explainer">
+    {children}
+  </ul>
+);
+
+export default MarkdownUnorderedList;

--- a/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
@@ -3,6 +3,11 @@
 /* eslint-disable react/no-children-prop */
 import ButtonV3 from "@components/UI/ButtonV3";
 import EthereumAddress from "@components/UI/EtheuremAddress";
+import MarkdownImage from "@components/UI/Markdown/components/MarkdownImage";
+import MarkdownList from "@components/UI/Markdown/components/MarkdownList";
+import MarkdownOrderedList from "@components/UI/Markdown/components/MarkdownOrderedList";
+import MarkdownText from "@components/UI/Markdown/components/MarkdownText";
+import MarkdownUnorderedList from "@components/UI/Markdown/components/MarkdownUnorderedList";
 import { formatNumber } from "@helpers/formatNumber";
 import { isUrlTweet } from "@helpers/isUrlTweet";
 import { useCastVotesStore } from "@hooks/useCastVotes/store";
@@ -10,6 +15,7 @@ import { ContestStatus, useContestStatusStore } from "@hooks/useContestStatus/st
 import { useUserStore } from "@hooks/useUser/store";
 import { load } from "cheerio";
 import moment from "moment";
+import React, { Children } from "react";
 import { FC, useEffect, useMemo, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { TwitterTweetEmbed } from "react-twitter-embed";
@@ -137,45 +143,35 @@ const ProposalContent: FC<ProposalContentProps> = ({ id, proposal, votingOpen, p
 
   return (
     <div className="flex flex-col w-full h-96 md:h-56 animate-appear rounded-[10px] border border-neutral-11 hover:bg-neutral-1 cursor-pointer transition-colors duration-500 ease-in-out">
-      <div className="flex items-center px-8 py-2 h-3/5 md:h-3/4" onClick={() => setIsProposalModalOpen(true)}>
+      <div
+        className="flex items-center overflow-hidden  px-8 py-2 h-3/5 md:h-3/4"
+        onClick={() => setIsProposalModalOpen(true)}
+      >
         <ReactMarkdown
-          className="markdown max-w-full overflow-x-hidden"
+          className="markdown max-w-full"
           components={{
-            img: ({ node, ...props }) => {
-              const [error, setError] = useState(false);
-
-              if (error) {
-                return (
-                  <p>
-                    <a href={props.src} target="_blank" rel="noopener noreferrer">
-                      {props.src}
-                    </a>
-                  </p>
-                );
-              }
-
-              return <img {...props} className="w-[170px] h-[130px]" alt="image" onError={() => setError(true)} />;
-            },
             div: ({ node, children, ...props }) => (
               <div {...props} className="flex gap-5 items-center markdown">
                 {children}
               </div>
             ),
-            p: ({ node, children, ...props }) => (
-              <p {...props} className="text-[16px]">
-                {children}
-              </p>
-            ),
-            ul: ({ node, children, ...props }) => (
-              <ul {...props} className="list-disc list-inside  list-explainer">
-                {children}
-              </ul>
-            ),
-            li: ({ node, children, ...props }) => (
-              <li {...props} className="flex items-center">
-                {children}
-              </li>
-            ),
+            img: ({ node, ...props }) => <MarkdownImage imageSize="compact" src={props.src ?? ""} />,
+            p: ({ node, children, ...props }) => <MarkdownText children={children} props={props} />,
+            ul: ({ node, children, ...props }) => {
+              const truncatedChildren = Children.toArray(children).slice(0, 3);
+              const combinedChildren =
+                children.length > 3 ? [...truncatedChildren, <li key="ellipsis">...</li>] : truncatedChildren;
+
+              return <MarkdownUnorderedList children={combinedChildren} props={props} />;
+            },
+            li: ({ node, children, ...props }) => <MarkdownList children={children} props={props} />,
+            ol: ({ node, children, ...props }) => {
+              const truncatedChildren = Children.toArray(children).slice(0, 3);
+              const finalChildren =
+                children.length > 3 ? [...truncatedChildren, <li key="ellipsis">...</li>] : truncatedChildren;
+
+              return <MarkdownOrderedList children={finalChildren} props={props} />;
+            },
           }}
           rehypePlugins={[rehypeRaw, rehypeSanitize, remarkGfm]}
           children={truncatedContent}

--- a/packages/react-app-revamp/layouts/LayoutViewContest/Proposal/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/Proposal/index.tsx
@@ -1,6 +1,10 @@
 /* eslint-disable @next/next/no-img-element */
 /* eslint-disable react/no-children-prop */
 import Collapsible from "@components/UI/Collapsible";
+import MarkdownImage from "@components/UI/Markdown/components/MarkdownImage";
+import MarkdownList from "@components/UI/Markdown/components/MarkdownList";
+import MarkdownText from "@components/UI/Markdown/components/MarkdownText";
+import MarkdownUnorderedList from "@components/UI/Markdown/components/MarkdownUnorderedList";
 import { Proposal } from "@components/_pages/ProposalContent";
 import { ChevronUpIcon } from "@heroicons/react/outline";
 import { useContestStore } from "@hooks/useContest/store";
@@ -61,36 +65,10 @@ const LayoutContestProposal: FC<LayoutContestProposalProps> = ({ proposal, conte
         <ReactMarkdown
           className="markdown"
           components={{
-            img: ({ node, ...props }) => {
-              const [error, setError] = useState(false);
-
-              if (error) {
-                return (
-                  <p>
-                    <a href={props.src} target="_blank" rel="noopener noreferrer">
-                      {props.src}
-                    </a>
-                  </p>
-                );
-              }
-
-              return <img {...props} className="w-[350px]" alt="image" onError={() => setError(true)} />;
-            },
-            p: ({ node, children, ...props }) => (
-              <p {...props} className="m-0 text-[16px]">
-                {children}
-              </p>
-            ),
-            ul: ({ node, children, ...props }) => (
-              <ul {...props} className="list-disc list-inside  list-explainer">
-                {children}
-              </ul>
-            ),
-            li: ({ node, children, ...props }) => (
-              <li {...props} className="flex items-center">
-                {children}
-              </li>
-            ),
+            img: ({ node, ...props }) => <MarkdownImage imageSize="full" src={props.src ?? ""} />,
+            p: ({ node, children, ...props }) => <MarkdownText children={children} props={props} />,
+            ul: ({ node, children, ...props }) => <MarkdownUnorderedList children={children} props={props} />,
+            li: ({ node, children, ...props }) => <MarkdownList children={children} props={props} />,
           }}
           rehypePlugins={[rehypeRaw, rehypeSanitize]}
         >
@@ -109,36 +87,10 @@ const LayoutContestProposal: FC<LayoutContestProposalProps> = ({ proposal, conte
         <ReactMarkdown
           className="markdown"
           components={{
-            img: ({ node, ...props }) => {
-              const [error, setError] = useState(false);
-
-              if (error) {
-                return (
-                  <p>
-                    <a href={props.src} target="_blank" rel="noopener noreferrer">
-                      {props.src}
-                    </a>
-                  </p>
-                );
-              }
-
-              return <img {...props} className="w-[350px]" alt="image" onError={() => setError(true)} />;
-            },
-            p: ({ node, children, ...props }) => (
-              <p {...props} className="m-0 text-[16px]">
-                {children}
-              </p>
-            ),
-            ul: ({ node, children, ...props }) => (
-              <ul {...props} className="list-disc list-inside  list-explainer">
-                {children}
-              </ul>
-            ),
-            li: ({ node, children, ...props }) => (
-              <li {...props} className="flex items-center">
-                {children}
-              </li>
-            ),
+            img: ({ node, ...props }) => <MarkdownImage imageSize="full" src={props.src ?? ""} />,
+            p: ({ node, children, ...props }) => <MarkdownText children={children} props={props} />,
+            ul: ({ node, children, ...props }) => <MarkdownUnorderedList children={children} props={props} />,
+            li: ({ node, children, ...props }) => <MarkdownList children={children} props={props} />,
           }}
           rehypePlugins={[rehypeRaw, rehypeSanitize]}
         >
@@ -154,21 +106,7 @@ const LayoutContestProposal: FC<LayoutContestProposalProps> = ({ proposal, conte
         <ReactMarkdown
           className="markdown"
           components={{
-            img: ({ node, ...props }) => {
-              const [error, setError] = useState(false);
-
-              if (error) {
-                return (
-                  <p>
-                    <a href={props.src} target="_blank" rel="noopener noreferrer">
-                      {props.src}
-                    </a>
-                  </p>
-                );
-              }
-
-              return <img {...props} className="w-[350px]" alt="image" onError={() => setError(true)} />;
-            },
+            img: ({ node, ...props }) => <MarkdownImage imageSize="full" src={props.src ?? ""} />,
           }}
           rehypePlugins={[rehypeRaw, rehypeSanitize]}
         >
@@ -182,21 +120,9 @@ const LayoutContestProposal: FC<LayoutContestProposalProps> = ({ proposal, conte
             <ReactMarkdown
               className="markdown"
               components={{
-                p: ({ node, children, ...props }) => (
-                  <p {...props} className="m-0 text-[16px]">
-                    {children}
-                  </p>
-                ),
-                ul: ({ node, children, ...props }) => (
-                  <ul {...props} className="list-disc list-inside  list-explainer">
-                    {children}
-                  </ul>
-                ),
-                li: ({ node, children, ...props }) => (
-                  <li {...props} className="flex items-center">
-                    {children}
-                  </li>
-                ),
+                p: ({ node, children, ...props }) => <MarkdownText children={children} props={props} />,
+                ul: ({ node, children, ...props }) => <MarkdownUnorderedList children={children} props={props} />,
+                li: ({ node, children, ...props }) => <MarkdownList children={children} props={props} />,
               }}
               rehypePlugins={[rehypeRaw, rehypeSanitize]}
             >
@@ -210,21 +136,9 @@ const LayoutContestProposal: FC<LayoutContestProposalProps> = ({ proposal, conte
         <ReactMarkdown
           className="markdown"
           components={{
-            p: ({ node, children, ...props }) => (
-              <p {...props} className="m-0 text-[16px]">
-                {children}
-              </p>
-            ),
-            ul: ({ node, children, ...props }) => (
-              <ul {...props} className="list-disc list-inside  list-explainer">
-                {children}
-              </ul>
-            ),
-            li: ({ node, children, ...props }) => (
-              <li {...props} className="flex items-center">
-                {children}
-              </li>
-            ),
+            p: ({ node, children, ...props }) => <MarkdownText children={children} props={props} />,
+            ul: ({ node, children, ...props }) => <MarkdownUnorderedList children={children} props={props} />,
+            li: ({ node, children, ...props }) => <MarkdownList children={children} props={props} />,
           }}
           rehypePlugins={[rehypeRaw, rehypeSanitize]}
         >
@@ -238,36 +152,10 @@ const LayoutContestProposal: FC<LayoutContestProposalProps> = ({ proposal, conte
             <ReactMarkdown
               className="markdown"
               components={{
-                img: ({ node, ...props }) => {
-                  const [error, setError] = useState(false);
-
-                  if (error) {
-                    return (
-                      <p>
-                        <a href={props.src} target="_blank" rel="noopener noreferrer">
-                          {props.src}
-                        </a>
-                      </p>
-                    );
-                  }
-
-                  return <img {...props} className="w-[350px]" alt="image" onError={() => setError(true)} />;
-                },
-                p: ({ node, children, ...props }) => (
-                  <p {...props} className="m-0 text-[16px]">
-                    {children}
-                  </p>
-                ),
-                ul: ({ node, children, ...props }) => (
-                  <ul {...props} className="list-disc list-inside  list-explainer">
-                    {children}
-                  </ul>
-                ),
-                li: ({ node, children, ...props }) => (
-                  <li {...props} className="flex items-center">
-                    {children}
-                  </li>
-                ),
+                img: ({ node, ...props }) => <MarkdownImage imageSize="full" src={props.src ?? ""} />,
+                p: ({ node, children, ...props }) => <MarkdownText children={children} props={props} />,
+                ul: ({ node, children, ...props }) => <MarkdownUnorderedList children={children} props={props} />,
+                li: ({ node, children, ...props }) => <MarkdownList children={children} props={props} />,
               }}
               rehypePlugins={[rehypeRaw, rehypeSanitize]}
             >

--- a/packages/react-app-revamp/styles/globals.css
+++ b/packages/react-app-revamp/styles/globals.css
@@ -66,6 +66,23 @@
   margin-top: 5px;
 }
 
+/* Custom ordered list */
+.markdown ol {
+  list-style: none;
+  counter-reset: orderedListCounter;
+}
+
+.markdown ol li {
+  counter-increment: orderedListCounter;
+}
+
+.markdown ol li::before {
+  content: counter(orderedListCounter) ". ";
+  font-family: "Sabo", sans-serif;
+  font-weight: bold;
+  font-size: 16px;
+}
+
 li.funds-distributed::before {
   background: url("/rewards/distributed-ellipse.svg");
   background-size: contain;


### PR DESCRIPTION
Closes #478 

This PR includes following:

- We are now preventing overflow on any kind of content, previously it was applied to children instead of parent.
- Code for markdown is a bit better organized and structured.
- In a preview box, we are also displaying up to 3 list items, since we can't prevent it otherwise just based on text characters length.
- Added custom numbers for ordered list.