### PR TITLE
chore: update q currency name

### DIFF
--- a/packages/react-app-revamp/config/wagmi/custom-chains/qChain.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/qChain.ts
@@ -7,8 +7,8 @@ export const qChain: Chain = {
   iconUrl: "/qchain.svg",
   nativeCurrency: {
     decimals: 18,
-    name: "Q",
-    symbol: "Q",
+    name: "Qtoken",
+    symbol: "QTOKEN",
   },
   rpcUrls: {
     public: {


### PR DESCRIPTION
MM was erroring with this when I tried to switch chains, looks like the currency symbol needs to be between 2 and 6 characters.

![image](https://github.com/jk-labs-inc/jokerace/assets/27874039/0639825b-ab02-48b3-bc8a-15342919df01)
