### PR TITLE
feat: add functionality for jokerace vip programme

### DIFF
--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestSubmission/components/SubmissionAllowlist/components/CSVEditor/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestSubmission/components/SubmissionAllowlist/components/CSVEditor/index.tsx
@@ -9,6 +9,7 @@ import { parseSubmissionCsv } from "@helpers/parseSubmissionsCsv";
 import { useDeployContestStore } from "@hooks/useDeployContest/store";
 import Image from "next/image";
 import React, { FC, useEffect, useState } from "react";
+import { useAccount } from "wagmi";
 import ScrollableTableBody from "./TableBody";
 
 export type SubmissionFieldObject = {
@@ -21,6 +22,7 @@ type CSVEditorProps = {
 };
 
 const CSVEditorSubmission: FC<CSVEditorProps> = ({ onChange }) => {
+  const { address } = useAccount();
   const {
     submissionAllowlistFields: fields,
     setSubmissionAllowlistFields: setFields,
@@ -96,7 +98,7 @@ const CSVEditorSubmission: FC<CSVEditorProps> = ({ onChange }) => {
   };
 
   const onFileSelectHandler = async (file: File) => {
-    const results = await parseSubmissionCsv(file);
+    const results = await parseSubmissionCsv(file, address);
 
     switch (results.error?.kind) {
       case "missingColumns":

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingAllowlist/components/CSVEditor/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingAllowlist/components/CSVEditor/index.tsx
@@ -7,6 +7,7 @@ import { useDeployContestStore } from "@hooks/useDeployContest/store";
 import { cloneDeep } from "lodash";
 import Image from "next/image";
 import React, { FC, useEffect, useState } from "react";
+import { useAccount } from "wagmi";
 import CSVParseError, { ParseError } from "./CSVParseError";
 import ScrollableTableBody from "./TableBody";
 
@@ -21,6 +22,7 @@ type CSVEditorProps = {
 };
 
 const CSVEditorVoting: FC<CSVEditorProps> = ({ onChange }) => {
+  const { address } = useAccount();
   const {
     votingAllowlistFields: fields,
     setVotingAllowlistFields: setFields,
@@ -121,7 +123,7 @@ const CSVEditorVoting: FC<CSVEditorProps> = ({ onChange }) => {
   };
 
   const onFileSelectHandler = async (file: File) => {
-    const results = await parseCsvVoting(file);
+    const results = await parseCsvVoting(file, address);
 
     switch (results.error?.kind) {
       case "missingColumns":

--- a/packages/react-app-revamp/helpers/parseSubmissionsCsv.ts
+++ b/packages/react-app-revamp/helpers/parseSubmissionsCsv.ts
@@ -19,7 +19,7 @@ export type ParseCsvResult = {
 
 export const MAX_ROWS = 100000; // 100k for now
 
-export const parseSubmissionCsv = (file: File): Promise<ParseCsvResult> => {
+export const parseSubmissionCsv = (file: File, userAddress: string | undefined): Promise<ParseCsvResult> => {
   return new Promise((resolve, reject) => {
     const worker = new Worker(new URL("/workers/parseSubmissionCsv", import.meta.url));
 
@@ -41,7 +41,10 @@ export const parseSubmissionCsv = (file: File): Promise<ParseCsvResult> => {
       dynamicTyping: true,
       skipEmptyLines: true,
       complete: results => {
-        worker.postMessage(results.data);
+        worker.postMessage({
+          data: results.data,
+          userAddress: userAddress,
+        });
       },
       error: error => {
         reject({ data: [], invalidEntries: [], error: { kind: "parseError", error } });

--- a/packages/react-app-revamp/helpers/parseVotingCsv.ts
+++ b/packages/react-app-revamp/helpers/parseVotingCsv.ts
@@ -23,7 +23,7 @@ export type ParseCsvResult = {
 export const MAX_ROWS = 100000; // 100k for now
 export const MAX_VOTES = 1e9; // 1 billion
 
-export const parseCsvVoting = (file: File): Promise<ParseCsvResult> => {
+export const parseCsvVoting = (file: File, userAddress: string | undefined): Promise<ParseCsvResult> => {
   return new Promise((resolve, reject) => {
     const worker = new Worker(new URL("/workers/parseVotingCsv", import.meta.url));
 
@@ -61,6 +61,7 @@ export const parseCsvVoting = (file: File): Promise<ParseCsvResult> => {
       complete: results => {
         worker.postMessage({
           data: results.data,
+          userAddress: userAddress,
         });
       },
       error: error => {

--- a/packages/react-app-revamp/lib/vip/index.ts
+++ b/packages/react-app-revamp/lib/vip/index.ts
@@ -1,0 +1,17 @@
+import { isSupabaseConfigured } from "@helpers/database";
+
+export const canUploadLargeAllowlist = async (userAddress: string, requiredSize: number) => {
+  if (isSupabaseConfigured) {
+    const config = await import("@config/supabase");
+    const supabase = config.supabase;
+    const { data, error } = await supabase
+      .from("user_permissions")
+      .select("allowlist_max_size, user_address")
+      .eq("user_address", userAddress);
+
+    if (error || !data[0]) return false;
+
+    return data[0].allowlist_max_size >= requiredSize;
+  }
+  return false;
+};

--- a/packages/react-app-revamp/lib/vip/index.ts
+++ b/packages/react-app-revamp/lib/vip/index.ts
@@ -6,7 +6,7 @@ export const canUploadLargeAllowlist = async (userAddress: string, requiredSize:
     const supabase = config.supabase;
     const { data, error } = await supabase
       .from("user_permissions")
-      .select("allowlist_max_size, user_address")
+      .select("allowlist_max_size")
       .eq("user_address", userAddress);
 
     if (error || !data[0]) return false;

--- a/packages/react-app-revamp/supabase_schemas/user_permissions.sql
+++ b/packages/react-app-revamp/supabase_schemas/user_permissions.sql
@@ -1,0 +1,7 @@
+create table
+  public.user_permissions (
+    id uuid not null default gen_random_uuid (),
+    allowlist_max_size integer not null,
+    user_address character varying not null,
+    constraint user_permissions_pkey primary key (id)
+  ) tablespace pg_default;


### PR DESCRIPTION
Closes #542 

In this PR we are adjusting codebase for jokerace vip programme and we did following:

- We added a file only for current and future calls upon `user_permissions` aka vip table
- We are now only checking for the allowlist size during either parsing a voting csv, submission csv or when user is trying to deploy a contest.