### PR TITLE
enhancement: add arbitrum chain to nft requirements

### DIFF
--- a/packages/react-app-revamp/components/_pages/Contest/Parameters/components/Requirements/Voting/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/Parameters/components/Requirements/Voting/index.tsx
@@ -9,6 +9,7 @@ const ContestParametersVotingRequirements = () => {
     votingRequirements?.tokenAddress ?? "",
     votingRequirements?.chain ?? "",
   );
+
   const chainExplorerUrl = chains.find(chain => chain.name === votingRequirements?.chain)?.blockExplorers?.default.url;
 
   if (!votingRequirements) return null;

--- a/packages/react-app-revamp/components/_pages/Contest/Parameters/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/Parameters/index.tsx
@@ -57,7 +57,7 @@ const ContestParameters = () => {
         <p>
           you have{" "}
           <span className="font-bold">
-            {formatNumber(currentUserAvailableVotesAmount)} votes{currentUserAvailableVotesAmount == 1 ? "" : "s"}
+            {formatNumber(currentUserAvailableVotesAmount)} vote{currentUserAvailableVotesAmount == 1 ? "" : "s"}{" "}
             {votingRequirements ? `(${votingRequirements.description})` : null}
           </span>
         </p>

--- a/packages/react-app-revamp/components/_pages/Create/components/Dropdown/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/components/Dropdown/index.tsx
@@ -4,6 +4,7 @@ import CreateTextInput from "../TextInput";
 
 export interface Option {
   value: string;
+  label: string;
   disabled?: boolean;
 }
 
@@ -24,14 +25,9 @@ const CreateDropdown: FC<CreateDropdownProps> = ({
   onChange,
   onMenuStateChange,
 }) => {
-  const [query, setQuery] = useState(value);
+  // Initial query state is set to the label of the option matching the value prop
+  const [query, setQuery] = useState(options.find(option => option.value === value)?.label || value);
   const [showOptions, setShowOptions] = useState(false);
-  const filteredOptions =
-    !searchEnabled || query === ""
-      ? options
-      : options.filter(option => {
-          return option.value.toLowerCase().includes(query.toLowerCase());
-        });
 
   const wrapperRef = useRef<HTMLDivElement>(null);
 
@@ -52,31 +48,40 @@ const CreateDropdown: FC<CreateDropdownProps> = ({
     };
   }, []);
 
-  const handleInputChange = (value: string) => {
+  const filteredOptions =
+    !searchEnabled || query === ""
+      ? options
+      : options.filter(
+          option =>
+            option.label.toLowerCase().includes(query.toLowerCase()) ||
+            option.value.toLowerCase().includes(query.toLowerCase()),
+        );
+
+  const handleInputChange = (inputValue: string) => {
+    setQuery(inputValue);
     if (searchEnabled) {
-      setQuery(value);
-      onChange?.(value);
-      const matchingOptions = options.filter(option => option.value.toLowerCase().startsWith(value.toLowerCase()));
-      if (value !== "" && matchingOptions.length > 0) {
-        setShowOptions(true);
-      } else {
-        setShowOptions(false);
-      }
+      const matchingOptions = options.filter(
+        option =>
+          option.label.toLowerCase().includes(inputValue.toLowerCase()) ||
+          option.value.toLowerCase().includes(inputValue.toLowerCase()),
+      );
+      setShowOptions(matchingOptions.length > 0);
     }
   };
 
-  const handleOptionClick = (option: string) => {
-    setQuery(option);
-    setShowOptions(false);
-    onChange?.(option);
+  const handleOptionClick = (optionValue: string) => {
+    const selectedOption = options.find(option => option.value === optionValue);
+    if (selectedOption) {
+      setQuery(selectedOption.label);
+      setShowOptions(false);
+      onChange?.(selectedOption.value);
+    }
   };
 
   const handleIconClick = () => {
-    // Only toggle `showOptions` if there are matching options
     if (filteredOptions.length > 0) {
       setShowOptions(!showOptions);
     } else {
-      // Ensure `showOptions` is false if there are no matching options
       setShowOptions(false);
     }
   };
@@ -107,7 +112,7 @@ const CreateDropdown: FC<CreateDropdownProps> = ({
               key={option.value}
               onClick={() => handleOptionClick(option.value)}
             >
-              {option.value}
+              {option.label}
             </li>
           ))}
         </ul>

--- a/packages/react-app-revamp/components/_pages/Create/components/RequirementsSettings/config.ts
+++ b/packages/react-app-revamp/components/_pages/Create/components/RequirementsSettings/config.ts
@@ -1,30 +1,40 @@
 import { Option } from "@components/_pages/Create/components/Dropdown";
 
 export const requirementsDropdownOptions: Option[] = [
-  { value: "NFT holders" },
-  { value: "token holders", disabled: true },
+  { value: "nftHolders", label: "NFT holders" },
+  { value: "erc20Holders", label: "token holders", disabled: true },
 ];
 
 export const chainDropdownOptions: Option[] = [
   {
     value: "mainnet",
+    label: "ethereum",
   },
   {
     value: "polygon",
+    label: "polygon",
+  },
+  {
+    value: "arbitrumone",
+    label: "arbitrum",
   },
   {
     value: "optimism",
+    label: "optimism",
   },
   {
     value: "base",
+    label: "base",
   },
 ];
 
 export const votingPowerOptions: Option[] = [
   {
     value: "token",
+    label: "token",
   },
   {
     value: "token holder",
+    label: "token holder",
   },
 ];

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestSubmission/components/SubmissionRequirements/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestSubmission/components/SubmissionRequirements/index.tsx
@@ -12,7 +12,11 @@ import { fetchNftHolders } from "lib/permissioning";
 import { useEffect, useState } from "react";
 import CreateSubmissionRequirementsNftSettings from "./components/NFT";
 
-const options: Option[] = [{ value: "anyone" }, { value: "voters (same requirements)" }, { value: "NFT holders" }];
+const options: Option[] = [
+  { value: "anyone", label: "anyone" },
+  { value: "voters", label: "voters (same requirements)" },
+  { value: "nftHolders", label: "NFT holders" },
+];
 
 type WorkerMessageData = {
   merkleRoot: string;
@@ -39,7 +43,7 @@ const CreateSubmissionRequirements = () => {
 
   const renderLayout = () => {
     switch (submissionRequirementsOption) {
-      case "NFT holders":
+      case "nftHolders":
         return <CreateSubmissionRequirementsNftSettings error={inputError} />;
       default:
         return null;
@@ -184,9 +188,9 @@ const CreateSubmissionRequirements = () => {
   };
 
   const handleNextStep = async () => {
-    if (submissionRequirementsOption === "voters (same requirements)") {
+    if (submissionRequirementsOption === "voters") {
       handleVotersSameRequirements();
-    } else if (submissionRequirementsOption === "NFT holders") {
+    } else if (submissionRequirementsOption === "nftHolders") {
       handleNftHolders();
     } else {
       setSubmissionAllowlistFields([]);

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestType/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestType/index.tsx
@@ -9,17 +9,17 @@ import { useNextStep } from "../../hooks/useNextStep";
 import { validationFunctions } from "../../utils/validation";
 
 const options: Option[] = [
-  { value: "hackathon" },
-  { value: "grants round" },
-  { value: "bounty" },
-  { value: "pulse check" },
-  { value: "amend a proposal" },
-  { value: "contest competition" },
-  { value: "giveaway" },
-  { value: "feature request" },
-  { value: "curation" },
-  { value: "game" },
-  { value: "election" },
+  { value: "hackathon", label: "hackathon" },
+  { value: "grants round", label: "grants round" },
+  { value: "bounty", label: "bounty" },
+  { value: "pulse check", label: "pulse check" },
+  { value: "amend a proposal", label: "amend a proposal" },
+  { value: "contest competition", label: "contest competition" },
+  { value: "giveaway", label: "giveaway" },
+  { value: "feature request", label: "feature request" },
+  { value: "curation", label: "curation" },
+  { value: "game", label: "game" },
+  { value: "election", label: "election" },
 ];
 
 const CreateContestType = () => {

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingRequirements/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingRequirements/index.tsx
@@ -52,7 +52,7 @@ const CreateVotingRequirements = () => {
 
   const renderLayout = () => {
     switch (selectedRequirement) {
-      case "NFT holders":
+      case "nftHolders":
         return <CreateVotingRequirementsNftSettings error={inputError} />;
       default:
         return null;

--- a/packages/react-app-revamp/lib/permissioning/index.ts
+++ b/packages/react-app-revamp/lib/permissioning/index.ts
@@ -14,7 +14,7 @@ export async function fetchNftHolders(
   votesPerUnit: number = 100,
   voteCalculationMethod: string = "token",
 ): Promise<Record<string, number> | Error> {
-  let baseAlchemyAppUrl = chains.filter(chain => chain.name === chainName.toLowerCase())[0].rpcUrls.default.http[0];
+  let baseAlchemyAppUrl = chains.filter(chain => chain.name == chainName.toLowerCase())[0].rpcUrls.default.http[0];
 
   baseAlchemyAppUrl = baseAlchemyAppUrl.replace(/(v2\/).*/, "$1");
 


### PR DESCRIPTION
I've noticed that we can use Arbitrum now retrieve the owners of NFT collections with Alchemy API.

To enable us to pass `arbitrumone` for the variables but maintain `arbitrum` as the label in the dropdown, i also refactored a dropdown to accept both value and label so we do not need to add those additional checks. This also applies to `ethereum` and the `mainnet`.

EDIT: I minted an NFT on Arbitrum 10 days ago, so i'm going to spin a contest to see how the community reacts :]