### PR TITLE
chore: don't filter deleted submissions from user profile results

### DIFF
--- a/packages/react-app-revamp/lib/user/index.tsx
+++ b/packages/react-app-revamp/lib/user/index.tsx
@@ -31,7 +31,6 @@ async function fetchSubmissions(
         .select("network_name, contest_address, proposal_id, created_at", { count: "exact" })
         .eq("user_address", criteria.user_address)
         .is("vote_amount", criteria.vote_amount)
-        .is("deleted", false)
         .order("created_at", { ascending: false })
         .range(range.from, range.to);
     } else {
@@ -39,7 +38,6 @@ async function fetchSubmissions(
         .from("analytics_contest_participants_v3")
         .select("network_name, contest_address, proposal_id, created_at, vote_amount")
         .eq("user_address", criteria.user_address)
-        .is("deleted", false)
         .not("vote_amount", "is", null)
         .order("created_at", { ascending: false })
         .range(range.from, range.to);


### PR DESCRIPTION
we don't need to do this because if users try to go to the submission will just show as "this submission has been deleted" anyways, and we don't want to do it because it slows down query times.

removes logic implemented in #814.

context for why we started collecting this data in the first place is just for analytics to be able to answer questions like "how many vote txns were cast on proposals that ended up being deleted in the past month?".