### PR TITLE
chore: reorder fe versions

### DIFF
--- a/packages/react-app-revamp/helpers/getContestContractVersion.ts
+++ b/packages/react-app-revamp/helpers/getContestContractVersion.ts
@@ -38,44 +38,44 @@ export async function getContestContractVersion(address: string, chainId: number
 
     const defaultReturn = { abi: null, version: "unknown" };
 
-    if (version === "2.8") {
-      return { abi: NumberedVersioningContract.abi, version };
-    } else if (version === "2.9") {
-      return { abi: GateSubmissionsOpenContract.abi, version };
-    } else if (version === "2.10") {
-      return { abi: BetterRewardsNotesContract.abi, version };
-    } else if (version === "3.1") {
-      return { abi: MerkleVotesContract.abi, version };
-    } else if (version === "3.2") {
-      return { abi: TotalVotesCastContract.abi, version };
-    } else if (version === "3.3") {
-      return { abi: SetCompilerContract.abi, version };
-    } else if (version === "3.4") {
-      return { abi: AddIsDeletedContract.abi, version };
-    } else if (version === "3.5") {
-      return { abi: DeletedDontHitLimitContract.abi, version };
-    } else if (version === "3.6") {
-      return { abi: BringBackDeletedIdsContract.abi, version };
-    } else if (version === "3.7") {
-      return { abi: ArrayOfDeletedIdsContract.abi, version };
-    } else if (version === "3.8") {
-      return { abi: DeletedIdAccessorContract.abi, version };
-    } else if (version === "3.9") {
-      return { abi: PrivateDeletedIdsContract.abi, version };
-    } else if (version === "3.10") {
-      return { abi: CantVoteOnDeletedContract.abi, version };
-    } else if (version === "3.11") {
-      return { abi: AuditMinorFixesContract.abi, version };
-    } else if (version === "3.12") {
-      return { abi: AuditInfoAndOptimizationsContract.abi, version };
-    } else if (version === "3.13") {
-      return { abi: CleanUpContractDocsContract.abi, version };
-    } else if (version === "3.14") {
-      return { abi: TrackProposalAuthorsContract.abi, version };
+    if (version === "3.16") {
+      return { abi: MakeVarsPublicContract.abi, version };
     } else if (version === "3.15") {
       return { abi: TrackVotersContract.abi, version };
-    } else if (version === "3.16") {
-      return { abi: MakeVarsPublicContract.abi, version };
+    } else if (version === "3.14") {
+      return { abi: TrackProposalAuthorsContract.abi, version };
+    } else if (version === "3.13") {
+      return { abi: CleanUpContractDocsContract.abi, version };
+    } else if (version === "3.12") {
+      return { abi: AuditInfoAndOptimizationsContract.abi, version };
+    } else if (version === "3.11") {
+      return { abi: AuditMinorFixesContract.abi, version };
+    } else if (version === "3.10") {
+      return { abi: CantVoteOnDeletedContract.abi, version };
+    } else if (version === "3.9") {
+      return { abi: PrivateDeletedIdsContract.abi, version };
+    } else if (version === "3.8") {
+      return { abi: DeletedIdAccessorContract.abi, version };
+    } else if (version === "3.7") {
+      return { abi: ArrayOfDeletedIdsContract.abi, version };
+    } else if (version === "3.6") {
+      return { abi: BringBackDeletedIdsContract.abi, version };
+    } else if (version === "3.5") {
+      return { abi: DeletedDontHitLimitContract.abi, version };
+    } else if (version === "3.4") {
+      return { abi: AddIsDeletedContract.abi, version };
+    } else if (version === "3.3") {
+      return { abi: SetCompilerContract.abi, version };
+    } else if (version === "3.2") {
+      return { abi: TotalVotesCastContract.abi, version };
+    } else if (version === "3.1") {
+      return { abi: MerkleVotesContract.abi, version };
+    } else if (version === "2.10") {
+      return { abi: BetterRewardsNotesContract.abi, version };
+    } else if (version === "2.9") {
+      return { abi: GateSubmissionsOpenContract.abi, version };
+    } else if (version === "2.8") {
+      return { abi: NumberedVersioningContract.abi, version };
     }
 
     if (version === "1") {

--- a/packages/react-app-revamp/helpers/getRewardsModuleContractVersion.ts
+++ b/packages/react-app-revamp/helpers/getRewardsModuleContractVersion.ts
@@ -30,46 +30,46 @@ export async function getRewardsModuleContractVersion(address: string, chainId: 
   try {
     const version: string = await executeWithTimeout(MAX_TIME_TO_WAIT_FOR_RPC, contract.version());
 
-    if (version === "1") {
-      return LegacyDeployedRewardsModuleContract.abi;
-    } else if (version === "2.3") {
-      return NumberedVersioningRewards.abi;
-    } else if (version === "2.4") {
-      return GateSubmissionsOpenRewards.abi;
-    } else if (version === "2.5") {
-      return BetterRewardsNotesRewards.abi;
-    } else if (version === "3.1") {
-      return MerkleVotesRewards.abi;
-    } else if (version === "3.2") {
-      return TotalVotesCastRewards.abi;
-    } else if (version === "3.3") {
-      return SetCompilerRewards.abi;
-    } else if (version === "3.4") {
-      return AddIsDeletedRewards.abi;
-    } else if (version === "3.5") {
-      return DeletedDontHitLimitRewards.abi;
-    } else if (version === "3.6") {
-      return BringBackDeletedIdsRewards.abi;
-    } else if (version === "3.7") {
-      return ArrayOfDeletedIdsRewards.abi;
-    } else if (version === "3.8") {
-      return DeletedIdAccessorRewards.abi;
-    } else if (version === "3.9") {
-      return PrivateDeletedIdsRewards.abi;
-    } else if (version === "3.10") {
-      return CantVoteOnDeletedPropsRewards.abi;
-    } else if (version === "3.11") {
-      return AuditMinorFixesRewards.abi;
-    } else if (version === "3.12") {
-      return AuditInfoAndOptimizationsRewards.abi;
-    } else if (version === "3.13") {
-      return CleanUpContractDocsRewards.abi;
-    } else if (version === "3.14") {
-      return TrackProposalAuthorsRewards.abi;
+    if (version === "3.16") {
+      return MakeVarsPublicRewards.abi;
     } else if (version === "3.15") {
       return TrackVotersRewards.abi;
-    } else if (version === "3.16") {
-      return MakeVarsPublicRewards.abi;
+    } else if (version === "3.14") {
+      return TrackProposalAuthorsRewards.abi;
+    } else if (version === "3.13") {
+      return CleanUpContractDocsRewards.abi;
+    } else if (version === "3.12") {
+      return AuditInfoAndOptimizationsRewards.abi;
+    } else if (version === "3.11") {
+      return AuditMinorFixesRewards.abi;
+    } else if (version === "3.10") {
+      return CantVoteOnDeletedPropsRewards.abi;
+    } else if (version === "3.9") {
+      return PrivateDeletedIdsRewards.abi;
+    } else if (version === "3.8") {
+      return DeletedIdAccessorRewards.abi;
+    } else if (version === "3.7") {
+      return ArrayOfDeletedIdsRewards.abi;
+    } else if (version === "3.6") {
+      return BringBackDeletedIdsRewards.abi;
+    } else if (version === "3.5") {
+      return DeletedDontHitLimitRewards.abi;
+    } else if (version === "3.4") {
+      return AddIsDeletedRewards.abi;
+    } else if (version === "3.3") {
+      return SetCompilerRewards.abi;
+    } else if (version === "3.2") {
+      return TotalVotesCastRewards.abi;
+    } else if (version === "3.1") {
+      return MerkleVotesRewards.abi;
+    } else if (version === "2.5") {
+      return BetterRewardsNotesRewards.abi;
+    } else if (version === "2.4") {
+      return GateSubmissionsOpenRewards.abi;
+    } else if (version === "2.3") {
+      return NumberedVersioningRewards.abi;
+    } else if (version === "1") {
+      return LegacyDeployedRewardsModuleContract.abi;
     } else {
       return DeployedRewardsContract.abi;
     }


### PR DESCRIPTION
Should come after #734.

for efficiency given the most likely scenario on average (a user will be getting the latest or one of the most recent versions).