### PR TITLE
bugfix: remove contest timing reset when it is not current time

### DIFF
--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestTiming/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestTiming/index.tsx
@@ -10,8 +10,7 @@ import CreateSubmissionsOpenDate from "./components/SubmissionDate";
 import CreateVotesOpenDate from "./components/VotesDate";
 
 const CreateContestTiming = () => {
-  const { step, votingOpen, votingClose, submissionOpen, setSubmissionOpen, setVotingOpen, setVotingClose } =
-    useDeployContestStore(state => state);
+  const { step, votingOpen, votingClose, submissionOpen, setSubmissionOpen } = useDeployContestStore(state => state);
   const datesValidation = validationFunctions.get(step);
 
   const onNextStep = useNextStep([
@@ -38,14 +37,6 @@ const CreateContestTiming = () => {
     const submissionOpenLessThanNow = submissionOpen.getTime() < now.getTime();
     if (submissionOpenLessThanNow) {
       setSubmissionOpen(now);
-
-      const votingOpenDate = new Date(now);
-      votingOpenDate.setDate(now.getDate() + 7);
-      setVotingOpen(votingOpenDate);
-
-      const votingCloseDate = new Date(now);
-      votingCloseDate.setDate(now.getDate() + 14);
-      setVotingClose(votingCloseDate);
     }
   }, []);
 


### PR DESCRIPTION
Closes #993 

When the user switches to the timing tab, we just set the submission open date to the current date. This is because, even if we advise doing so immediately, if you spend any time on any other tabs before the timing tab, it won't be current, so we need to reset it so the user doesn't have to.