### PR TITLE
bugfix: remove max-height on contest-prompt

### DIFF
--- a/packages/react-app-revamp/components/_pages/Contest/components/Prompt/components/Page/components/Layout/Legacy/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/components/Prompt/components/Page/components/Layout/Legacy/index.tsx
@@ -6,7 +6,6 @@ import { FC, ReactNode, RefObject } from "react";
 interface ContestPromptPageLegacyLayoutProps {
   prompt: string;
   isExpanded: boolean;
-  maxHeight: string;
   contentRef: RefObject<HTMLDivElement>;
   displayReadMore: boolean;
   handleToggle: () => void;
@@ -27,7 +26,6 @@ const transform = (node: HTMLElement, children: Node[]): ReactNode => {
 const ContestPromptPageLegacyLayout: FC<ContestPromptPageLegacyLayoutProps> = ({
   prompt,
   isExpanded,
-  maxHeight,
   contentRef,
   displayReadMore,
   handleToggle,
@@ -39,11 +37,7 @@ const ContestPromptPageLegacyLayout: FC<ContestPromptPageLegacyLayoutProps> = ({
       </div>
       <div className="pl-5">
         <div className="border-l border-true-white">
-          <div
-            className="prose prose-invert pl-5 overflow-hidden transition-max-height duration-500 ease-in-out"
-            style={{ maxHeight: isExpanded ? maxHeight : "3em" }}
-            ref={contentRef}
-          >
+          <div className="prose prose-invert pl-5 overflow-hidden" style={{ maxHeight: "999em" }} ref={contentRef}>
             <Interweave content={prompt} matchers={[new UrlMatcher("url")]} transform={transform} />
           </div>
           {displayReadMore && (

--- a/packages/react-app-revamp/components/_pages/Contest/components/Prompt/components/Page/components/Layout/Legacy/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/components/Prompt/components/Page/components/Layout/Legacy/index.tsx
@@ -6,7 +6,6 @@ import { FC, ReactNode, RefObject } from "react";
 interface ContestPromptPageLegacyLayoutProps {
   prompt: string;
   isExpanded: boolean;
-  contentRef: RefObject<HTMLDivElement>;
   displayReadMore: boolean;
   handleToggle: () => void;
 }
@@ -26,7 +25,6 @@ const transform = (node: HTMLElement, children: Node[]): ReactNode => {
 const ContestPromptPageLegacyLayout: FC<ContestPromptPageLegacyLayoutProps> = ({
   prompt,
   isExpanded,
-  contentRef,
   displayReadMore,
   handleToggle,
 }) => {
@@ -37,7 +35,7 @@ const ContestPromptPageLegacyLayout: FC<ContestPromptPageLegacyLayoutProps> = ({
       </div>
       <div className="pl-5">
         <div className="border-l border-true-white">
-          <div className="prose prose-invert pl-5 overflow-hidden" style={{ maxHeight: "999em" }} ref={contentRef}>
+          <div className="prose prose-invert pl-5 overflow-hidden" style={{ maxHeight: "999em" }}>
             <Interweave content={prompt} matchers={[new UrlMatcher("url")]} transform={transform} />
           </div>
           {displayReadMore && (

--- a/packages/react-app-revamp/components/_pages/Contest/components/Prompt/components/Page/components/Layout/V3/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/components/Prompt/components/Page/components/Layout/V3/index.tsx
@@ -9,7 +9,6 @@ interface ContestPromptPageV3LayoutProps {
   summaryContent: string;
   evaluateContent: string;
   isExpanded: boolean;
-  maxHeight: string;
   contentRef: RefObject<HTMLDivElement>;
   displayReadMore: boolean;
   shouldDisplayEvaluate: boolean;
@@ -22,7 +21,6 @@ const ContestPromptPageV3Layout: FC<ContestPromptPageV3LayoutProps> = ({
   summaryContent,
   evaluateContent,
   isExpanded,
-  maxHeight,
   contentRef,
   displayReadMore,
   shouldDisplayEvaluate,
@@ -38,11 +36,7 @@ const ContestPromptPageV3Layout: FC<ContestPromptPageV3LayoutProps> = ({
       </div>
       <div className="pl-5">
         <div className="border-l border-true-white">
-          <div
-            className=" overflow-hidden transition-max-height duration-500 ease-in-out"
-            style={{ maxHeight: isExpanded ? maxHeight : "10em" }}
-            ref={contentRef}
-          >
+          <div className="overflow-hidden" style={{ maxHeight: "999em" }} ref={contentRef}>
             <div className="prose prose-invert pl-5 flex flex-col">
               <Interweave content={summaryContent} matchers={[new UrlMatcher("url")]} />
               {shouldDisplayEvaluate ? (

--- a/packages/react-app-revamp/components/_pages/Contest/components/Prompt/components/Page/components/Layout/V3/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/components/Prompt/components/Page/components/Layout/V3/index.tsx
@@ -9,7 +9,6 @@ interface ContestPromptPageV3LayoutProps {
   summaryContent: string;
   evaluateContent: string;
   isExpanded: boolean;
-  contentRef: RefObject<HTMLDivElement>;
   displayReadMore: boolean;
   shouldDisplayEvaluate: boolean;
   handleToggle: () => void;
@@ -21,7 +20,6 @@ const ContestPromptPageV3Layout: FC<ContestPromptPageV3LayoutProps> = ({
   summaryContent,
   evaluateContent,
   isExpanded,
-  contentRef,
   displayReadMore,
   shouldDisplayEvaluate,
   handleToggle,
@@ -36,7 +34,7 @@ const ContestPromptPageV3Layout: FC<ContestPromptPageV3LayoutProps> = ({
       </div>
       <div className="pl-5">
         <div className="border-l border-true-white">
-          <div className="overflow-hidden" style={{ maxHeight: "999em" }} ref={contentRef}>
+          <div className="overflow-hidden" style={{ maxHeight: "999em" }}>
             <div className="prose prose-invert pl-5 flex flex-col">
               <Interweave content={summaryContent} matchers={[new UrlMatcher("url")]} />
               {shouldDisplayEvaluate ? (

--- a/packages/react-app-revamp/components/_pages/Contest/components/Prompt/components/Page/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/components/Prompt/components/Page/index.tsx
@@ -13,15 +13,8 @@ const MAX_LENGTH = 100;
 const ContestPromptPage: FC<ContestPromptPageProps> = ({ prompt }) => {
   const { isV3 } = useContestStore(state => state);
   const [isExpanded, setIsExpanded] = useState(false);
-  const [maxHeight, setMaxHeight] = useState("0px");
   const contentRef = useRef<HTMLDivElement>(null);
   const [contestType, contestTitle, contestSummary, contestEvaluate] = prompt.split("|");
-
-  useEffect(() => {
-    if (contentRef.current) {
-      setMaxHeight(`${contentRef.current.scrollHeight}px`);
-    }
-  }, [contentRef, isExpanded]);
 
   const shouldDisplayReadMore = () => {
     if (!isV3) {
@@ -61,7 +54,6 @@ const ContestPromptPage: FC<ContestPromptPageProps> = ({ prompt }) => {
           summaryContent={getSummaryContent()}
           evaluateContent={getEvaluateContent()}
           isExpanded={isExpanded}
-          maxHeight={maxHeight}
           contentRef={contentRef}
           displayReadMore={shouldDisplayReadMore()}
           shouldDisplayEvaluate={shouldDisplayEvaluate()}
@@ -71,7 +63,6 @@ const ContestPromptPage: FC<ContestPromptPageProps> = ({ prompt }) => {
         <ContestPromptPageLegacyLayout
           prompt={prompt}
           isExpanded={isExpanded}
-          maxHeight={maxHeight}
           contentRef={contentRef}
           displayReadMore={shouldDisplayReadMore()}
           handleToggle={toggleExpand}

--- a/packages/react-app-revamp/components/_pages/Contest/components/Prompt/components/Page/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/components/Prompt/components/Page/index.tsx
@@ -13,7 +13,6 @@ const MAX_LENGTH = 100;
 const ContestPromptPage: FC<ContestPromptPageProps> = ({ prompt }) => {
   const { isV3 } = useContestStore(state => state);
   const [isExpanded, setIsExpanded] = useState(false);
-  const contentRef = useRef<HTMLDivElement>(null);
   const [contestType, contestTitle, contestSummary, contestEvaluate] = prompt.split("|");
 
   const shouldDisplayReadMore = () => {
@@ -54,7 +53,6 @@ const ContestPromptPage: FC<ContestPromptPageProps> = ({ prompt }) => {
           summaryContent={getSummaryContent()}
           evaluateContent={getEvaluateContent()}
           isExpanded={isExpanded}
-          contentRef={contentRef}
           displayReadMore={shouldDisplayReadMore()}
           shouldDisplayEvaluate={shouldDisplayEvaluate()}
           handleToggle={toggleExpand}
@@ -63,7 +61,6 @@ const ContestPromptPage: FC<ContestPromptPageProps> = ({ prompt }) => {
         <ContestPromptPageLegacyLayout
           prompt={prompt}
           isExpanded={isExpanded}
-          contentRef={contentRef}
           displayReadMore={shouldDisplayReadMore()}
           handleToggle={toggleExpand}
         />


### PR DESCRIPTION
I saw that on https://jokerace.xyz/contest/unique/0xf905aF366b5a7C14B514CB523b40CA5C4be7f3EB if you try read more and read less, on the first time, prompt is not expanded fully due to incorrect calculation of max-height.

I figured out and it is best practice, to set that max-height to 999em and not worry about it!