### PR TITLE
chore: rm unneeded awaits to try and speed up rewards

### DIFF
--- a/packages/react-app-revamp/hooks/useContest/index.ts
+++ b/packages/react-app-revamp/hooks/useContest/index.ts
@@ -180,9 +180,9 @@ export function useContest() {
       setIsListProposalsLoading(false);
 
       await Promise.all([
-        await fetchTotalVotesCast(),
-        await processRewardData(contestRewardModuleAddress),
-        await processContestData(submissionMerkleRoot, contestMaxNumberSubmissionsPerUser),
+        fetchTotalVotesCast(),
+        processRewardData(contestRewardModuleAddress),
+        processContestData(submissionMerkleRoot, contestMaxNumberSubmissionsPerUser),
       ]);
     } catch (error) {
       const customError = error as CustomError;


### PR DESCRIPTION
Was trying to figure out why rewards takes so long and this was at least something I found, need to dig more though.