### PR TITLE
enhancement: redirect users to PWA when clicked on link

### DIFF
--- a/packages/react-app-revamp/public/.well-known/web-app-origin-association
+++ b/packages/react-app-revamp/public/.well-known/web-app-origin-association
@@ -1,0 +1,6 @@
+{
+  "relation": [{
+    "relation_name": "delegate_permission/common.handle_urls",
+    "target": "/.well-known/pwa-url-handler"
+  }]
+}

--- a/packages/react-app-revamp/public/manifest.json
+++ b/packages/react-app-revamp/public/manifest.json
@@ -7,11 +7,13 @@
   "name": "Jokerace",
   "short_name": "jokerace",
   "description": "contests for communities to make, execute, and reward decisions",
-  "url_handlers": [
-    {
-      "origin": "https://jokerace-git-enhancement-redirect-users-to-pwa-jokerace.vercel.app/"
-    }
-  ],
+  "handle_links": {
+    "platform": "web",
+    "url": "https://jokerace-git-enhancement-redirect-users-to-pwa-jokerace.vercel.app",
+    "delegate_permission": "none",
+    "exclude_paths": [],
+    "paths": ["/*"]
+  },
   "icons": [
     {
       "src": "/icon-192x192.png",

--- a/packages/react-app-revamp/public/manifest.json
+++ b/packages/react-app-revamp/public/manifest.json
@@ -7,6 +7,11 @@
   "name": "Jokerace",
   "short_name": "jokerace",
   "description": "contests for communities to make, execute, and reward decisions",
+  "url_handlers": [
+    {
+      "origin": "https://jokerace.xyz"
+    }
+  ],
   "icons": [
     {
       "src": "/icon-192x192.png",

--- a/packages/react-app-revamp/public/manifest.json
+++ b/packages/react-app-revamp/public/manifest.json
@@ -9,7 +9,7 @@
   "description": "contests for communities to make, execute, and reward decisions",
   "url_handlers": [
     {
-      "origin": "https://jokerace.xyz"
+      "origin": "https://jokerace-git-enhancement-redirect-users-to-pwa-jokerace.vercel.app/"
     }
   ],
   "icons": [


### PR DESCRIPTION
Closes #840

First tried from here https://developer.chrome.com/articles/pwa-url-handler but it looks like `url_handlers` is deprecated, as demo that is presented on this source doesn't work as well.

Trying different approach now with `handle_links` but still no success, there isn't any relevant docs on how to implement this from start to end, i'm going to continue research.

Launch Handler API only supported on ChromeOS devices - https://developer.chrome.com/docs/web-platform/launch-handler/


EDIT: Unfortunately for now there isn't support for iOS at all, while android devices are more or less supported.
![image](https://github.com/jk-labs-inc/jokerace/assets/18723426/e5d45d51-0836-42a5-86e7-3273c948db3b)

I would propose to close this issue for now until it becomes available to implement in the future.