### PR TITLE
bugfix: user page incorrect qualification

### DIFF
--- a/packages/react-app-revamp/lib/contests/index.ts
+++ b/packages/react-app-revamp/lib/contests/index.ts
@@ -260,8 +260,13 @@ export async function getRewards(contests: any[]) {
   return Promise.all(contests.map(contest => processContestRewardsData(contest.address, contest.network_name)));
 }
 
-export async function getUserContests(currentPage: number, itemsPerPage: number, userAddress: string) {
-  if (isSupabaseConfigured && userAddress) {
+export async function getUserContests(
+  currentPage: number,
+  itemsPerPage: number,
+  profileAddress: string,
+  currentUserAddress: string,
+) {
+  if (isSupabaseConfigured && profileAddress) {
     const config = await import("@config/supabase");
     const supabase = config.supabase;
     const { from, to } = getPagination(currentPage, itemsPerPage);
@@ -273,7 +278,7 @@ export async function getUserContests(currentPage: number, itemsPerPage: number,
           "created_at, start_at, end_at, address, author_address, network_name, vote_start_at, featured, title, type, summary, prompt, submissionMerkleRoot, hidden, votingMerkleRoot, voting_requirements, submission_requirements",
           { count: "exact" },
         )
-        .eq("author_address", userAddress)
+        .eq("author_address", profileAddress)
         .order("created_at", { ascending: false })
         .range(from, to);
 
@@ -282,7 +287,9 @@ export async function getUserContests(currentPage: number, itemsPerPage: number,
         throw new Error(error.message);
       }
 
-      const processedData = await Promise.all(data.map(contest => processContestQualifications(contest, userAddress)));
+      const processedData = await Promise.all(
+        data.map(contest => processContestQualifications(contest, currentUserAddress)),
+      );
 
       return { data: processedData, count };
     } catch (e) {

--- a/packages/react-app-revamp/pages/user/[address]/index.tsx
+++ b/packages/react-app-revamp/pages/user/[address]/index.tsx
@@ -65,8 +65,6 @@ const Page: NextPage = (props: UserPageProps) => {
     useContests(address, currentUserAddress as string, initialData?.data);
   const isCreator = currentUserAddress === address;
 
-  console.log({ currentUserAddress });
-
   return (
     <LayoutUser address={address}>
       <Head>

--- a/packages/react-app-revamp/pages/user/[address]/index.tsx
+++ b/packages/react-app-revamp/pages/user/[address]/index.tsx
@@ -15,7 +15,7 @@ export interface UserPageProps {
   ensName: string;
 }
 
-function useContests(creatorAddress: string, initialData: any) {
+function useContests(profileAddress: string, currentUserAddress: string, initialData: any) {
   const [page, setPage] = useState(0);
 
   //@ts-ignore
@@ -27,12 +27,12 @@ function useContests(creatorAddress: string, initialData: any) {
     error,
     isFetching: isContestDataFetching,
   } = useQuery(
-    ["userContests", creatorAddress, page],
+    ["userContests", profileAddress, page, currentUserAddress],
     () => {
-      return getUserContests(page, ITEMS_PER_PAGE, creatorAddress);
+      return getUserContests(page, ITEMS_PER_PAGE, profileAddress, currentUserAddress);
     },
     {
-      enabled: !!creatorAddress,
+      enabled: !!profileAddress,
     },
   );
 
@@ -60,10 +60,12 @@ function useContests(creatorAddress: string, initialData: any) {
 //@ts-ignore
 const Page: NextPage = (props: UserPageProps) => {
   const { address, ensName, initialData } = props;
+  const { address: currentUserAddress } = useAccount();
   const { page, setPage, status, contestData, rewardsData, isRewardsFetching, error, isContestDataFetching } =
-    useContests(address, initialData?.data);
-  const { address: userWalletConnectedAddress } = useAccount();
-  const isCreator = userWalletConnectedAddress === address;
+    useContests(address, currentUserAddress as string, initialData?.data);
+  const isCreator = currentUserAddress === address;
+
+  console.log({ currentUserAddress });
 
   return (
     <LayoutUser address={address}>


### PR DESCRIPTION
Ugh this one was kind of stupid and not sure how i didn't test this before, but basically we only had `profileAddress` when checking for qualifications on the user page, so, by visiting any profile page, you would actually qualify for all the contests they have created.