### PR TITLE
chore: remove merkle root calls from contracts v3

### DIFF
--- a/packages/react-app-revamp/hooks/useContest/v3/contracts.ts
+++ b/packages/react-app-revamp/hooks/useContest/v3/contracts.ts
@@ -10,8 +10,6 @@ export function getV3Contracts(contractConfig: any) {
     "state",
     "prompt",
     "downvotingAllowed",
-    "submissionMerkleRoot",
-    "votingMerkleRoot",
   ];
 
   const contracts = contractFunctionNames.map(functionName => ({


### PR DESCRIPTION
Currently we are still fetching for `submissionMerkleRoot` and `votingMerkleRoot` in the `readContracts` call when we are loading the contest.

It isn't needed anymore as it is handled afterwards.