### PR TITLE
feat: add participants and rewards internal analytics components

### DIFF
--- a/packages/react-app-revamp/components/_pages/Rewards/components/Fund/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Rewards/components/Fund/index.tsx
@@ -52,6 +52,7 @@ const CreateRewardsFunding: FC<CreateRewardsFundingProps> = ({ isFundingForTheFi
         isErc20: reward.address.startsWith("0x"),
         rewardsContractAddress: rewardsContractAddress,
         amount: ethers.utils.parseUnits(reward.amount, decimals).toString(),
+        decimals: decimals,
       };
     });
 

--- a/packages/react-app-revamp/hooks/useCastVotes/index.ts
+++ b/packages/react-app-revamp/hooks/useCastVotes/index.ts
@@ -1,6 +1,5 @@
 import { toastDismiss, toastError, toastLoading, toastSuccess } from "@components/UI/Toast";
 import DeployedContestContract from "@contracts/bytecodeAndAbi/Contest.sol/Contest.json";
-import { TransactionResponse } from "@ethersproject/abstract-provider";
 import getContestContractVersion from "@helpers/getContestContractVersion";
 import { useContest } from "@hooks/useContest";
 import { useContestStore } from "@hooks/useContest/store";
@@ -11,6 +10,7 @@ import { useUserStore } from "@hooks/useUser/store";
 import { prepareWriteContract, readContract, waitForTransaction, writeContract } from "@wagmi/core";
 import { BigNumber, utils } from "ethers";
 import { parseUnits } from "ethers/lib/utils";
+import { incrementUserActionForAnalytics } from "lib/analytics/participants";
 import { useRouter } from "next/router";
 import { CustomError, ErrorCodes } from "types/error";
 import { useAccount, useNetwork } from "wagmi";
@@ -115,6 +115,7 @@ export function useCastVotes() {
       }
 
       await updateCurrentUserVotes();
+      incrementUserActionForAnalytics(userAddress, "voted", id, chainId);
       setIsLoading(false);
       setIsSuccess(true);
       toastSuccess("your votes have been deployed successfully");

--- a/packages/react-app-revamp/hooks/useSubmitProposal/index.ts
+++ b/packages/react-app-revamp/hooks/useSubmitProposal/index.ts
@@ -3,11 +3,11 @@ import { chains } from "@config/wagmi";
 import { TransactionResponse } from "@ethersproject/abstract-provider";
 import getContestContractVersion from "@helpers/getContestContractVersion";
 import { removeSubmissionFromLocalStorage } from "@helpers/submissionCaching";
-import { useContestStore } from "@hooks/useContest/store";
 import { useGenerateProof } from "@hooks/useGenerateProof";
 import useProposal from "@hooks/useProposal";
 import { useUserStore } from "@hooks/useUser/store";
 import { waitForTransaction, writeContract } from "@wagmi/core";
+import { incrementUserActionForAnalytics } from "lib/analytics/participants";
 import { useRouter } from "next/router";
 import { CustomError, ErrorCodes } from "types/error";
 import { useAccount, useNetwork } from "wagmi";
@@ -95,6 +95,8 @@ export function useSubmitProposal() {
           hash: receipt.transactionHash,
           transactionHref: `${chain?.blockExplorers?.default?.url}/tx/${txSendProposal?.hash}`,
         });
+
+        incrementUserActionForAnalytics(userAddress, "proposed", address, chainName);
 
         setIsLoading(false);
         setIsSuccess(true);

--- a/packages/react-app-revamp/hooks/useUser/index.ts
+++ b/packages/react-app-revamp/hooks/useUser/index.ts
@@ -7,7 +7,7 @@ import { useProposalStore } from "@hooks/useProposal/store";
 import { getAccount, readContract } from "@wagmi/core";
 import { BigNumber } from "ethers";
 import { useRouter } from "next/router";
-import { Abi, createPublicClient, http } from "viem";
+import { Abi } from "viem";
 import { useAccount, useNetwork } from "wagmi";
 import { useUserStore } from "./store";
 

--- a/packages/react-app-revamp/lib/analytics/participants/index.ts
+++ b/packages/react-app-revamp/lib/analytics/participants/index.ts
@@ -1,0 +1,93 @@
+import { isSupabaseConfigured } from "@helpers/database";
+
+interface SaveToAnalyticsContestParticipantsV3Options {
+  contest_address: string;
+  user_address: `0x${string}` | undefined;
+  network_name: string;
+  times_proposed?: number;
+  times_voted?: number;
+}
+
+interface GetAnalyticsForUserOptions {
+  user_address: `0x${string}` | undefined;
+  contest_address: string;
+  network_name: string;
+}
+
+export const incrementUserActionForAnalytics = async (
+  user_address: `0x${string}` | undefined,
+  action: "proposed" | "voted",
+  contest_address: string,
+  network_name: string,
+) => {
+  if (isSupabaseConfigured) {
+    const config = await import("@config/supabase");
+    const supabase = config.supabase;
+
+    const userData = await getAnalyticsForUser({ user_address, contest_address, network_name });
+
+    if (userData) {
+      const updatedCount =
+        action === "proposed"
+          ? { times_proposed: (userData.times_proposed || 0) + 1 }
+          : { times_voted: (userData.times_voted || 0) + 1 };
+
+      const { error } = await supabase
+        .from("analytics_contest_participants_v3")
+        .update(updatedCount)
+        .eq("user_address", user_address)
+        .eq("contest_address", contest_address)
+        .eq("network_name", network_name);
+
+      if (error) {
+        throw new Error(error.message);
+      }
+    } else {
+      await saveToAnalyticsContestParticipantsV3({
+        contest_address: contest_address,
+        user_address: user_address,
+        network_name: network_name,
+        times_proposed: action === "proposed" ? 1 : 0,
+        times_voted: action === "voted" ? 1 : 0,
+      });
+    }
+  }
+};
+
+const saveToAnalyticsContestParticipantsV3 = async (options: SaveToAnalyticsContestParticipantsV3Options) => {
+  if (isSupabaseConfigured) {
+    const config = await import("@config/supabase");
+    const supabase = config.supabase;
+
+    const { error } = await supabase.from("analytics_contest_participants_v3").insert(options);
+
+    if (error) {
+      throw new Error(error.message);
+    }
+  }
+};
+
+const getAnalyticsForUser = async (options: GetAnalyticsForUserOptions) => {
+  const { user_address, contest_address, network_name } = options;
+
+  if (isSupabaseConfigured) {
+    const config = await import("@config/supabase");
+    const supabase = config.supabase;
+
+    const { data, error } = await supabase
+      .from("analytics_contest_participants_v3")
+      .select("times_proposed, times_voted")
+      .eq("user_address", user_address)
+      .eq("contest_address", contest_address)
+      .eq("network_name", network_name);
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    if (data && data.length > 0) {
+      return data[0];
+    }
+  }
+  return null;
+};

--- a/packages/react-app-revamp/lib/analytics/rewards/index.ts
+++ b/packages/react-app-revamp/lib/analytics/rewards/index.ts
@@ -18,7 +18,7 @@ export const updateRewardAnalytics = async (options: RewardAnalyticsUpdateOption
 
     let fetchQuery = supabase
       .from("analytics_rewards_v3")
-      .select("*")
+      .select("amount_paid_in, amount_paid_out, uuid")
       .eq("rewards_module_address", rewards_module_address)
       .eq("contest_address", contest_address)
       .eq("network_name", network_name);

--- a/packages/react-app-revamp/lib/analytics/rewards/index.ts
+++ b/packages/react-app-revamp/lib/analytics/rewards/index.ts
@@ -1,0 +1,71 @@
+import { isSupabaseConfigured } from "@helpers/database";
+
+interface RewardAnalyticsUpdateOptions {
+  contest_address: string;
+  rewards_module_address: string;
+  network_name: string;
+  amount: number;
+  operation: "deposit" | "distribute";
+  token_address: string | null;
+}
+
+export const updateRewardAnalytics = async (options: RewardAnalyticsUpdateOptions) => {
+  const { contest_address, rewards_module_address, network_name, token_address, amount, operation } = options;
+
+  if (isSupabaseConfigured) {
+    const config = await import("@config/supabase");
+    const supabase = config.supabase;
+
+    let fetchQuery = supabase
+      .from("analytics_rewards_v3")
+      .select("*")
+      .eq("rewards_module_address", rewards_module_address)
+      .eq("contest_address", contest_address)
+      .eq("network_name", network_name);
+
+    if (token_address === null) {
+      fetchQuery = fetchQuery.is("token_address", null);
+    } else {
+      fetchQuery = fetchQuery.eq("token_address", token_address.toLowerCase());
+    }
+
+    const { data, error: fetchError } = await fetchQuery;
+
+    if (fetchError) {
+      throw new Error(fetchError.message);
+    }
+
+    if (data && data.length > 0) {
+      const entry = data[0];
+      const updatePayload =
+        operation === "deposit"
+          ? { amount_paid_in: entry.amount_paid_in + amount }
+          : { amount_paid_out: entry.amount_paid_out + amount };
+
+      const { error: updateError } = await supabase
+        .from("analytics_rewards_v3")
+        .update(updatePayload)
+        .eq("uuid", entry.uuid);
+
+      if (updateError) {
+        throw new Error(updateError.message);
+      }
+      return;
+    } else {
+      const insertPayload = {
+        contest_address,
+        rewards_module_address,
+        network_name,
+        token_address: token_address ? token_address.toLowerCase() : null,
+        amount_paid_in: operation === "deposit" ? amount : 0,
+        amount_paid_out: operation === "distribute" ? amount : 0,
+      };
+
+      const { error: insertError } = await supabase.from("analytics_rewards_v3").insert(insertPayload);
+
+      if (insertError) {
+        throw new Error(insertError.message);
+      }
+    }
+  }
+};

--- a/packages/react-app-revamp/supabase_schemas/analytics_contest_participants_v3 .sql
+++ b/packages/react-app-revamp/supabase_schemas/analytics_contest_participants_v3 .sql
@@ -1,0 +1,9 @@
+create table public.analytics_contest_participants_v3 (
+    uuid uuid not null default gen_random_uuid(),
+    contest_address character varying not null,
+    user_address character varying not null,
+    network_name character varying not null,
+    times_proposed integer default 0,
+    times_voted integer default 0,
+    constraint analytics_contest_participants_v3_pkey primary key (uuid)
+) tablespace pg_default;

--- a/packages/react-app-revamp/supabase_schemas/analytics_rewards_v3.sql
+++ b/packages/react-app-revamp/supabase_schemas/analytics_rewards_v3.sql
@@ -1,0 +1,10 @@
+create table public.analytics_rewards_v3 (
+    uuid uuid not null default gen_random_uuid(),
+    contest_address character varying not null,
+    rewards_module_address character varying not null,
+    network_name character varying not null,
+    token_address character varying default null,
+    amount_paid_in numeric default 0,   
+    amount_paid_out numeric default 0,  
+    constraint analytics_rewards_v3_pkey primary key (uuid)
+) tablespace pg_default;


### PR DESCRIPTION
Closes #362 

In this PR we are adding an internal analytics system so we can track how many times each user has either voted or submitter on contest and on the other side if contest has rewards, we are tracking tokens that are being deposited or distributed.

Codebase changes:

- I've added under `lib` folder a new folder called `analytics` which as 2 subfolders `rewards` and `participants`
- In each folder we are implementing a business logic for getting, updating or inserting rows into those tables
- We are tracking events on submit a proposal, vote on a proposal, deposit into the rewards pool or distribute from the rewards pool