### PR TITLE
feat: add functionality for image upload and append modularity for future implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ You can also find v1 at [jokedao.jokedao.io](https://jokedao.jokedao.io)!
 - Install dependencies with `yarn install`
 - Create a `.env` file in `packages/react-app-revamp` (the frontend package) and paste the following values:
 
+Required
 ```
-NEXT_PUBLIC_ALCHEMY_KEY=
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=
@@ -22,6 +22,12 @@ NEXT_PUBLIC_R2_ACCOUNT_ID=
 NEXT_PUBLIC_R2_ACCESS_KEY_ID=
 NEXT_PUBLIC_R2_SECRET_ACCESS_KEY=
 NEXT_PUBLIC_MERKLE_TREES_BUCKET=
+```
+
+Optional
+```
+NEXT_PUBLIC_ALCHEMY_KEY=
+NEXT_PUBLIC_IMGUR_CLIENT_ID=
 ```
 ## Getting Started
 

--- a/packages/react-app-revamp/README.md
+++ b/packages/react-app-revamp/README.md
@@ -13,8 +13,8 @@ You can also find v1 at [jokedao.jokedao.io](https://jokedao.jokedao.io)!
 - Install dependencies with `yarn install`
 - Create a `.env` file in `packages/react-app-revamp` (the frontend package) and paste the following values:
 
+Required
 ```
-NEXT_PUBLIC_ALCHEMY_KEY=
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=
@@ -22,6 +22,12 @@ NEXT_PUBLIC_R2_ACCOUNT_ID=
 NEXT_PUBLIC_R2_ACCESS_KEY_ID=
 NEXT_PUBLIC_R2_SECRET_ACCESS_KEY=
 NEXT_PUBLIC_MERKLE_TREES_BUCKET=
+```
+
+Optional
+```
+NEXT_PUBLIC_ALCHEMY_KEY=
+NEXT_PUBLIC_IMGUR_CLIENT_ID=
 ```
 ## Getting Started
 

--- a/packages/react-app-revamp/hooks/useUploadImage/index.tsx
+++ b/packages/react-app-revamp/hooks/useUploadImage/index.tsx
@@ -1,0 +1,57 @@
+import { uploadToImgur } from "lib/image/imgur";
+import { create } from "zustand";
+
+type UploadService = "imgur" | "arweave" | "ipfs";
+
+type UploadImageStore = {
+  uploadService: UploadService;
+  setUploadService: (service: UploadService) => void;
+  uploadImage: (file: File) => Promise<string | null>;
+};
+
+export const useUploadImageStore = create<UploadImageStore>((set, get) => ({
+  uploadService: "imgur",
+
+  setUploadService: service => set({ uploadService: service }),
+
+  uploadImage: async (file: File) => {
+    const currentService = get().uploadService;
+    const base64Image = await fileToBase64(file);
+    const base64Data = base64Image.split(",")[1];
+
+    switch (currentService) {
+      case "imgur":
+        return uploadToImgur(base64Data);
+      case "arweave":
+        // logic for arweave ( when implemented )
+        return null;
+      case "ipfs":
+        // logic for IPFS ( when implemented )
+        return null;
+      default:
+        throw new Error(`Unsupported service: ${currentService}`);
+    }
+  },
+}));
+
+/**
+ * Convert a file object to its base64 string representation.
+ * @param file - The file object to convert.
+ * @returns A promise resolving to the file's base64 string representation.
+ */
+function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = function (e: ProgressEvent<FileReader>) {
+      if (e.target?.result) {
+        resolve(e.target.result as string);
+      } else {
+        reject(new Error("Failed to convert file to base64."));
+      }
+    };
+    reader.onerror = function (error) {
+      reject(error);
+    };
+    reader.readAsDataURL(file);
+  });
+}

--- a/packages/react-app-revamp/lib/image/imgur/index.tsx
+++ b/packages/react-app-revamp/lib/image/imgur/index.tsx
@@ -1,0 +1,37 @@
+import { toastDismiss, toastError, toastLoading, toastSuccess } from "@components/UI/Toast";
+
+const IMGUR_API_ENDPOINT = "https://api.imgur.com/3/image";
+const IMGUR_CLIENT_ID = process.env.NEXT_PUBLIC_IMGUR_CLIENT_ID;
+
+if (!IMGUR_CLIENT_ID) {
+  console.error("Please set the NEXT_PUBLIC_IMGUR_CLIENT_ID environment variable.");
+}
+
+export async function uploadToImgur(base64Image: string): Promise<string> {
+  try {
+    toastLoading("Uploading image...", false);
+
+    const response = await fetch(IMGUR_API_ENDPOINT, {
+      method: "POST",
+      headers: {
+        Authorization: `Client-ID ${IMGUR_CLIENT_ID}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ image: base64Image }),
+    });
+
+    if (!response.ok) {
+      toastError("Failed to upload an image, please try again.");
+      throw new Error(`Imgur API responded with ${response.status}: ${response.statusText}`);
+    }
+
+    const jsonResponse = await response.json();
+    toastSuccess("Image uploaded successfully!");
+
+    return jsonResponse.data.link;
+  } catch (error) {
+    toastDismiss();
+    toastError("Failed to upload an image, please try again.");
+    throw error;
+  }
+}


### PR DESCRIPTION
Closes #567 

In this PR we are implementing following:

- We added a `useUploadImage` store that will handle upload of all images based on services we are providing
- For now we are hardcoding `imgur` as a service since we do not support other implementations
- All business logic is extracted in the store itself, we only need to provide file args in the UI components
- We have file upload from PC and as well drag & drop upload from PC
- We are currently limited to **12,500 requests per day** for free tier, however, if in future we start to generate revenue, we would need to signup for commercial usage
- Added `NEXT_PUBLIC_IMGUR_CLIENT_ID` as an env variable only locally for now, we do not need secret id as we are posting anonymously these images, however created one from jklabs email, should we set up PROD and DEV projects as we are doing with the others? but it looks like i can't create more than one app from single account

Everything works smoothly, i've tested everything and if you try to test it locally you won't be able to, since imgur doesn't allow POST from `localhost`

Workaround i found is by changing `hosts` on my windows to something like `http://imgurtesting:3000/` 