### PR TITLE
chain: add ending slashes to block explorers

### DIFF
--- a/packages/react-app-revamp/config/wagmi/custom-chains/arbitrumOneTestnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/arbitrumOneTestnet.ts
@@ -18,7 +18,7 @@ export const arbitrumOneTestnet: Chain = {
     },
   },
   blockExplorers: {
-    etherscan: { name: "Arbitrum Testnet Etherscan", url: "https://goerli-rollup-explorer.arbitrum.io" },
-    default: { name: "Arbitrum Testnet Etherscan", url: "https://goerli-rollup-explorer.arbitrum.io" },
+    etherscan: { name: "Arbitrum Testnet Etherscan", url: "https://goerli-rollup-explorer.arbitrum.io/" },
+    default: { name: "Arbitrum Testnet Etherscan", url: "https://goerli-rollup-explorer.arbitrum.io/" },
   },
 };

--- a/packages/react-app-revamp/config/wagmi/custom-chains/base.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/base.ts
@@ -14,7 +14,7 @@ export const base: Chain = {
     default: { http: [`https://base-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_KEY}`] },
   },
   blockExplorers: {
-    etherscan: { name: "Base Mainnet Scan", url: "https://basescan.org" },
-    default: { name: "Base Mainnet Scan", url: "https://basescan.org" },
+    etherscan: { name: "Base Mainnet Scan", url: "https://basescan.org/" },
+    default: { name: "Base Mainnet Scan", url: "https://basescan.org/" },
   },
 };

--- a/packages/react-app-revamp/config/wagmi/custom-chains/baseTestnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/baseTestnet.ts
@@ -18,7 +18,7 @@ export const baseTestnet: Chain = {
     },
   },
   blockExplorers: {
-    etherscan: { name: "Base Testnet Scan", url: "https://goerli.basescan.org" },
-    default: { name: "Base Testnet Scan", url: "https://goerli.basescan.org" },
+    etherscan: { name: "Base Testnet Scan", url: "https://goerli.basescan.org/" },
+    default: { name: "Base Testnet Scan", url: "https://goerli.basescan.org/" },
   },
 };

--- a/packages/react-app-revamp/config/wagmi/custom-chains/bnb.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/bnb.ts
@@ -18,7 +18,7 @@ export const bnb: Chain = {
     },
   },
   blockExplorers: {
-    escan: { name: "BNB Explorer", url: "https://bscscan.com" },
-    default: { name: "BNB Explorer", url: "https://bscscan.com" },
+    escan: { name: "BNB Explorer", url: "https://bscscan.com/" },
+    default: { name: "BNB Explorer", url: "https://bscscan.com/" },
   },
 };

--- a/packages/react-app-revamp/config/wagmi/custom-chains/celo.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/celo.ts
@@ -19,7 +19,7 @@ export const celo: Chain = {
     },
   },
   blockExplorers: {
-    etherscan: { name: "Celo Block Explorer", url: "https://celoscan.io" },
-    default: { name: "Celo Block Explorer", url: "https://celoscan.io" },
+    etherscan: { name: "Celo Block Explorer", url: "https://celoscan.io/" },
+    default: { name: "Celo Block Explorer", url: "https://celoscan.io/" },
   },
 };

--- a/packages/react-app-revamp/config/wagmi/custom-chains/celoTestnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/celoTestnet.ts
@@ -19,7 +19,7 @@ export const celoTestnet: Chain = {
     },
   },
   blockExplorers: {
-    etherscan: { name: "Celo Testnet Block Explorer", url: "https://explorer.celo.org/alfajores" },
-    default: { name: "Celo Testnet Block Explorer", url: "https://explorer.celo.org/alfajores" },
+    etherscan: { name: "Celo Testnet Block Explorer", url: "https://explorer.celo.org/alfajores/" },
+    default: { name: "Celo Testnet Block Explorer", url: "https://explorer.celo.org/alfajores/" },
   },
 };

--- a/packages/react-app-revamp/config/wagmi/custom-chains/eos.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/eos.ts
@@ -19,7 +19,7 @@ export const eos: Chain = {
     },
   },
   blockExplorers: {
-    escan: { name: "EOS Mainnet Block Explorer", url: "https://explorer.evm.eosnetwork.com" },
-    default: { name: "EOS Mainnet Block Explorer", url: "https://explorer.evm.eosnetwork.com" },
+    escan: { name: "EOS Mainnet Block Explorer", url: "https://explorer.evm.eosnetwork.com/" },
+    default: { name: "EOS Mainnet Block Explorer", url: "https://explorer.evm.eosnetwork.com/" },
   },
 };

--- a/packages/react-app-revamp/config/wagmi/custom-chains/eosTestnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/eosTestnet.ts
@@ -19,7 +19,7 @@ export const eosTestnet: Chain = {
     },
   },
   blockExplorers: {
-    escan: { name: "EOS Testnet Block Explorer", url: "https://explorer.testnet.evm.eosnetwork.com" },
-    default: { name: "EOS Testnet Block Explorer", url: "https://explorer.testnet.evm.eosnetwork.com" },
+    escan: { name: "EOS Testnet Block Explorer", url: "https://explorer.testnet.evm.eosnetwork.com/" },
+    default: { name: "EOS Testnet Block Explorer", url: "https://explorer.testnet.evm.eosnetwork.com/" },
   },
 };

--- a/packages/react-app-revamp/config/wagmi/custom-chains/evmos.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/evmos.ts
@@ -19,7 +19,7 @@ export const evmos: Chain = {
     },
   },
   blockExplorers: {
-    escan: { name: "escan.live", url: "https://escan.live" },
-    default: { name: "escan.live", url: "https://escan.live" },
+    escan: { name: "escan.live", url: "https://escan.live/" },
+    default: { name: "escan.live", url: "https://escan.live/" },
   },
 };

--- a/packages/react-app-revamp/config/wagmi/custom-chains/evmosTestnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/evmosTestnet.ts
@@ -19,7 +19,7 @@ export const evmosTestnet: Chain = {
     },
   },
   blockExplorers: {
-    mintscan: { name: "Mintscan", url: "https://testnet.mintscan.io/evmos-testnet" },
-    default: { name: "Mintscan", url: "https://testnet.mintscan.io/evmos-testnet" },
+    mintscan: { name: "Mintscan", url: "https://testnet.mintscan.io/evmos-testnet/" },
+    default: { name: "Mintscan", url: "https://testnet.mintscan.io/evmos-testnet/" },
   },
 };

--- a/packages/react-app-revamp/config/wagmi/custom-chains/lukso.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/lukso.ts
@@ -19,7 +19,7 @@ export const lukso: Chain = {
     },
   },
   blockExplorers: {
-    etherscan: { name: "Lukso Mainnet Block Explorer", url: "https://explorer.execution.mainnet.lukso.network" },
-    default: { name: "Lukso Mainnet Block Explorer", url: "https://explorer.execution.mainnet.lukso.network" },
+    etherscan: { name: "Lukso Mainnet Block Explorer", url: "https://explorer.execution.mainnet.lukso.network/" },
+    default: { name: "Lukso Mainnet Block Explorer", url: "https://explorer.execution.mainnet.lukso.network/" },
   },
 };

--- a/packages/react-app-revamp/config/wagmi/custom-chains/luksoTestnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/luksoTestnet.ts
@@ -19,7 +19,7 @@ export const luksoTestnet: Chain = {
     },
   },
   blockExplorers: {
-    etherscan: { name: "Lukso Testnet Block Explorer", url: "https://explorer.execution.testnet.lukso.network" },
-    default: { name: "Lukso Testnet Block Explorer", url: "https://explorer.execution.testnet.lukso.network" },
+    etherscan: { name: "Lukso Testnet Block Explorer", url: "https://explorer.execution.testnet.lukso.network/" },
+    default: { name: "Lukso Testnet Block Explorer", url: "https://explorer.execution.testnet.lukso.network/" },
   },
 };

--- a/packages/react-app-revamp/config/wagmi/custom-chains/mantle.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/mantle.ts
@@ -19,7 +19,7 @@ export const mantle: Chain = {
     },
   },
   blockExplorers: {
-    etherscan: { name: "Mantle Mainnet Scan", url: "https://explorer.mantle.xyz" },
-    default: { name: "Mantle Mainnet Scan", url: "https://explorer.mantle.xyz" },
+    etherscan: { name: "Mantle Mainnet Scan", url: "https://explorer.mantle.xyz/" },
+    default: { name: "Mantle Mainnet Scan", url: "https://explorer.mantle.xyz/" },
   },
 };

--- a/packages/react-app-revamp/config/wagmi/custom-chains/mantleTestnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/mantleTestnet.ts
@@ -19,7 +19,7 @@ export const mantleTestnet: Chain = {
     },
   },
   blockExplorers: {
-    etherscan: { name: "Mantle Testnet Scan", url: "https://explorer.testnet.mantle.xyz" },
-    default: { name: "Mantle Testnet Scan", url: "https://explorer.testnet.mantle.xyz" },
+    etherscan: { name: "Mantle Testnet Scan", url: "https://explorer.testnet.mantle.xyz/" },
+    default: { name: "Mantle Testnet Scan", url: "https://explorer.testnet.mantle.xyz/" },
   },
 };

--- a/packages/react-app-revamp/config/wagmi/custom-chains/polygonZkTestnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/polygonZkTestnet.ts
@@ -19,7 +19,7 @@ export const polygonZkTestnet: Chain = {
     },
   },
   blockExplorers: {
-    etherscan: { name: "Polygon zkEvm Testnet Scan", url: "https://explorer.public.zkevm-test.net" },
-    default: { name: "Polygon zkEvm Testnet Scan", url: "https://explorer.public.zkevm-test.net" },
+    etherscan: { name: "Polygon zkEvm Testnet Scan", url: "https://explorer.public.zkevm-test.net/" },
+    default: { name: "Polygon zkEvm Testnet Scan", url: "https://explorer.public.zkevm-test.net/" },
   },
 };

--- a/packages/react-app-revamp/config/wagmi/custom-chains/qChainTestnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/qChainTestnet.ts
@@ -19,7 +19,7 @@ export const qChainTestnet: Chain = {
     },
   },
   blockExplorers: {
-    etherscan: { name: "Q Testnet Scan", url: "https://explorer.qtestnet.org" },
-    default: { name: "Q Testnet Scan", url: "https://explorer.qtestnet.org" },
+    etherscan: { name: "Q Testnet Scan", url: "https://explorer.qtestnet.org/" },
+    default: { name: "Q Testnet Scan", url: "https://explorer.qtestnet.org/" },
   },
 };

--- a/packages/react-app-revamp/config/wagmi/custom-chains/roninTestnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/roninTestnet.ts
@@ -18,7 +18,7 @@ export const roninTestnet: Chain = {
     },
   },
   blockExplorers: {
-    etherscan: { name: "Ronin Testnet Scan", url: "https://saigon-explorer.roninchain.com" },
-    default: { name: "Ronin Testnet Scan", url: "https://saigon-explorer.roninchain.com" },
+    etherscan: { name: "Ronin Testnet Scan", url: "https://saigon-explorer.roninchain.com/" },
+    default: { name: "Ronin Testnet Scan", url: "https://saigon-explorer.roninchain.com/" },
   },
 };

--- a/packages/react-app-revamp/config/wagmi/custom-chains/scrollSepoliaTestnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/scrollSepoliaTestnet.ts
@@ -19,7 +19,7 @@ export const scrollSepoliaTestnet: Chain = {
     },
   },
   blockExplorers: {
-    etherscan: { name: "Scroll Sepolia Scan", url: "https://sepolia-blockscout.scroll.io" },
-    default: { name: "Scroll Sepolia Scan", url: "https://sepolia-blockscout.scroll.io" },
+    etherscan: { name: "Scroll Sepolia Scan", url: "https://sepolia-blockscout.scroll.io/" },
+    default: { name: "Scroll Sepolia Scan", url: "https://sepolia-blockscout.scroll.io/" },
   },
 };

--- a/packages/react-app-revamp/config/wagmi/custom-chains/sepolia.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/sepolia.ts
@@ -18,7 +18,7 @@ export const sepolia: Chain = {
     },
   },
   blockExplorers: {
-    etherscan: { name: "Sepolia Etherscan", url: "https://sepolia.etherscan" },
-    default: { name: "Sepolia Otterscan", url: "https://sepolia.otterscan" },
+    etherscan: { name: "Sepolia Etherscan", url: "https://sepolia.etherscan/" },
+    default: { name: "Sepolia Otterscan", url: "https://sepolia.otterscan/" },
   },
 };

--- a/packages/react-app-revamp/config/wagmi/custom-chains/zetaTestnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/zetaTestnet.ts
@@ -19,7 +19,7 @@ export const zetaTestnet: Chain = {
     },
   },
   blockExplorers: {
-    etherscan: { name: "Zeta Block Explorer", url: "https://explorer.zetachain.com" },
-    default: { name: "Zeta Block Explorer", url: "https://explorer.zetachain.com" },
+    etherscan: { name: "Zeta Block Explorer", url: "https://explorer.zetachain.com/" },
+    default: { name: "Zeta Block Explorer", url: "https://explorer.zetachain.com/" },
   },
 };


### PR DESCRIPTION
the link to the rewards module address for contests who have one and are on a chain that doesn't have an ending slash at the end of their block explorer url in the chain config like mantle (and this contest on mantle) was failing and going to

`https://explorer.mantle.xyzaddress/0x9D7e68621311a88f7f44d78b652D3e027fE4D718`

instead of the correct url of

`https://explorer.mantle.xyz/address/0x9D7e68621311a88f7f44d78b652D3e027fE4D718`.

this PR fixes this issue for our mantle config as well as others that were missing this slash.