### PR TITLE
feat: add google analytics to frontend

### DIFF
--- a/packages/react-app-revamp/lib/gtag/index.ts
+++ b/packages/react-app-revamp/lib/gtag/index.ts
@@ -1,0 +1,22 @@
+export const GA_TRACKING_ID = "G-ZMLFLXBZCD";
+
+type GTagEvent = {
+  action: string;
+  category: string;
+  label: string;
+  value: number;
+};
+
+export const pageview = (url: URL): void => {
+  window.gtag("config", GA_TRACKING_ID, {
+    page_path: url,
+  });
+};
+
+export const event = ({ action, category, label, value }: GTagEvent): void => {
+  window.gtag("event", action, {
+    event_category: category,
+    event_label: label,
+    value,
+  });
+};

--- a/packages/react-app-revamp/package.json
+++ b/packages/react-app-revamp/package.json
@@ -84,6 +84,7 @@
     "@graphql-codegen/typescript": "^2.7.4",
     "@graphql-codegen/typescript-operations": "^2.5.4",
     "@tailwindcss/typography": "^0.5.2",
+    "@types/gtag.js": "^0.0.17",
     "@types/lodash": "^4.14.195",
     "@types/papaparse": "^5.3.7",
     "@types/react": "18.0.11",

--- a/packages/react-app-revamp/pages/_app.tsx
+++ b/packages/react-app-revamp/pages/_app.tsx
@@ -1,21 +1,24 @@
-import { polyfill } from "interweave-ssr";
-polyfill();
 import { jokeraceTheme } from "@config/rainbowkit";
 import { chains, config } from "@config/wagmi";
+import { Portal } from "@headlessui/react";
 import LayoutBase from "@layouts/LayoutBase";
 import { RainbowKitProvider } from "@rainbow-me/rainbowkit";
 import "@rainbow-me/rainbowkit/styles.css";
 import "@styles/globals.css";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { polyfill } from "interweave-ssr";
 import type { AppProps } from "next/app";
 import Head from "next/head";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
 import "react-datepicker/dist/react-datepicker.css";
 import "react-loading-skeleton/dist/skeleton.css";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.min.css";
 import "react-tooltip/dist/react-tooltip.css";
 import { WagmiConfig } from "wagmi";
-import { Portal } from "@headlessui/react";
+import * as gtag from "../lib/gtag";
+polyfill();
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -27,7 +30,10 @@ const queryClient = new QueryClient({
   },
 });
 
+const isProd = process.env.NODE_ENV === "production";
+
 function MyApp({ Component, pageProps }: AppProps) {
+  const router = useRouter();
   const title: string = pageProps.title ? `${pageProps.title}` : "jokerace";
   const description: string = pageProps.description
     ? pageProps.description
@@ -35,6 +41,16 @@ function MyApp({ Component, pageProps }: AppProps) {
 
   //@ts-ignore
   const getLayout = Component.getLayout ?? ((page: any) => <LayoutBase>{page}</LayoutBase>);
+
+  useEffect(() => {
+    const handleRouteChange = (url: URL) => {
+      if (isProd) gtag.pageview(url);
+    };
+    router.events.on("routeChangeComplete", handleRouteChange);
+    return () => {
+      router.events.off("routeChangeComplete", handleRouteChange);
+    };
+  }, [router.events]);
 
   return (
     <>

--- a/packages/react-app-revamp/pages/_document.tsx
+++ b/packages/react-app-revamp/pages/_document.tsx
@@ -1,10 +1,30 @@
-import Document, { Html, Head, Main, NextScript } from "next/document";
+import { GA_TRACKING_ID } from "lib/gtag";
+import Document, { Head, Html, Main, NextScript } from "next/document";
+
+const isProd = process.env.NODE_ENV === "production";
 
 class MyDocument extends Document {
   render() {
     return (
       <Html>
         <Head>
+          {isProd && (
+            <>
+              <script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`} />
+              <script
+                dangerouslySetInnerHTML={{
+                  __html: `
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${GA_TRACKING_ID}', {
+              page_path: window.location.pathname,
+            });
+          `,
+                }}
+              />
+            </>
+          )}
           <link rel="manifest" href="/manifest.json" />
           <link rel="apple-touch-icon" href="/icon.png"></link>
           <meta name="theme-color" content="#fff" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -5703,6 +5703,11 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/gtag.js@^0.0.17":
+  version "0.0.17"
+  resolved "https://registry.yarnpkg.com/@types/gtag.js/-/gtag.js-0.0.17.tgz#4f84440e3424149517b41f60bd787374900d0b55"
+  integrity sha512-OsSO6Yyuygr3DeeTovOY0ppLiAVHoXg4CSanO9/vzDQCV+e8pkZNE+HR2dVxGJfUbtRe2IqzC97PYuHSNUepJw==
+
 "@types/js-cookie@^2.2.6":
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.7.tgz#226a9e31680835a6188e887f3988e60c04d3f6a3"


### PR DESCRIPTION
Closes #918

Implementation of it was followed by nextjs guide of how to implement google analytics as we can't just add script tag, because we need to follow route changes to achieve correct tracking.