### PR TITLE
chain: make explicit mainnet config

### DIFF
--- a/packages/react-app-revamp/components/UI/EtheuremAddress/index.tsx
+++ b/packages/react-app-revamp/components/UI/EtheuremAddress/index.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable @next/next/no-img-element */
 import { ROUTE_VIEW_USER } from "@config/routes";
+import { mainnet } from "@config/wagmi/custom-chains/mainnet";
 import { useAvatarStore } from "@hooks/useAvatar";
 import { getDefaultProfile } from "@services/lens/getDefaultProfile";
 import { useQuery } from "@tanstack/react-query";
-import { fetchEnsAvatar, fetchEnsName, mainnet } from "@wagmi/core";
+import { fetchEnsAvatar, fetchEnsName } from "@wagmi/core";
 import Link from "next/link";
 
 const DEFAULT_AVATAR_URL = "/contest/avatar.svg";
@@ -29,7 +30,7 @@ const EthereumAddress = ({
   const { setAvatar } = useAvatarStore(state => state);
   const avatarSizeClass = isLarge ? "w-[100px] h-[100px]" : "w-8 h-8";
   const textSizeClass = isLarge ? "text-[24px] font-sabo" : "text-[16px]";
-  const etherscan = mainnet.blockExplorers.etherscan.url;
+  const etherscan = mainnet.blockExplorers?.etherscan.url;
 
   const fetchAvatarAndProfile = async () => {
     try {

--- a/packages/react-app-revamp/config/wagmi/custom-chains/mainnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/mainnet.ts
@@ -1,0 +1,25 @@
+import { Chain } from "@rainbow-me/rainbowkit";
+
+export const mainnet: Chain = {
+  id: 1,
+  name: "mainnet",
+  network: "mainnet",
+  iconUrl: "/ethereum.svg",
+  nativeCurrency: {
+    decimals: 18,
+    name: "Ether",
+    symbol: "ETH",
+  },
+  rpcUrls: {
+    public: {
+      http: ["https://eth.llamarpc.com"],
+    },
+    default: {
+      http: [`https://eth-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_KEY}`],
+    },
+  },
+  blockExplorers: {
+    etherscan: { name: "Etherscan", url: "https://https://etherscan.io/" },
+    default: { name: "Etherscan", url: "https://https://etherscan.io/" },
+  },
+};

--- a/packages/react-app-revamp/config/wagmi/custom-chains/mainnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/mainnet.ts
@@ -19,7 +19,7 @@ export const mainnet: Chain = {
     },
   },
   blockExplorers: {
-    etherscan: { name: "Etherscan", url: "https://https://etherscan.io/" },
-    default: { name: "Etherscan", url: "https://https://etherscan.io/" },
+    etherscan: { name: "Etherscan", url: "https://etherscan.io/" },
+    default: { name: "Etherscan", url: "https://etherscan.io/" },
   },
 };

--- a/packages/react-app-revamp/config/wagmi/index.ts
+++ b/packages/react-app-revamp/config/wagmi/index.ts
@@ -1,6 +1,6 @@
 import { connectorsForWallets, getDefaultWallets } from "@rainbow-me/rainbowkit";
 import { metaMaskWallet, walletConnectWallet, rainbowWallet, okxWallet, tahoWallet, coinbaseWallet, argentWallet, imTokenWallet, ledgerWallet, omniWallet, trustWallet } from "@rainbow-me/rainbowkit/wallets";
-import { Chain, configureChains, createConfig, mainnet } from "wagmi";
+import { Chain, configureChains, createConfig } from "wagmi";
 import { jsonRpcProvider } from "wagmi/providers/jsonRpc";
 import { arbitrumOne } from "./custom-chains/arbitrumOne";
 import { avaxCChain } from "./custom-chains/avaxCChain";
@@ -26,6 +26,7 @@ import { lootChain } from "./custom-chains/lootChain";
 import { lootChainTestnet } from "./custom-chains/lootChainTestnet";
 import { lukso } from "./custom-chains/lukso";
 import { luksoTestnet } from "./custom-chains/luksoTestnet";
+import { mainnet } from "./custom-chains/mainnet";
 import { mantle } from "./custom-chains/mantle";
 import { mantleTestnet } from "./custom-chains/mantleTestnet";
 import { modeTestnet } from "./custom-chains/modeTestnet";


### PR DESCRIPTION
wagmi's default mainnet provider was cloudflare-eth.com, and ever since we have moved over to cloudflare that has been causing very weird and intermittent problems when we are trying to call `fetchEnsName`, so we are explicitly setting our own config for mainnet.