### PR TITLE
chore: rm redundant tailwind plugin

### DIFF
--- a/packages/react-app-revamp/tailwind.config.js
+++ b/packages/react-app-revamp/tailwind.config.js
@@ -370,5 +370,5 @@ module.exports = {
       transform: ["hover"],
     },
   },
-  plugins: [require("tailwindcss-logical"), require("@tailwindcss/typography"), require("@tailwindcss/line-clamp")],
+  plugins: [require("tailwindcss-logical"), require("@tailwindcss/typography")],
 };


### PR DESCRIPTION
rmed to get rid of this warning when running `turbo build`/in the Vercel builds generally.

<img width="835" alt="Screenshot 2023-12-02 at 10 05 47 AM" src="https://github.com/jk-labs-inc/jokerace/assets/27874039/2df9eda8-c457-41c3-b775-f2990baa6a48">
