### PR TITLE
bug: add timeout for unresponsive RPCs

### DIFF
--- a/packages/react-app-revamp/helpers/getContestContractVersion.ts
+++ b/packages/react-app-revamp/helpers/getContestContractVersion.ts
@@ -8,6 +8,7 @@ import RewardsContract from "@contracts/bytecodeAndAbi/Contest.2.6.rewards.sol/C
 import NumberedVersioningContract from "@contracts/bytecodeAndAbi/Contest.2.8.numberedVersioning.sol/Contest.json";
 import GateSubmissionsOpenContract from "@contracts/bytecodeAndAbi/Contest.2.9.gateSubmissionsOpen.sol/Contest.json";
 import MerkleVotesContract from "@contracts/bytecodeAndAbi/Contest.3.1.merkleVotes.sol/Contest.json";
+import CantVoteOnDeletedContract from "@contracts/bytecodeAndAbi/Contest.3.10.cantVoteOnDeletedProps.sol/Contest.json";
 import TotalVotesCastContract from "@contracts/bytecodeAndAbi/Contest.3.2.totalVotesCast.sol/Contest.json";
 import SetCompilerContract from "@contracts/bytecodeAndAbi/Contest.3.3.setCompilerTo8Dot19.sol/Contest.json";
 import AddIsDeletedContract from "@contracts/bytecodeAndAbi/Contest.3.4.addIsDeleted.sol/Contest.json";
@@ -16,12 +17,10 @@ import BringBackDeletedIdsContract from "@contracts/bytecodeAndAbi/Contest.3.6.b
 import ArrayOfDeletedIdsContract from "@contracts/bytecodeAndAbi/Contest.3.7.makeArrayOfDeletedIds.sol/Contest.json";
 import DeletedIdAccessorContract from "@contracts/bytecodeAndAbi/Contest.3.8.makeDeletedIdAccessor.sol/Contest.json";
 import PrivateDeletedIdsContract from "@contracts/bytecodeAndAbi/Contest.3.9.privateDeletedIds.sol/Contest.json";
-import CantVoteOnDeletedContract from "@contracts/bytecodeAndAbi/Contest.3.10.cantVoteOnDeletedProps.sol/Contest.json";
 import DeployedContestContract from "@contracts/bytecodeAndAbi/Contest.sol/Contest.json";
 import { ethers, utils } from "ethers";
 import { getEthersProvider } from "./ethers";
-
-const MAX_TIME_TO_WAIT_FOR_RPC = 5000;
+import { executeWithTimeout, MAX_TIME_TO_WAIT_FOR_RPC } from "./timeout";
 
 export async function getContestContractVersion(address: string, chainId: number) {
   try {
@@ -84,17 +83,6 @@ export async function getContestContractVersion(address: string, chainId: number
     console.error(`Error while fetching the contract version for address ${address} on chainId ${chainId}:`, error);
     return { abi: null, version: "error" };
   }
-}
-
-async function executeWithTimeout<T>(timeoutDuration: number, targetPromise: Promise<T>): Promise<T> {
-  let timeoutPromise = new Promise<T>((_, reject) => {
-    let timerId = setTimeout(() => {
-      clearTimeout(timerId);
-      reject(new Error(`RPC timed out after ${timeoutDuration}ms.`));
-    }, timeoutDuration);
-  });
-
-  return Promise.race([targetPromise, timeoutPromise]);
 }
 
 export default getContestContractVersion;

--- a/packages/react-app-revamp/helpers/getRewardsModuleContractVersion.ts
+++ b/packages/react-app-revamp/helpers/getRewardsModuleContractVersion.ts
@@ -3,6 +3,7 @@ import NumberedVersioningRewards from "@contracts/bytecodeAndAbi/modules/Rewards
 import GateSubmissionsOpenRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.2.4.gateSubmissionsOpen.sol/RewardsModule.json";
 import BetterRewardsNotesRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.2.5.betterRewardsNotes.sol/RewardsModule.json";
 import MerkleVotesRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.3.1.merkleVotes.sol/RewardsModule.json";
+import CantVoteOnDeletedPropsRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.3.10.cantVoteOnDeletedProps.sol/RewardsModule.json";
 import TotalVotesCastRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.3.2.totalVotesCast.sol/RewardsModule.json";
 import SetCompilerRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.3.3.setCompilerTo8Dot19.sol/RewardsModule.json";
 import AddIsDeletedRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.3.4.addIsDeleted.sol/RewardsModule.json";
@@ -11,17 +12,17 @@ import BringBackDeletedIdsRewards from "@contracts/bytecodeAndAbi/modules/Reward
 import ArrayOfDeletedIdsRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.3.7.makeArrayOfDeletedIds.sol/RewardsModule.json";
 import DeletedIdAccessorRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.3.8.makeDeletedIdAccessor.sol/RewardsModule.json";
 import PrivateDeletedIdsRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.3.9.privateDeletedIds.sol/RewardsModule.json";
-import CantVoteOnDeletedPropsRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.3.10.cantVoteOnDeletedProps.sol/RewardsModule.json";
 import DeployedRewardsContract from "@contracts/bytecodeAndAbi/modules/RewardsModule.sol/RewardsModule.json";
 import { ethers } from "ethers";
 import { getEthersProvider } from "./ethers";
+import { executeWithTimeout, MAX_TIME_TO_WAIT_FOR_RPC } from "./timeout";
 
 export async function getRewardsModuleContractVersion(address: string, chainId: number) {
   const provider = getEthersProvider({ chainId });
   const contract = new ethers.Contract(address, NumberedVersioningRewards.abi, provider);
 
   try {
-    const version: string = await contract.version();
+    const version: string = await executeWithTimeout(MAX_TIME_TO_WAIT_FOR_RPC, contract.version());
 
     if (version === "1") {
       return LegacyDeployedRewardsModuleContract.abi;

--- a/packages/react-app-revamp/helpers/timeout.ts
+++ b/packages/react-app-revamp/helpers/timeout.ts
@@ -1,0 +1,12 @@
+export const MAX_TIME_TO_WAIT_FOR_RPC = 5000;
+
+export async function executeWithTimeout<T>(timeoutDuration: number, targetPromise: Promise<T>): Promise<T> {
+  let timeoutPromise = new Promise<T>((_, reject) => {
+    let timerId = setTimeout(() => {
+      clearTimeout(timerId);
+      reject(new Error(`Promise timed out after ${timeoutDuration}ms.`));
+    }, timeoutDuration);
+  });
+
+  return Promise.race([targetPromise, timeoutPromise]);
+}


### PR DESCRIPTION
Closes #677 

So it looks like this one was a more of a broader issue than related to the rewards only and i'll try to explain here.

If one of the RPCs are hanging, in our codebase, `version` wouldn't be resolved and since it doesn't return in error but rather in hang state, we couldn't resolve it with try / catch here.
Initially i wanted to call some other functions on `provider` and check if RPC is alive, but if RPC is unresponsive, it just hangs rather than error out.

Therefore we have to add a little hack here and it is up to us to set a max amount of time we want to wait for RPC to be responsive, and using `Promise.race` we are checking which will first be executed, if everything is successful it will always race over that timeout that we set, otherwise, it would hang for in our case 5 seconds to try and wait for RPC to come alive.