### PR TITLE
wording: use plural for submissions if applicable

### DIFF
--- a/packages/react-app-revamp/components/Parameters/index.tsx
+++ b/packages/react-app-revamp/components/Parameters/index.tsx
@@ -101,7 +101,7 @@ const ContestParameters = () => {
             <span>
               {maxProposalsPerUserCapped
                 ? "as many submissions as desired"
-                : `a max of ${contestMaxNumberSubmissionsPerUser.toString()} submission `}
+                : `a max of ${contestMaxNumberSubmissionsPerUser.toString()} submission${contestMaxNumberSubmissionsPerUser > 1 ? "s" : ""} `}
             </span>
           </li>
           <li className="list-disc">contest accept up to {contestMaxProposalCount.toString()} submissions</li>


### PR DESCRIPTION
Smol grammatical fix. Currently at [this contest](contest/base/0x037Bfb31d1f656b42aB6aCA506dFed5272914561), the limit is 2 submissions per user but this is what it's currently saying.
<img width="357" alt="Screenshot 2023-09-12 at 10 27 05 AM" src="https://github.com/jk-labs-inc/jokerace/assets/27874039/cc7603c0-03cc-416e-97ab-c3c4be11cc99">

Should be "2 submissions" and this PR fixes that.