### PR TITLE
bug: reload user qualifications when acccount is changed

### DIFF
--- a/packages/react-app-revamp/hooks/useAccountChange/index.tsx
+++ b/packages/react-app-revamp/hooks/useAccountChange/index.tsx
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+import { ConnectorData, useAccount } from "wagmi";
+
+export const useAccountChange = () => {
+  const { connector: activeConnector } = useAccount();
+  const [account, setAccount] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handleConnectorUpdate = ({ account: updatedAccount }: ConnectorData) => {
+      if (updatedAccount) {
+        setAccount(updatedAccount);
+      }
+    };
+
+    if (activeConnector) {
+      activeConnector.on("change", handleConnectorUpdate);
+    }
+
+    return () => activeConnector?.off("change", handleConnectorUpdate) as any;
+  }, [activeConnector]);
+
+  return account;
+};

--- a/packages/react-app-revamp/hooks/useContest/index.ts
+++ b/packages/react-app-revamp/hooks/useContest/index.ts
@@ -14,7 +14,6 @@ import { FetchBalanceResult, readContract, readContracts } from "@wagmi/core";
 import { differenceInMilliseconds, differenceInMinutes, isBefore, minutesToMilliseconds } from "date-fns";
 import { BigNumber, utils } from "ethers";
 import { fetchFirstToken, fetchNativeBalance, fetchTokenBalances } from "lib/contests";
-import { generateMerkleTree, Recipient } from "lib/merkletree/generateMerkleTree";
 import { useRouter } from "next/router";
 import { useState } from "react";
 import { CustomError } from "types/error";
@@ -67,6 +66,7 @@ export function useContest() {
     setVotesClose,
     setVotesOpen,
     setRewards,
+    setSubmissionMerkleRoot,
     setSubmissionsOpen,
     setCanUpdateVotesInRealTime,
     setIsReadOnly,
@@ -144,7 +144,7 @@ export function useContest() {
       const submissionMerkleRoot = results[10].result as string;
       setContestName(results[0].result as string);
       setContestAuthor(results[1].result as string, results[1].result as string);
-
+      setSubmissionMerkleRoot(submissionMerkleRoot);
       setContestMaxNumberSubmissionsPerUser(contestMaxNumberSubmissionsPerUser);
       setContestMaxProposalCount(contestMaxProposalCount);
       setSubmissionsOpen(submissionsOpenDate);

--- a/packages/react-app-revamp/hooks/useContest/store.tsx
+++ b/packages/react-app-revamp/hooks/useContest/store.tsx
@@ -29,6 +29,7 @@ export interface ContestState {
   downvotingAllowed: boolean;
   canUpdateVotesInRealTime: boolean;
   supportsRewardsModule: boolean;
+  submissionMerkleRoot: string;
   submitters: {
     address: string;
   }[];
@@ -54,6 +55,7 @@ export interface ContestState {
   setRewards: (rewards: Reward | null) => void;
   setVoters: (voters: { address: string; numVotes: number }[]) => void;
   setSubmitters: (submitters: { address: string }[]) => void;
+  setSubmissionMerkleRoot: (root: string) => void;
   setIsLoading: (value: boolean) => void;
   setError: (value: CustomError | null) => void;
   setIsSuccess: (value: boolean) => void;
@@ -71,6 +73,7 @@ export const createContestStore = () =>
     submissionsOpen: new Date(),
     votesOpen: new Date(),
     votesClose: new Date(),
+    submissionMerkleRoot: "",
     submitters: [],
     voters: [],
     totalVotesCast: 0,
@@ -100,6 +103,7 @@ export const createContestStore = () =>
     setVotesClose: datetime => set({ votesClose: datetime }),
     setVoters: voters => set({ voters: voters }),
     setSubmitters: submitters => set({ submitters: submitters }),
+    setSubmissionMerkleRoot: root => set({ submissionMerkleRoot: root }),
     setTotalVotesCast: amount => set({ totalVotesCast: amount }),
     setTotalVotes: amount => set({ totalVotes: amount }),
     setRewards: rewards => set({ rewards: rewards }),


### PR DESCRIPTION
Closes #503 

This PR includes following:

- We built a custom hook called `useAccountChange` that watches for account changes and put it in the hooks section so it may be reused if needed in the future.

- When a user switches accounts, we are now displaying the right qualifications because we are listening for these changes in the contest layout. 