### PR TITLE
bugfix: only show parenthesis in params if permissioning requirements

### DIFF
--- a/packages/react-app-revamp/components/_pages/Contest/Parameters/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/Parameters/index.tsx
@@ -64,8 +64,8 @@ const ContestParameters = () => {
         <p>
           you have{" "}
           <span className="font-bold">
-            {formatNumber(currentUserAvailableVotesAmount)} votes (
-            {votingRequirements ? `${votingRequirements.description}` : null})
+            {formatNumber(currentUserAvailableVotesAmount)} votes{" "}
+            {votingRequirements ? `(${votingRequirements.description})` : null}
           </span>
         </p>
       );


### PR DESCRIPTION
Closes #872 