### PR TITLE
chore: bring back version param, tests, and fetchSingleProposal from #663

### DIFF
--- a/packages/forge/test/Contest.t.sol
+++ b/packages/forge/test/Contest.t.sol
@@ -275,17 +275,15 @@ contract ContestTest is Test {
     function testSort0FromZeroToZero() public {
         vm.warp(1681650001);
 
-        uint256[] memory sortedProposalIds = contest.sortedProposals(true, 0, 0);
-
-        assertEq(sortedProposalIds.length, 0);
+        vm.expectRevert(bytes("GovernorSorting: cannot sort a list of zero length"));
+        contest.sortedProposals(true);
     }
 
     function testSort0FromZeroToOneHundred() public {
         vm.warp(1681650001);
 
-        uint256[] memory sortedProposalIds = contest.sortedProposals(true, 0, 0);
-
-        assertEq(sortedProposalIds.length, 0);
+        vm.expectRevert(bytes("GovernorSorting: cannot sort a list of zero length"));
+        contest.sortedProposals(true);
     }
 
     function testSort1NoVotesFromZeroToZero() public {
@@ -293,7 +291,7 @@ contract ContestTest is Test {
         vm.prank(PERMISSIONED_ADDRESS_1);
         uint256 proposalId = contest.propose(firstProposalPA1, submissionProof1);
 
-        uint256[] memory sortedProposalIds = contest.sortedProposals(true, 0, 0);
+        uint256[] memory sortedProposalIds = contest.sortedProposals(true);
 
         assertEq(sortedProposalIds[0], proposalId);
     }
@@ -303,7 +301,7 @@ contract ContestTest is Test {
         vm.prank(PERMISSIONED_ADDRESS_1);
         uint256 proposalId = contest.propose(firstProposalPA1, submissionProof1);
 
-        uint256[] memory sortedProposalIds = contest.sortedProposals(true, 0, 100);
+        uint256[] memory sortedProposalIds = contest.sortedProposals(true);
 
         assertEq(sortedProposalIds[0], proposalId);
     }
@@ -315,7 +313,7 @@ contract ContestTest is Test {
         vm.prank(PERMISSIONED_ADDRESS_1);
         uint256 proposalId2 = contest.propose(secondProposalPA1, submissionProof2);
 
-        uint256[] memory sortedProposalIds = contest.sortedProposals(true, 0, 0);
+        uint256[] memory sortedProposalIds = contest.sortedProposals(true);
 
         assertEq(sortedProposalIds[0], proposalId1);
         assertEq(sortedProposalIds[1], proposalId2);
@@ -328,7 +326,7 @@ contract ContestTest is Test {
         vm.prank(PERMISSIONED_ADDRESS_1);
         uint256 proposalId2 = contest.propose(secondProposalPA1, submissionProof2);
 
-        uint256[] memory sortedProposalIds = contest.sortedProposals(true, 0, 100);
+        uint256[] memory sortedProposalIds = contest.sortedProposals(true);
 
         assertEq(sortedProposalIds[0], proposalId1);
         assertEq(sortedProposalIds[1], proposalId2);
@@ -344,7 +342,7 @@ contract ContestTest is Test {
         contest.castVote(proposalId, 0, 10 ether, 1 ether, votingProof1);
         vm.stopPrank();
 
-        uint256[] memory sortedProposalIds = contest.sortedProposals(true, 0, 0);
+        uint256[] memory sortedProposalIds = contest.sortedProposals(true);
 
         assertEq(sortedProposalIds[0], proposalId);
     }
@@ -357,7 +355,7 @@ contract ContestTest is Test {
         contest.castVote(proposalId, 0, 10 ether, 1 ether, votingProof1);
         vm.stopPrank();
 
-        uint256[] memory sortedProposalIds = contest.sortedProposals(true, 0, 100);
+        uint256[] memory sortedProposalIds = contest.sortedProposals(true);
 
         assertEq(sortedProposalIds[0], proposalId);
     }
@@ -371,7 +369,7 @@ contract ContestTest is Test {
         contest.castVote(proposalId1, 0, 10 ether, 1 ether, votingProof1);
         vm.stopPrank();
 
-        uint256[] memory sortedProposalIds = contest.sortedProposals(true, 0, 0);
+        uint256[] memory sortedProposalIds = contest.sortedProposals(true);
 
         assertEq(sortedProposalIds[0], proposalId2);
         assertEq(sortedProposalIds[1], proposalId1);
@@ -386,7 +384,7 @@ contract ContestTest is Test {
         contest.castVote(proposalId1, 0, 10 ether, 1 ether, votingProof1);
         vm.stopPrank();
 
-        uint256[] memory sortedProposalIds = contest.sortedProposals(true, 0, 100);
+        uint256[] memory sortedProposalIds = contest.sortedProposals(true);
 
         assertEq(sortedProposalIds[0], proposalId2);
         assertEq(sortedProposalIds[1], proposalId1);

--- a/packages/forge/test/Contest.t.sol
+++ b/packages/forge/test/Contest.t.sol
@@ -267,4 +267,130 @@ contract ContestTest is Test {
     }
 
     /////////////////////////////
+
+    // SORTING
+
+    //// NO VOTES
+
+    function testSort0FromZeroToZero() public {
+        vm.warp(1681650001);
+
+        uint256[] memory sortedProposalIds = contest.sortedProposals(true, 0, 0);
+
+        assertEq(sortedProposalIds.length, 0);
+    }
+
+    function testSort0FromZeroToOneHundred() public {
+        vm.warp(1681650001);
+
+        uint256[] memory sortedProposalIds = contest.sortedProposals(true, 0, 0);
+
+        assertEq(sortedProposalIds.length, 0);
+    }
+
+    function testSort1NoVotesFromZeroToZero() public {
+        vm.warp(1681650001);
+        vm.prank(PERMISSIONED_ADDRESS_1);
+        uint256 proposalId = contest.propose(firstProposalPA1, submissionProof1);
+
+        uint256[] memory sortedProposalIds = contest.sortedProposals(true, 0, 0);
+
+        assertEq(sortedProposalIds[0], proposalId);
+    }
+
+    function testSort1NoVotesFromZeroToOneHundred() public {
+        vm.warp(1681650001);
+        vm.prank(PERMISSIONED_ADDRESS_1);
+        uint256 proposalId = contest.propose(firstProposalPA1, submissionProof1);
+
+        uint256[] memory sortedProposalIds = contest.sortedProposals(true, 0, 100);
+
+        assertEq(sortedProposalIds[0], proposalId);
+    }
+
+    function testSort2NoVotesFromZeroToZero() public {
+        vm.warp(1681650001);
+        vm.prank(PERMISSIONED_ADDRESS_1);
+        uint256 proposalId1 = contest.propose(firstProposalPA1, submissionProof1);
+        vm.prank(PERMISSIONED_ADDRESS_1);
+        uint256 proposalId2 = contest.propose(secondProposalPA1, submissionProof2);
+
+        uint256[] memory sortedProposalIds = contest.sortedProposals(true, 0, 0);
+
+        assertEq(sortedProposalIds[0], proposalId1);
+        assertEq(sortedProposalIds[1], proposalId2);
+    }
+
+    function testSort2NoVotesFromZeroToOneHundred() public {
+        vm.warp(1681650001);
+        vm.prank(PERMISSIONED_ADDRESS_1);
+        uint256 proposalId1 = contest.propose(firstProposalPA1, submissionProof1);
+        vm.prank(PERMISSIONED_ADDRESS_1);
+        uint256 proposalId2 = contest.propose(secondProposalPA1, submissionProof2);
+
+        uint256[] memory sortedProposalIds = contest.sortedProposals(true, 0, 100);
+
+        assertEq(sortedProposalIds[0], proposalId1);
+        assertEq(sortedProposalIds[1], proposalId2);
+    }
+
+    //// WITH VOTES
+
+    function testSort1WithVotesFromZeroToZero() public {
+        vm.startPrank(PERMISSIONED_ADDRESS_1);
+        vm.warp(1681650001);
+        uint256 proposalId = contest.propose(firstProposalPA1, submissionProof1);
+        vm.warp(1681660001);
+        contest.castVote(proposalId, 0, 10 ether, 1 ether, votingProof1);
+        vm.stopPrank();
+
+        uint256[] memory sortedProposalIds = contest.sortedProposals(true, 0, 0);
+
+        assertEq(sortedProposalIds[0], proposalId);
+    }
+
+    function testSort1WithVotesFromZeroToOneHundred() public {
+        vm.startPrank(PERMISSIONED_ADDRESS_1);
+        vm.warp(1681650001);
+        uint256 proposalId = contest.propose(firstProposalPA1, submissionProof1);
+        vm.warp(1681660001);
+        contest.castVote(proposalId, 0, 10 ether, 1 ether, votingProof1);
+        vm.stopPrank();
+
+        uint256[] memory sortedProposalIds = contest.sortedProposals(true, 0, 100);
+
+        assertEq(sortedProposalIds[0], proposalId);
+    }
+
+    function testSort2WithVotesFromZeroToZero() public {
+        vm.startPrank(PERMISSIONED_ADDRESS_1);
+        vm.warp(1681650001);
+        uint256 proposalId1 = contest.propose(firstProposalPA1, submissionProof1);
+        uint256 proposalId2 = contest.propose(secondProposalPA1, submissionProof2);
+        vm.warp(1681660001);
+        contest.castVote(proposalId1, 0, 10 ether, 1 ether, votingProof1);
+        vm.stopPrank();
+
+        uint256[] memory sortedProposalIds = contest.sortedProposals(true, 0, 0);
+
+        assertEq(sortedProposalIds[0], proposalId2);
+        assertEq(sortedProposalIds[1], proposalId1);
+    }
+
+    function testSort2WithVotesFromZeroToOneHundred() public {
+        vm.startPrank(PERMISSIONED_ADDRESS_1);
+        vm.warp(1681650001);
+        uint256 proposalId1 = contest.propose(firstProposalPA1, submissionProof1);
+        uint256 proposalId2 = contest.propose(secondProposalPA1, submissionProof2);
+        vm.warp(1681660001);
+        contest.castVote(proposalId1, 0, 10 ether, 1 ether, votingProof1);
+        vm.stopPrank();
+
+        uint256[] memory sortedProposalIds = contest.sortedProposals(true, 0, 100);
+
+        assertEq(sortedProposalIds[0], proposalId2);
+        assertEq(sortedProposalIds[1], proposalId1);
+    }
+
+    /////////////////////////////
 }

--- a/packages/react-app-revamp/components/_pages/ListProposals/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListProposals/index.tsx
@@ -11,6 +11,16 @@ import { useState } from "react";
 import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
 import { useAccount } from "wagmi";
 
+const ProposalSkeleton = ({ count, highlightColor }: { count?: number; highlightColor: string }) => (
+  <SkeletonTheme baseColor="#000000" highlightColor={highlightColor} duration={1}>
+    <Skeleton
+      borderRadius={10}
+      count={count}
+      className="flex flex-col w-full h-96 md:h-56 animate-appear rounded-[10px] border border-neutral-11 mt-3"
+    />
+  </SkeletonTheme>
+);
+
 export const ListProposals = () => {
   const { address } = useAccount();
   const { fetchProposalsPage } = useProposal();
@@ -60,13 +70,10 @@ export const ListProposals = () => {
 
   if (isPageProposalsLoading && !Object.keys(listProposalsData)?.length) {
     return (
-      <SkeletonTheme baseColor="#000000" highlightColor="#FFE25B" duration={1}>
-        <Skeleton
-          count={listProposalsIds.length > PROPOSALS_PER_PAGE ? PROPOSALS_PER_PAGE : listProposalsIds.length}
-          borderRadius={10}
-          className="flex flex-col h-96 md:h-56 animate-appear border border-neutral-11  mb-3"
-        />
-      </SkeletonTheme>
+      <ProposalSkeleton
+        count={listProposalsIds.length > PROPOSALS_PER_PAGE ? PROPOSALS_PER_PAGE : listProposalsIds.length}
+        highlightColor="#FFE25B"
+      />
     );
   }
 
@@ -81,14 +88,7 @@ export const ListProposals = () => {
             .sort((a, b) => listProposalsData[b].votes - listProposalsData[a].votes)
             .map(id => {
               if (deletingProposalIds.includes(id) && isDeleteInProcess) {
-                return (
-                  <SkeletonTheme baseColor="#000000" highlightColor="#FF78A9" duration={1} key={id}>
-                    <Skeleton
-                      borderRadius={10}
-                      className="flex flex-col w-full h-96 md:h-56 animate-appear rounded-[10px] border border-neutral-11 mt-3"
-                    />
-                  </SkeletonTheme>
-                );
+                return <ProposalSkeleton key={id} highlightColor="#FF78A9" />;
               }
               const votes = listProposalsData[id].votes;
 
@@ -146,13 +146,7 @@ export const ListProposals = () => {
       )}
 
       {isPageProposalsLoading && Object.keys(listProposalsData)?.length && (
-        <SkeletonTheme baseColor="#000000" highlightColor="#FFE25B" duration={1}>
-          <Skeleton
-            borderRadius={10}
-            count={skeletonRemainingLoaderCount}
-            className="flex flex-col w-full h-96 md:h-56 animate-appear rounded-[10px] border border-neutral-11 mt-3"
-          />
-        </SkeletonTheme>
+        <ProposalSkeleton count={skeletonRemainingLoaderCount} highlightColor="#FFE25B" />
       )}
 
       {Object.keys(listProposalsData)?.length < listProposalsIds.length && !isPageProposalsLoading && (

--- a/packages/react-app-revamp/hooks/useContest/index.ts
+++ b/packages/react-app-revamp/hooks/useContest/index.ts
@@ -16,7 +16,7 @@ import { loadFileFromBucket } from "lib/buckets";
 import { fetchFirstToken, fetchNativeBalance, fetchTokenBalances } from "lib/contests";
 import { Recipient } from "lib/merkletree/generateMerkleTree";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { CustomError } from "types/error";
 import { useNetwork } from "wagmi";
 import { useContestStore } from "./store";
@@ -175,13 +175,17 @@ export function useContest() {
     setIsLoading(false);
   }
 
-  async function fetchV3ContestInfo(contractConfig: ContractConfig, contestRewardModuleAddress: string | undefined) {
+  async function fetchV3ContestInfo(
+    contractConfig: ContractConfig,
+    contestRewardModuleAddress: string | undefined,
+    version: string,
+  ) {
     try {
       setIsListProposalsLoading(false);
 
       await Promise.all([
         fetchContestContractData(contractConfig),
-        fetchProposalsIdsList(contractConfig.abi),
+        fetchProposalsIdsList(contractConfig.abi, version),
         processContestData(contractConfig),
         processRewardData(contestRewardModuleAddress),
         fetchTotalVotesCast(),
@@ -199,7 +203,7 @@ export function useContest() {
     }
   }
 
-  async function fetchV1ContestInfo(contractConfig: ContractConfig) {
+  async function fetchV1ContestInfo(contractConfig: ContractConfig, version: string) {
     try {
       const contracts = getV1Contracts(contractConfig);
       const results = await readContracts({ contracts });
@@ -207,7 +211,7 @@ export function useContest() {
       setIsV3(false);
 
       // List of proposals for this contest
-      await fetchProposalsIdsList(contractConfig.abi);
+      await fetchProposalsIdsList(contractConfig.abi, version);
 
       const closingVoteDate = new Date(Number(results[6].result) * 1000 + 1000);
       const submissionsOpenDate = new Date(Number(results[5].result) * 1000 + 1000);
@@ -294,9 +298,9 @@ export function useContest() {
     }
 
     if (parseFloat(version) >= 3) {
-      await fetchV3ContestInfo(contractConfig, contestRewardModuleAddress);
+      await fetchV3ContestInfo(contractConfig, contestRewardModuleAddress, version);
     } else {
-      await fetchV1ContestInfo(contractConfig);
+      await fetchV1ContestInfo(contractConfig, version);
     }
   }
 

--- a/packages/react-app-revamp/hooks/useProposal/index.ts
+++ b/packages/react-app-revamp/hooks/useProposal/index.ts
@@ -302,9 +302,79 @@ export function useProposal() {
     }
   };
 
+  /**
+   * Fetch a single proposal based on its ID.
+   * @param proposalId - the ID of the proposal to fetch
+   */
+  async function fetchSingleProposal(proposalId: any) {
+    try {
+      const { abi } = await getContestContractVersion(address, chainId);
+
+      if (abi === null) {
+        const errorMsg = `This contract doesn't exist on ${chain?.name ?? "this chain"}.`;
+        toastError(errorMsg);
+        setIsPageProposalsError({ message: errorMsg });
+        return;
+      }
+
+      const contractConfig: any = {
+        address: address as `0x${string}`,
+        abi: abi,
+        chainId: chains.find(
+          c => c.name.replace(/\s+/g, "").toLowerCase() === chainName.replace(/\s+/g, "").toLowerCase(),
+        )?.id,
+      };
+
+      const contracts = [
+        {
+          ...contractConfig,
+          functionName: "getProposal",
+          args: [proposalId],
+        },
+        {
+          ...contractConfig,
+          functionName: "proposalVotes",
+          args: [proposalId],
+        },
+      ];
+
+      const results: any = await readContracts({ contracts });
+
+      const data = results[0].result;
+
+      const isContentImage = isUrlToImage(data.description) ? true : false;
+
+      const forVotesBigInt = results[1].result[0] as bigint;
+      const againstVotesBigInt = results[1].result[1] as bigint;
+      const votesBigNumber = BigNumber.from(forVotesBigInt).sub(againstVotesBigInt);
+      const votes = Number(utils.formatEther(votesBigNumber));
+
+      const proposalData = {
+        authorEthereumAddress: data.author,
+        content: data.description,
+        isContentImage,
+        exists: data.exists,
+        votes,
+      };
+
+      setProposalData({ id: proposalId, data: proposalData });
+    } catch (e) {
+      const customError = e as CustomError;
+
+      if (!customError) return;
+
+      toastError("Something went wrong while getting the proposal.", customError.message);
+      setIsPageProposalsError({
+        code: customError.code,
+        message: customError.message,
+      });
+    }
+  }
+
   return {
     fetchProposal,
     fetchProposalsPage,
+    fetchSingleProposal,
     fetchProposalsIdsList,
   };
 }

--- a/packages/react-app-revamp/hooks/useProposal/index.ts
+++ b/packages/react-app-revamp/hooks/useProposal/index.ts
@@ -161,7 +161,7 @@ export function useProposal() {
    * Fetch the list of proposals ids for this contest, order them by votes and set up pagination
    * @param abi - ABI to use
    */
-  async function fetchProposalsIdsList(abi: any) {
+  async function fetchProposalsIdsList(abi: any, version: string) {
     setIsListProposalsLoading(true);
 
     try {
@@ -179,7 +179,7 @@ export function useProposal() {
         )?.id,
       };
 
-      const proposalsIdsRawData = await getProposalIdsRaw(contractConfig, useLegacyGetAllProposalsIdFn);
+      const proposalsIdsRawData = await getProposalIdsRaw(contractConfig, useLegacyGetAllProposalsIdFn, version);
 
       let proposalsIds: Result;
       if (!useLegacyGetAllProposalsIdFn) {
@@ -243,7 +243,7 @@ export function useProposal() {
     }
   }
 
-  async function getProposalIdsRaw(contractConfig: any, isLegacy: boolean) {
+  async function getProposalIdsRaw(contractConfig: any, isLegacy: boolean, version: string) {
     if (isLegacy) {
       return (await readContract({
         ...contractConfig,

--- a/packages/react-app-revamp/hooks/useSubmitProposal/index.ts
+++ b/packages/react-app-revamp/hooks/useSubmitProposal/index.ts
@@ -29,7 +29,7 @@ const safeMetadata = {
 export function useSubmitProposal() {
   const { asPath, ...router } = useRouter();
   const { address: userAddress } = useAccount();
-  const { fetchProposalsIdsList } = useProposal();
+  const { fetchSingleProposal } = useProposal();
   const { increaseCurrentUserProposalCount } = useUserStore(state => state);
   const { getProofs } = useGenerateProof();
   const [chainName, address] = asPath.split("/").slice(2, 4);
@@ -47,7 +47,7 @@ export function useSubmitProposal() {
     setTransactionData(null);
 
     return new Promise<{ tx: TransactionResponse; proposalId: string }>(async (resolve, reject) => {
-      const { abi, version } = await getContestContractVersion(address, chainId);
+      const { abi } = await getContestContractVersion(address, chainId);
 
       try {
         const proofs = await getProofs(userAddress ?? "", "submission", "10");
@@ -106,7 +106,7 @@ export function useSubmitProposal() {
         toastSuccess("proposal submitted successfully!");
         increaseCurrentUserProposalCount();
         removeSubmissionFromLocalStorage("submissions", address);
-        fetchProposalsIdsList(abi, version);
+        fetchSingleProposal(proposalId);
         resolve({ tx: txSendProposal, proposalId });
 
         addUserActionForAnalytics({

--- a/packages/react-app-revamp/hooks/useSubmitProposal/index.ts
+++ b/packages/react-app-revamp/hooks/useSubmitProposal/index.ts
@@ -47,7 +47,7 @@ export function useSubmitProposal() {
     setTransactionData(null);
 
     return new Promise<{ tx: TransactionResponse; proposalId: string }>(async (resolve, reject) => {
-      const { abi } = await getContestContractVersion(address, chainId);
+      const { abi, version } = await getContestContractVersion(address, chainId);
 
       try {
         const proofs = await getProofs(userAddress ?? "", "submission", "10");
@@ -106,7 +106,7 @@ export function useSubmitProposal() {
         toastSuccess("proposal submitted successfully!");
         increaseCurrentUserProposalCount();
         removeSubmissionFromLocalStorage("submissions", address);
-        fetchProposalsIdsList(abi);
+        fetchProposalsIdsList(abi, version);
         resolve({ tx: txSendProposal, proposalId });
 
         addUserActionForAnalytics({


### PR DESCRIPTION
Closes #664 

- [x] correct tests to use the current version of `sortedProposals()`
- [x] add back in the `fetchSingleProposal()` logic upon submission that was in #653 