### PR TITLE
bugfix: hide submission navigation containers if there is only one submission in contest

### DIFF
--- a/packages/react-app-revamp/components/_pages/DialogModalProposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalProposal/index.tsx
@@ -65,7 +65,7 @@ const DialogModalProposal: FC<DialogModalProposalProps> = ({
     >
       <div className="flex flex-col gap-8 md:pl-[50px] lg:pl-[100px] mt-[20px] md:mt-[60px] pb-[60px]">
         <ContestPrompt type="modal" prompt={prompt} hidePrompt />
-        <div className="flex gap-4">
+        <div className={`${totalProposals > 1 ? "flex" : "hidden"} gap-4`}>
           {currentIndex !== 0 && (
             <ButtonV3
               colorClass="bg-primary-2"

--- a/packages/react-app-revamp/components/_pages/Submission/Mobile/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Submission/Mobile/index.tsx
@@ -173,7 +173,9 @@ const SubmissionPageMobileLayout: FC<SubmissionPageMobileLayoutProps> = ({
         </div>
         <div className="mt-20">
           <div
-            className={`fixed ${isInPwaMode ? "bottom-[88px]" : "bottom-16"} left-0 right-0 flex ${
+            className={`${totalProposals > 1 ? "fixed" : "hidden"} ${
+              isInPwaMode ? "bottom-[88px]" : "bottom-16"
+            } left-0 right-0 flex ${
               currentIndex === 0 || currentIndex === totalProposals - 1 ? "justify-center" : "justify-between"
             } px-8 py-5 z-50 border-t-neutral-2 border-t-2 bg-true-black`}
           >


### PR DESCRIPTION
Just a small visual bug, on desktop there is unused space between prompt and creator when there is only one proposal, while on mobile, container with borders is visible when there is only one proposal

### Desktop:
![image](https://github.com/jk-labs-inc/jokerace/assets/18723426/8e959341-8a0a-4a9f-a840-ebf41006ca62)

### Mobile:
![image](https://github.com/jk-labs-inc/jokerace/assets/18723426/4f0568c2-d4de-462f-bfd5-c5fca340c0e6)

