### PR TITLE
bugfix: add mainnet ENS resolver config

### DIFF
--- a/packages/react-app-revamp/config/wagmi/custom-chains/mainnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/mainnet.ts
@@ -22,4 +22,17 @@ export const mainnet: Chain = {
     etherscan: { name: "Etherscan", url: "https://etherscan.io/" },
     default: { name: "Etherscan", url: "https://etherscan.io/" },
   },
+  contracts: {
+    ensRegistry: {
+      address: "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e"
+    },
+    ensUniversalResolver: {
+      address: "0xc0497E381f536Be9ce14B0dD3817cBcAe57d2F62",
+      blockCreated: 16966585
+    },
+    multicall3: {
+      address: "0xca11bde05977b3631167028862be2a173976ca11",
+      blockCreated: 14353601
+    }
+  }
 };


### PR DESCRIPTION
Closes #794 

we just needed to add the necessary config information for mainnet to be able to resolve ENS information. got it from the official wagmi package [here](https://www.npmjs.com/package/@wagmi/chains?activeTab=code).