### PR TITLE
bug: add prose-invert class to all prose classes

### DIFF
--- a/packages/react-app-revamp/layouts/LayoutViewContest/Prompt/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/Prompt/index.tsx
@@ -67,7 +67,7 @@ const LayoutContestPrompt: FC<LayoutContestPromptProps> = ({ prompt, hidePrompt 
           <div className="pl-5">
             <Collapsible isOpen={isPromptOpen}>
               <div className="border-l border-true-white ">
-                <div className="prose pl-5 ">
+                <div className="prose prose-invert pl-5 ">
                   <ReactMarkdown
                     rehypePlugins={[rehypeRaw, rehypeSanitize, remarkGfm]}
                     components={{

--- a/packages/react-app-revamp/layouts/LayoutViewContest/Proposal/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/Proposal/index.tsx
@@ -64,7 +64,7 @@ const LayoutContestProposal: FC<LayoutContestProposalProps> = ({ proposal, conte
   if (!collapsible) {
     return (
       <div className="flex flex-col gap-4">
-        <Interweave className="prose" content={proposal.content} matchers={[new UrlMatcher("url")]} />
+        <Interweave className="prose prose-invert" content={proposal.content} matchers={[new UrlMatcher("url")]} />
         {contestStatus === ContestStatus.SubmissionOpen && (
           <p className="text-[16px] text-primary-10">voting opens {formattedVotesOpen}</p>
         )}
@@ -75,31 +75,33 @@ const LayoutContestProposal: FC<LayoutContestProposalProps> = ({ proposal, conte
   const CollapsibleContent = (
     <div>
       <Collapsible isOpen={isProposalOpen}>
-        <Interweave className="prose" content={proposal.content} matchers={[new UrlMatcher("url")]} />
+        <Interweave className="prose prose-invert" content={proposal.content} matchers={[new UrlMatcher("url")]} />
       </Collapsible>
     </div>
   );
 
   return (
     <div className="flex flex-col gap-4">
-      {isOnlyImage && <Interweave className="prose" content={totalContent} matchers={[new UrlMatcher("url")]} />}
+      {isOnlyImage && (
+        <Interweave className="prose prose-invert" content={totalContent} matchers={[new UrlMatcher("url")]} />
+      )}
 
       {isOnlyText && totalContent.length >= 90 ? (
         <>
           <div className="flex gap-4 items-center">
-            <Interweave className="prose" content={totalContent} matchers={[new UrlMatcher("url")]} />
+            <Interweave className="prose prose-invert" content={totalContent} matchers={[new UrlMatcher("url")]} />
             {arrowButton}
           </div>
           {CollapsibleContent}
         </>
       ) : (
-        <Interweave className="prose" content={totalContent} matchers={[new UrlMatcher("url")]} />
+        <Interweave className="prose prose-invert" content={totalContent} matchers={[new UrlMatcher("url")]} />
       )}
 
       {isImageAndText && (
         <>
-          <div className="flex gap-4 prose items-center">
-            <Interweave className="prose" content={truncatedContent} matchers={[new UrlMatcher("url")]} />
+          <div className="flex gap-4 prose prose-invert items-center">
+            <Interweave className="prose prose-invert" content={truncatedContent} matchers={[new UrlMatcher("url")]} />
             {arrowButton}
           </div>
           {CollapsibleContent}


### PR DESCRIPTION
We just need to apply `prose-invert` class along with `prose` class so colors aren't inherited with prose.

Example is last proposal from this contest https://jokerace.xyz/contest/lootchain/0x1041cF51444cDaC8918514c5E1C97343200580a0

You can see that the titles are in dark-blue, this PR includes a fix for the above!