### PR TITLE
feat: add getProposals

### DIFF
--- a/packages/forge/src/governance/Governor.sol
+++ b/packages/forge/src/governance/Governor.sol
@@ -159,10 +159,21 @@ abstract contract Governor is Context, ERC165, EIP712, GovernorMerkleVotes, IGov
     }
 
     /**
-     * @dev Retrieve proposal data"_.
+     * @dev Retrieve proposal data.
      */
     function getProposal(uint256 proposalId) public view virtual returns (ProposalCore memory) {
         return _proposals[proposalId];
+    }
+
+    /**
+     * @dev Retrieve data from multiple proposals.
+     */
+    function getProposals(uint256[] memory proposalIds) public view virtual returns (ProposalCore[] memory) {
+        ProposalCore[] memory proposals = new ProposalCore[](proposalIds.length);
+        for (uint256 index = 0; index < proposalIds.length; index++) {
+            proposals[index] = getProposal(proposalIds[index]);
+        }
+        return proposals;
     }
 
     /**


### PR DESCRIPTION
Closes #731 

should decrease the number of RPC calls we have to make by a good bit!

I don't think it will have an impact on the performance of the site either (might even speed it up bc of latency on multiple requests possibly?) since we're already `await` all of the proposals to be loaded for a page anyways.

For the future:
 - Maybe do this for all the accessors in `GovernorCountingSimple` too? (optimize them too wrt reading state values?)
 - and `getNumSubmissions()` in `Governor` too? maybe not this one, doesn't get as much bang for our buck but worth thinking about
 - a `getAllAddressesThatHaveVoted()` data