### PR TITLE
chore: add gh action to auto-merge main PRs into staging

### DIFF
--- a/.github/workflows/auto_merge_main_PRs.yml
+++ b/.github/workflows/auto_merge_main_PRs.yml
@@ -1,0 +1,25 @@
+name: PRs to main
+
+on: 
+  pull_request:
+    branches: [main]
+    types: [closed]
+jobs:
+  merge-main-back-to-staging:
+    if: github.event.pull_request.merged == true
+    timeout-minutes: 2
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set Git config
+      run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "Github Actions"
+    - name: Merge main back to staging
+      run: |
+          git status
+          git fetch --unshallow
+          git switch staging
+          git pull
+          git merge main
+          git push

--- a/.github/workflows/auto_merge_main_PRs.yml
+++ b/.github/workflows/auto_merge_main_PRs.yml
@@ -15,11 +15,11 @@ jobs:
       run: |
           git config --local user.email "actions@github.com"
           git config --local user.name "Github Actions"
-    - name: Merge main back to staging
+    - name: Rebase main to staging
       run: |
           git status
           git fetch --unshallow
           git switch staging
           git pull
-          git merge main
+          git rebase main
           git push

--- a/.github/workflows/auto_rebase_main_PRs.yml
+++ b/.github/workflows/auto_rebase_main_PRs.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     types: [closed]
 jobs:
-  merge-main-back-to-staging:
+  rebase-main-back-to-staging:
     if: github.event.pull_request.merged == true
     timeout-minutes: 2
     runs-on: ubuntu-latest
@@ -15,7 +15,7 @@ jobs:
       run: |
           git config --local user.email "actions@github.com"
           git config --local user.name "Github Actions"
-    - name: Rebase main to staging
+    - name: Rebase main back to staging
       run: |
           git status
           git fetch --unshallow


### PR DESCRIPTION
add an automation to keep staging synced up with main whenever we merge into main.

when we merge into main from staging in our current flow, a merge commit is created, and that merge commit needs to be merged into staging for staging to be kept up to date with main. this workflow automates that.

tested in #906, #907, #908, #909, and #910

inspo from https://medium.com/@karlstad/create-a-github-actions-workflow-that-auto-merges-the-master-back-to-dev-branch-8b1ebe7009b3