### PR TITLE
bugfix: voters same requirements

### DIFF
--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestSubmission/components/SubmissionRequirements/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestSubmission/components/SubmissionRequirements/index.tsx
@@ -130,8 +130,6 @@ const CreateSubmissionRequirements = () => {
       return acc;
     }, {} as Record<string, number>);
 
-    console.log({ submissionAllowlist });
-
     if (isVotingAllowlistPrefilled) {
       const { tokenAddress, minTokensRequired, timestamp, type, chain } = votingRequirements;
       setSubmissionRequirements({

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestSubmission/components/SubmissionRequirements/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestSubmission/components/SubmissionRequirements/index.tsx
@@ -125,6 +125,13 @@ const CreateSubmissionRequirements = () => {
     const allowList = Object.keys(votingAllowlist.manual).length ? votingAllowlist.manual : votingAllowlist.prefilled;
     const isVotingAllowlistPrefilled = allowList === votingAllowlist.prefilled;
 
+    const submissionAllowlist: Record<string, number> = Object.keys(allowList).reduce((acc, address) => {
+      acc[address] = 10;
+      return acc;
+    }, {} as Record<string, number>);
+
+    console.log({ submissionAllowlist });
+
     if (isVotingAllowlistPrefilled) {
       const { tokenAddress, minTokensRequired, timestamp, type, chain } = votingRequirements;
       setSubmissionRequirements({
@@ -138,7 +145,7 @@ const CreateSubmissionRequirements = () => {
 
     worker.postMessage({
       decimals: 18,
-      allowList,
+      allowList: submissionAllowlist,
     });
   };
 
@@ -152,6 +159,7 @@ const CreateSubmissionRequirements = () => {
 
     try {
       const result = await fetchNftHolders(
+        "submission",
         submissionRequirements.tokenAddress,
         submissionRequirements.chain,
         submissionRequirements.minTokensRequired,

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingRequirements/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingRequirements/index.tsx
@@ -134,8 +134,6 @@ const CreateVotingRequirements = () => {
         votingRequirements.powerType,
       );
 
-      console.log({ result });
-
       if (result instanceof Error) {
         toastError(result.message);
         return;

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingRequirements/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingRequirements/index.tsx
@@ -126,12 +126,15 @@ const CreateVotingRequirements = () => {
     toastLoading("processing your allowlist...", false);
     try {
       const result = await fetchNftHolders(
+        "voting",
         votingRequirements.tokenAddress,
         votingRequirements.chain,
         votingRequirements.minTokensRequired,
         votingRequirements.powerValue,
         votingRequirements.powerType,
       );
+
+      console.log({ result });
 
       if (result instanceof Error) {
         toastError(result.message);

--- a/packages/react-app-revamp/lib/permissioning/index.ts
+++ b/packages/react-app-revamp/lib/permissioning/index.ts
@@ -7,6 +7,7 @@ export type VoteCalculationMethod = "token" | "token holder";
 const HARD_LIMIT = 400000;
 
 export async function fetchNftHolders(
+  type: "voting" | "submission",
   contractAddress: string,
   chainName: string,
   minTokensRequired: number = 1,
@@ -87,6 +88,7 @@ export async function fetchNftHolders(
       votesPerUnit,
       voteCalculationMethod,
       minTokensRequired,
+      eventType: type,
     });
   });
 }

--- a/packages/react-app-revamp/workers/nftOwnersProcessing.ts
+++ b/packages/react-app-revamp/workers/nftOwnersProcessing.ts
@@ -20,10 +20,11 @@ interface EventData {
   voteCalculationMethod: VoteCalculationMethod;
   votesPerUnit: number;
   minTokensRequired: number;
+  eventType: "voting" | "submission";
 }
 
 self.onmessage = (event: MessageEvent<EventData>) => {
-  const { ownersData, voteCalculationMethod, votesPerUnit, minTokensRequired } = event.data;
+  const { ownersData, voteCalculationMethod, votesPerUnit, minTokensRequired, eventType } = event.data;
   const ownersBalancesRecord: OwnersBalancesRecord = {};
   let qualifiedOwnersCount = 0;
 
@@ -38,10 +39,14 @@ self.onmessage = (event: MessageEvent<EventData>) => {
       qualifiedOwnersCount++;
       let totalVotes: number = 0;
 
-      if (voteCalculationMethod === "token") {
-        totalVotes = numTokens * votesPerUnit;
-      } else if (voteCalculationMethod === "token holder") {
-        totalVotes = owner.tokenBalances.length > 0 ? votesPerUnit : 0;
+      if (eventType === "voting") {
+        if (voteCalculationMethod === "token") {
+          totalVotes = numTokens * votesPerUnit;
+        } else if (voteCalculationMethod === "token holder") {
+          totalVotes = owner.tokenBalances.length > 0 ? votesPerUnit : 0;
+        }
+      } else if (eventType === "submission") {
+        totalVotes = 10; // hardcoded to 10 for submission allowlists
       }
 
       ownersBalancesRecord[ownerAddress] = totalVotes;


### PR DESCRIPTION
I've noticed a bug in `submission` tab when creating a contest, if you set up voters to be submitters as well, while merkle root is the same, we didn't hardcode 10 votes per address as we need for submitters.