### PR TITLE
fmt: use double quotes

### DIFF
--- a/packages/react-app-revamp/components/_pages/Contest/Rewards/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/Rewards/index.tsx
@@ -19,7 +19,7 @@ import { useRewardsStore } from "@hooks/useRewards/store";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { useAccount } from "wagmi";
-import { compareVersions } from 'compare-versions';
+import { compareVersions } from "compare-versions";
 
 const ContestRewards = () => {
   const { asPath } = useRouter();

--- a/packages/react-app-revamp/components/_pages/DialogModalProposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalProposal/index.tsx
@@ -17,7 +17,7 @@ import { useUserStore } from "@hooks/useUser/store";
 import Image from "next/image";
 import { FC, useEffect } from "react";
 import { useAccount } from "wagmi";
-import { compareVersions } from 'compare-versions';
+import { compareVersions } from "compare-versions";
 import ListProposalVotes from "../ListProposalVotes";
 import { Proposal } from "../ProposalContent";
 import { COMMENTS_VERSION } from "lib/proposal";

--- a/packages/react-app-revamp/components/_pages/Submission/Mobile/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Submission/Mobile/index.tsx
@@ -20,7 +20,7 @@ import { useAccountModal, useConnectModal } from "@rainbow-me/rainbowkit";
 import Image from "next/image";
 import { FC } from "react";
 import { useAccount } from "wagmi";
-import { compareVersions } from 'compare-versions';
+import { compareVersions } from "compare-versions";
 import { COMMENTS_VERSION } from "lib/proposal";
 
 interface SubmissionPageMobileLayoutProps {

--- a/packages/react-app-revamp/hooks/useContest/index.ts
+++ b/packages/react-app-revamp/hooks/useContest/index.ts
@@ -21,7 +21,7 @@ import { useState } from "react";
 import { useContestStore } from "./store";
 import { getV1Contracts } from "./v1/contracts";
 import { getContracts } from "./v3v4/contracts";
-import { compareVersions } from 'compare-versions';
+import { compareVersions } from "compare-versions";
 
 interface ContractConfigResult {
   contractConfig: {

--- a/packages/react-app-revamp/hooks/useContest/v3v4/contracts.ts
+++ b/packages/react-app-revamp/hooks/useContest/v3v4/contracts.ts
@@ -1,4 +1,4 @@
-import { compareVersions } from 'compare-versions';
+import { compareVersions } from "compare-versions";
 export function getContracts(contractConfig: any, version: number) {
   const commonFunctionNames = [
     "name",

--- a/packages/react-app-revamp/lib/proposal/index.ts
+++ b/packages/react-app-revamp/lib/proposal/index.ts
@@ -4,7 +4,7 @@ import { MappedProposalIds } from "@hooks/useProposal/store";
 import { getProposalIdsRaw } from "@hooks/useProposal/utils";
 import { BigNumber, utils } from "ethers";
 import { readContracts } from "wagmi";
-import { compareVersions } from 'compare-versions';
+import { compareVersions } from "compare-versions";
 
 interface RankDictionary {
   [key: string]: number;


### PR DESCRIPTION
used single quotes for `compareVersions` import in #1110 and just fixing to make formatting cleaner and consistent.