### PR TITLE
bug: remove roots from contest store

### DIFF
--- a/packages/react-app-revamp/hooks/useContest/index.ts
+++ b/packages/react-app-revamp/hooks/useContest/index.ts
@@ -141,7 +141,8 @@ export function useContest() {
       const isDownvotingAllowed = Number(results[9].result) === 1;
       const contestMaxNumberSubmissionsPerUser = Number(results[2].result);
       const contestMaxProposalCount = Number(results[3].result);
-
+      const submissionMerkleRoot = results[10].result as string;
+      const votingMerkleRoot = results[11].result as string;
       setContestName(results[0].result as string);
       setContestAuthor(results[1].result as string, results[1].result as string);
       setContestMaxNumberSubmissionsPerUser(contestMaxNumberSubmissionsPerUser);
@@ -150,7 +151,7 @@ export function useContest() {
       setVotesClose(closingVoteDate);
       setVotesOpen(votesOpenDate);
       setContestPrompt(results[8].result as string);
-
+      setSubmissionMerkleRoot(submissionMerkleRoot);
       setDownvotingAllowed(isDownvotingAllowed);
 
       // We want to track VoteCast event only 2H before the end of the contest, and only if alchemy support is enabled and if alchemy is configured
@@ -181,7 +182,7 @@ export function useContest() {
       await Promise.all([
         fetchTotalVotesCast(),
         processRewardData(contestRewardModuleAddress),
-        processContestData(contractConfig, contestMaxNumberSubmissionsPerUser),
+        processContestData(submissionMerkleRoot, votingMerkleRoot, contestMaxNumberSubmissionsPerUser),
       ]);
     } catch (error) {
       const customError = error as CustomError;
@@ -300,35 +301,16 @@ export function useContest() {
   /**
    * Fetch merkle tree data from DB and re-create the tree
    */
-  async function processContestData(contractConfig: ContractConfig, contestMaxNumberSubmissionsPerUser: number) {
+  async function processContestData(
+    submissionMerkleRoot: string,
+    votingMerkleRoot: string,
+    contestMaxNumberSubmissionsPerUser: number,
+  ) {
     // Do not fetch merkle tree data if the contest is not using it
     if (contestStatus === ContestStatus.VotingClosed) {
       setIsUserStoreLoading(false);
       return;
     }
-
-    const results = await readContracts({
-      contracts: [
-        {
-          ...contractConfig,
-          functionName: "submissionMerkleRoot",
-          args: [],
-        },
-        {
-          ...contractConfig,
-          functionName: "votingMerkleRoot",
-          args: [],
-        },
-      ],
-    });
-
-    if (!results) {
-      setIsUserStoreLoading(false);
-      return;
-    }
-
-    const submissionMerkleRoot = results[0].result as unknown as string;
-    const votingMerkleRoot = results[1].result as unknown as string;
 
     if (!isSupabaseConfigured) {
       setIsReadOnly(true);

--- a/packages/react-app-revamp/hooks/useContest/store.tsx
+++ b/packages/react-app-revamp/hooks/useContest/store.tsx
@@ -30,7 +30,6 @@ export interface ContestState {
   downvotingAllowed: boolean;
   canUpdateVotesInRealTime: boolean;
   supportsRewardsModule: boolean;
-  submissionMerkleRoot: string;
   submitters: {
     address: string;
   }[];
@@ -53,7 +52,6 @@ export interface ContestState {
   setRewards: (rewards: Reward | null) => void;
   setVoters: (voters: Recipient[]) => void;
   setSubmitters: (submitters: { address: string }[]) => void;
-  setSubmissionMerkleRoot: (root: string) => void;
   setIsLoading: (value: boolean) => void;
   setError: (value: CustomError | null) => void;
   setIsSuccess: (value: boolean) => void;
@@ -71,7 +69,6 @@ export const createContestStore = () =>
     submissionsOpen: new Date(),
     votesOpen: new Date(),
     votesClose: new Date(),
-    submissionMerkleRoot: "",
     submitters: [],
     voters: [],
     totalVotesCast: 0,
@@ -101,7 +98,6 @@ export const createContestStore = () =>
     setVotesClose: datetime => set({ votesClose: datetime }),
     setVoters: voters => set({ voters: voters }),
     setSubmitters: submitters => set({ submitters: submitters }),
-    setSubmissionMerkleRoot: root => set({ submissionMerkleRoot: root }),
     setTotalVotesCast: amount => set({ totalVotesCast: amount }),
     setTotalVotes: amount => set({ totalVotes: amount }),
     setRewards: rewards => set({ rewards: rewards }),

--- a/packages/react-app-revamp/hooks/useContest/v3/contracts.ts
+++ b/packages/react-app-revamp/hooks/useContest/v3/contracts.ts
@@ -10,6 +10,8 @@ export function getV3Contracts(contractConfig: any) {
     "state",
     "prompt",
     "downvotingAllowed",
+    "submissionMerkleRoot",
+    "votingMerkleRoot",
   ];
 
   const contracts = contractFunctionNames.map(functionName => ({


### PR DESCRIPTION
This PR solves a bug that was introduced by yesterday PR for the R2 stuff.

It is no biggie in terms of codebase change, the only thing i've noticed is when you aren't connected and try to connect, wrong qualifications are displayed, and this was because i've refactored yesterday hook ( which is good refactor ) but forgot to set roots in the store.

Now because i really don't want to relay on store for these kind of info which are easily fetchable from the chain ( roots ) and it is better if we always fetch for these when we need them rather than passing around in the zustand.