### PR TITLE
bugfix: add utility fn to update proposal rank

### DIFF
--- a/packages/react-app-revamp/components/_pages/ListProposals/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListProposals/index.tsx
@@ -14,20 +14,6 @@ import { useEffect, useState } from "react";
 import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
 import { useAccount } from "wagmi";
 
-interface RankDictionary {
-  [key: string]: number;
-}
-
-const checkForTiedRanks = (ranks: RankDictionary, currentRank: number) => {
-  let count = 0;
-  Object.values(ranks).forEach(rank => {
-    if (rank === currentRank) {
-      count++;
-    }
-  });
-  return count > 1;
-};
-
 const ProposalSkeleton = ({ count, highlightColor }: { count?: number; highlightColor: string }) => (
   <SkeletonTheme baseColor="#000000" highlightColor={highlightColor} duration={1}>
     <Skeleton
@@ -48,6 +34,7 @@ export const ListProposals = () => {
     isPageProposalsError,
     currentPagePaginationProposals,
     indexPaginationProposals,
+    submissionsCount,
     totalPagesPaginationProposals,
     listProposalsData,
   } = useProposalStore(state => state);
@@ -59,7 +46,7 @@ export const ListProposals = () => {
   const [deletingProposalIds, setDeletingProposalIds] = useState<string[]>([]);
   const [selectedProposalIds, setSelectedProposalIds] = useState<string[]>([]);
   const showDeleteButton = selectedProposalIds.length > 0 && !isDeleteInProcess;
-  const remainingProposalsToLoad = listProposalsIds.length - listProposalsData.length;
+  const remainingProposalsToLoad = submissionsCount - listProposalsData.length;
   const skeletonRemainingLoaderCount = Math.min(remainingProposalsToLoad, PROPOSALS_PER_PAGE);
 
   useEffect(() => {
@@ -173,7 +160,7 @@ export const ListProposals = () => {
         <ProposalSkeleton count={skeletonRemainingLoaderCount} highlightColor="#FFE25B" />
       )}
 
-      {listProposalsData.length < listProposalsIds.length && !isPageProposalsLoading && (
+      {listProposalsData.length < submissionsCount && !isPageProposalsLoading && (
         <div className="pt-8 flex animate-appear">
           <Button
             intent="neutral-outline"

--- a/packages/react-app-revamp/hooks/useProposal/utils.ts
+++ b/packages/react-app-revamp/hooks/useProposal/utils.ts
@@ -87,6 +87,11 @@ export function formatProposalData(
   });
 }
 
+/**
+ * Assign ranks to a proposals on update based on their net votes, using a complete list of all proposals.
+ * @param updatedProposals - Updated proposals ( either when user vote or delete it)
+ * @param initialMappedProposalIds - Array of all proposals with their IDs and votes.
+ */
 export function updateAndRankProposals(
   updatedProposals: ProposalCore[],
   initialMappedProposalIds: MappedProposalIds[],


### PR DESCRIPTION
Implemented a new utility function `updateAndRankProposals` for dynamic ranking of proposals on updates/deletions. Adjusted proposal count logic to accurately reflect changes when proposals are deleted.

There are 3 key changes here:

- New utility function recalculates rankings upon proposal updates or deletions.
- Accurate submission count: `submissionsCount` now updates correctly when proposals are deleted.
- Modified to use `submissionsCount` for determining if more proposals are available to load.