### PR TITLE
bugfix: call fetch proposal page in hook

### DIFF
--- a/packages/react-app-revamp/components/_pages/ListProposals/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListProposals/index.tsx
@@ -1,8 +1,6 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 import Button from "@components/UI/Button";
 import ButtonV3, { ButtonSize } from "@components/UI/ButtonV3";
 import ProposalContent from "@components/_pages/ProposalContent";
-import arrayToChunks from "@helpers/arrayToChunks";
 import { formatNumber } from "@helpers/formatNumber";
 import { CheckIcon, TrashIcon } from "@heroicons/react/outline";
 import { useContestStore } from "@hooks/useContest/store";
@@ -10,7 +8,7 @@ import { ContestStatus, useContestStatusStore } from "@hooks/useContestStatus/st
 import useDeleteProposal from "@hooks/useDeleteProposal";
 import useProposal, { PROPOSALS_PER_PAGE } from "@hooks/useProposal";
 import { useProposalStore } from "@hooks/useProposal/store";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
 import { useAccount } from "wagmi";
 
@@ -48,14 +46,6 @@ export const ListProposals = () => {
   const showDeleteButton = selectedProposalIds.length > 0 && !isDeleteInProcess;
   const remainingProposalsToLoad = submissionsCount - listProposalsData.length;
   const skeletonRemainingLoaderCount = Math.min(remainingProposalsToLoad, PROPOSALS_PER_PAGE);
-
-  useEffect(() => {
-    if (!listProposalsIds.length) return;
-
-    const paginationChunks = arrayToChunks(listProposalsIds, PROPOSALS_PER_PAGE);
-
-    fetchProposalsPage(0, paginationChunks[0], paginationChunks.length);
-  }, [listProposalsIds]);
 
   const onDeleteSelectedProposals = async () => {
     setDeletingProposalIds(selectedProposalIds);

--- a/packages/react-app-revamp/hooks/useProposal/index.ts
+++ b/packages/react-app-revamp/hooks/useProposal/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 import { toastError } from "@components/UI/Toast";
 import { chains } from "@config/wagmi";
 import arrayToChunks from "@helpers/arrayToChunks";
@@ -195,6 +194,8 @@ export function useProposal() {
       const paginationChunks = arrayToChunks(proposalsIds as string[], PROPOSALS_PER_PAGE);
       setTotalPagesPaginationProposals(paginationChunks.length);
       setIndexPaginationProposalPerId(paginationChunks);
+
+      fetchProposalsPage(0, paginationChunks[0], paginationChunks.length);
     } catch (e) {
       handleError(e, "Something went wrong while getting proposal ids.");
       setError(error);


### PR DESCRIPTION
This PR addresses an issue where switching tabs caused duplicate proposals to appear due to repeated calls with the same `listProposalIds` 

We integrated `fetchProposalsPage` to be called at the end of `fetchProposalsIdsList` since that function is being called only when you switch contests.