### PR TITLE
chore: bump maximumFileSizeToCacheInBytes to 5mb

### DIFF
--- a/packages/react-app-revamp/next.config.js
+++ b/packages/react-app-revamp/next.config.js
@@ -23,4 +23,5 @@ module.exports = withPWA({
   register: true,
   skipWaiting: true,
   disable: process.env.NODE_ENV === "development",
+  maximumFileSizeToCacheInBytes: 5 * 1024 * 1024, // 5mb
 })(nextConfig);


### PR DESCRIPTION
gets rid of this warning, and I don't think we need to worry about this bc we do a ton of caching at the Cloudflare layer, so Vercel is saved the brunt of loading this stuff, and it's not all that much for Vercel anyways, so worth it for performance and clean builds.

<img width="907" alt="Screenshot 2023-12-02 at 10 19 14 AM" src="https://github.com/jk-labs-inc/jokerace/assets/27874039/3a9d45f7-a5a3-46d7-859a-42c639694377">
