### PR TITLE
chore: invoke process user qualifications immediately after contract results

### DIFF
--- a/packages/react-app-revamp/hooks/useContest/v3v4/contracts.ts
+++ b/packages/react-app-revamp/hooks/useContest/v3v4/contracts.ts
@@ -10,6 +10,8 @@ export function getContracts(contractConfig: any, version: number) {
     "voteStart",
     "prompt",
     "downvotingAllowed",
+    "submissionMerkleRoot",
+    "votingMerkleRoot",
   ];
 
   const v4FunctionNames = ["costToPropose", "percentageToCreator"];


### PR DESCRIPTION
I have noticed that is is better to fetch for merkle roots in the batch when we fetch contract data results, since we can invoke process user qualifications fn immediately after it.