### PR TITLE
chore: bump maximumFileSizeToCacheInBytes to 10mb

### DIFF
--- a/packages/react-app-revamp/next.config.js
+++ b/packages/react-app-revamp/next.config.js
@@ -23,5 +23,5 @@ module.exports = withPWA({
   register: true,
   skipWaiting: true,
   disable: process.env.NODE_ENV === "development",
-  maximumFileSizeToCacheInBytes: 6 * 1024 * 1024, // 5mb
+  maximumFileSizeToCacheInBytes: 10 * 1024 * 1024, // 5mb
 })(nextConfig);


### PR DESCRIPTION
Was getting the complaint that Vercel wasn't able to pre-cache again [here](https://vercel.com/jokerace/jokerace/ADJxzRfgASjSFtxdLFGRPF4wAyTq) so just bumping to hopefully solve it for a while.
![image](https://github.com/jk-labs-inc/jokerace/assets/27874039/933812cd-be60-4919-bd34-1ea4b8f61435)
