### PR TITLE
bugfix: use version as string for proposal page

### DIFF
--- a/packages/react-app-revamp/components/_pages/DialogModalProposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalProposal/index.tsx
@@ -14,7 +14,6 @@ import { useUserStore } from "@hooks/useUser/store";
 import { compareVersions } from "compare-versions";
 import { COMMENTS_VERSION } from "lib/proposal";
 import Image from "next/image";
-import { useRouter } from "next/router";
 import { FC, useEffect } from "react";
 import { useAccount } from "wagmi";
 import ListProposalVotes from "../ListProposalVotes";
@@ -24,7 +23,7 @@ interface DialogModalProposalProps {
   contestInfo: {
     address: string;
     chain: string;
-    version: number;
+    version: string;
   };
   isOpen: boolean;
   prompt: string;
@@ -53,7 +52,6 @@ const DialogModalProposal: FC<DialogModalProposalProps> = ({
   onNextEntry,
   onConnectWallet,
 }) => {
-  const { query } = useRouter();
   const contestStatus = useContestStatusStore(state => state.contestStatus);
   const { isConnected } = useAccount();
   const { isSuccess } = useCastVotes();
@@ -65,7 +63,7 @@ const DialogModalProposal: FC<DialogModalProposalProps> = ({
   const { currentUserAvailableVotesAmount, currentUserTotalVotesAmount } = useUserStore(state => state);
   const outOfVotes = currentUserAvailableVotesAmount === 0 && currentUserTotalVotesAmount > 0;
   const chainId = chains.filter(chain => chain.name.toLowerCase().replace(" ", "") === contestInfo.chain)?.[0]?.id;
-  const commentsAllowed = compareVersions(contestInfo.version.toString(), COMMENTS_VERSION) == -1 ? false : true;
+  const commentsAllowed = compareVersions(contestInfo.version, COMMENTS_VERSION) == -1 ? false : true;
 
   useEffect(() => {
     if (isSuccess) setIsOpen?.(false);

--- a/packages/react-app-revamp/components/_pages/Submission/Desktop/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Submission/Desktop/index.tsx
@@ -6,7 +6,7 @@ interface SubmissionPageDesktopLayoutProps {
   contestInfo: {
     address: string;
     chain: string;
-    version: number;
+    version: string;
   };
   proposalId: string;
   prompt: string;

--- a/packages/react-app-revamp/components/_pages/Submission/Mobile/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Submission/Mobile/index.tsx
@@ -25,7 +25,7 @@ interface SubmissionPageMobileLayoutProps {
   contestInfo: {
     address: string;
     chain: string;
-    version: number;
+    version: string;
   };
   numberOfComments: number;
   proposalId: string;
@@ -62,7 +62,7 @@ const SubmissionPageMobileLayout: FC<SubmissionPageMobileLayoutProps> = ({
   const totalProposals = listProposalsIds.length;
   const outOfVotes = currentUserAvailableVotesAmount === 0 && currentUserTotalVotesAmount > 0;
   const isInPwaMode = window.matchMedia("(display-mode: standalone)").matches;
-  const commentsAllowed = compareVersions(contestInfo.version.toString(), COMMENTS_VERSION) == -1 ? false : true;
+  const commentsAllowed = compareVersions(contestInfo.version, COMMENTS_VERSION) == -1 ? false : true;
   const chainId = chains.filter(chain => chain.name.toLowerCase().replace(" ", "") === contestInfo.chain)?.[0]?.id;
 
   return (

--- a/packages/react-app-revamp/components/_pages/Submission/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Submission/index.tsx
@@ -13,7 +13,7 @@ interface SubmissionPageProps {
   contestInfo: {
     address: string;
     chain: string;
-    version: number;
+    version: string;
   };
   proposal: Proposal | null;
   proposalId: string;

--- a/packages/react-app-revamp/lib/proposal/index.ts
+++ b/packages/react-app-revamp/lib/proposal/index.ts
@@ -108,7 +108,7 @@ const fetchProposalInfo = async (address: string, chainId: number, submission: s
       votes,
       ...rankInfo,
     },
-    version: parseFloat(version),
+    version: version,
   };
 };
 

--- a/packages/react-app-revamp/pages/contest/[chain]/[address]/submission/[submission]/index.tsx
+++ b/packages/react-app-revamp/pages/contest/[chain]/[address]/submission/[submission]/index.tsx
@@ -13,7 +13,7 @@ import { FC, useEffect } from "react";
 interface PageProps {
   address: string;
   chain: string;
-  version: number;
+  version: string;
   proposal: Proposal | null;
   numberOfComments: number;
 }


### PR DESCRIPTION
`parseFloat("4.20")` was returning 4.2 instead of 4.20, which would mean that our frontend would think that the contracts for contests like [this boi](https://jokerace.xyz/contest/optimism/0xD610D18d3B3c0eeFF64F0aD54D0b4f3f8A0Bde02) and [this boi](https://jokerace.xyz/contest/arbitrumone/0x3e3770C3838aad94AE5784509c0A45016795A36f) were not high enough of a version to support comments even though they in fact were.