### PR TITLE
bugfix: check lowercase chain names for entry charge

### DIFF
--- a/packages/react-app-revamp/lib/monetization/index.ts
+++ b/packages/react-app-revamp/lib/monetization/index.ts
@@ -10,7 +10,7 @@ export const fetchEntryChargeDetails = async (chainName: string): Promise<number
     const { data, error } = await supabase
       .from("chain_params")
       .select("min_cost_to_propose")
-      .eq("network_name", chainName)
+      .eq("network_name", chainName.toLowerCase())
       .limit(1)
       .single();
 


### PR DESCRIPTION
chains with names containing multiple words like publicGoodsNetwork or polygonZk weren't populating as having entry fees enabled because the frontend wasn't parsing the info from the db correctly.