### PR TITLE
chore: increase time to wait for rpc to 10s

### DIFF
--- a/packages/react-app-revamp/helpers/timeout.ts
+++ b/packages/react-app-revamp/helpers/timeout.ts
@@ -1,4 +1,4 @@
-export const MAX_TIME_TO_WAIT_FOR_RPC = 5000;
+export const MAX_TIME_TO_WAIT_FOR_RPC = 10000;
 
 export async function executeWithTimeout<T>(timeoutDuration: number, targetPromise: Promise<T>): Promise<T> {
   let timeoutPromise = new Promise<T>((_, reject) => {


### PR DESCRIPTION
was timing out on calls to mantle's testnet, so need to bump