### PR TITLE
bugfix: add max delay for timeout and adapt live vote

### DIFF
--- a/packages/react-app-revamp/helpers/timeout.ts
+++ b/packages/react-app-revamp/helpers/timeout.ts
@@ -1,5 +1,8 @@
 export const MAX_TIME_TO_WAIT_FOR_RPC = 30000;
 
+// https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value
+export const MAX_MS_TIMEOUT = 2147483647;
+
 export async function executeWithTimeout<T>(timeoutDuration: number, targetPromise: Promise<T>): Promise<T> {
   let timeoutPromise = new Promise<T>((_, reject) => {
     let timerId = setTimeout(() => {

--- a/packages/react-app-revamp/hooks/useCastVotes/index.ts
+++ b/packages/react-app-revamp/hooks/useCastVotes/index.ts
@@ -23,7 +23,7 @@ export function useCastVotes() {
   const { fetchTotalVotesCast } = useContest();
   const { canUpdateVotesInRealTime } = useContestStore(state => state);
   const { updateProposal } = useProposal();
-  const { listProposalsData, sortBy } = useProposalStore(state => state);
+  const { listProposalsData } = useProposalStore(state => state);
   const {
     castPositiveAmountOfVotes,
     pickedProposal,
@@ -128,10 +128,13 @@ export function useCastVotes() {
         const existingProposal = listProposalsData.find(proposal => proposal.id === pickedProposal);
 
         if (existingProposal) {
-          updateProposal({
-            ...existingProposal,
-            netVotes: votes,
-          });
+          updateProposal(
+            {
+              ...existingProposal,
+              netVotes: votes,
+            },
+            listProposalsData,
+          );
         }
       }
 

--- a/packages/react-app-revamp/hooks/useContest/index.ts
+++ b/packages/react-app-revamp/hooks/useContest/index.ts
@@ -5,6 +5,7 @@ import { isSupabaseConfigured } from "@helpers/database";
 import { extractPathSegments } from "@helpers/extractPath";
 import getContestContractVersion from "@helpers/getContestContractVersion";
 import getRewardsModuleContractVersion from "@helpers/getRewardsModuleContractVersion";
+import { MAX_MS_TIMEOUT } from "@helpers/timeout";
 import { ContestStatus, useContestStatusStore } from "@hooks/useContestStatus/store";
 import { useError } from "@hooks/useError";
 import useProposal from "@hooks/useProposal";
@@ -38,10 +39,6 @@ interface ContractConfig {
   abi: any;
   chainId: number;
 }
-
-// Maximum delay for setTimeout in milliseconds
-// https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value
-const MAX_DELAY = 2147483647;
 
 export function useContest() {
   const router = useRouter();
@@ -179,7 +176,7 @@ export function useContest() {
           differenceInMilliseconds(closingVoteDate, new Date()) - minutesToMilliseconds(120);
 
         // Cap the delay at the maximum allowable value to prevent overflow
-        delayBeforeVotesCanBeUpdated = Math.min(delayBeforeVotesCanBeUpdated, MAX_DELAY);
+        delayBeforeVotesCanBeUpdated = Math.min(delayBeforeVotesCanBeUpdated, MAX_MS_TIMEOUT);
 
         setTimeout(() => {
           setCanUpdateVotesInRealTime(true);

--- a/packages/react-app-revamp/hooks/useContestEvents/index.ts
+++ b/packages/react-app-revamp/hooks/useContestEvents/index.ts
@@ -69,20 +69,9 @@ export function useContestEvents() {
           args: [proposalId],
         })) as any;
 
-        let author;
-        try {
-          author = await fetchEnsName({
-            address: proposal[0] as `0x${string}`,
-            chainId: 1,
-          });
-        } catch (error: any) {
-          author = proposal[0];
-        }
-
         const proposalData: any = {
           id: proposalId,
           authorEthereumAddress: proposal.author,
-          author: author ?? proposal.author,
           content: proposal.description,
           isContentImage: isUrlToImage(proposal.description) ? true : false,
           exists: proposal.exists,

--- a/packages/react-app-revamp/hooks/useProposal/index.ts
+++ b/packages/react-app-revamp/hooks/useProposal/index.ts
@@ -269,8 +269,8 @@ export function useProposal() {
     setProposalData(rankedProposals);
   }
 
-  function updateProposal(updatedProposal: ProposalCore) {
-    const updatedProposals = listProposalsData.map(proposal =>
+  function updateProposal(updatedProposal: ProposalCore, existingProposalsData: ProposalCore[]) {
+    const updatedProposals = existingProposalsData.map(proposal =>
       proposal.id === updatedProposal.id ? updatedProposal : proposal,
     );
 

--- a/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
@@ -43,8 +43,7 @@ import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
 import { useMediaQuery } from "react-responsive";
 import { useAccount } from "wagmi";
 import { getLayout as getBaseLayout } from "./../LayoutBase";
-
-const MAX_MS_TIMEOUT: number = 100000000;
+import { MAX_MS_TIMEOUT } from "@helpers/timeout";
 
 const LayoutViewContest = (props: any) => {
   const { asPath, pathname, reload } = useRouter();


### PR DESCRIPTION
Closes #1053 

This bugfix includes fix to 2 issues. The first issue is why live vote updates was allowed in the contest, despite though there are about ~29 days remaining to vote (we should only let people vote in the last two hours). 

The reason real-time voting updates were allowed in that contest is that `setTimeout` has a maximum delay value of 24.8 days or 2,147,483,647 ms. This leads to integer overflow, which causes the timeout to be executed immediately, see [here](https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value)

The second problem was that when we used the cast vote listener for realtime voting, the update proposal have received an empty list of all proposal data, which led to mapping over an empty array (which is why the warning appears).