### PR TITLE
bugfix: add isNaN check for voting csv

### DIFF
--- a/packages/react-app-revamp/workers/parseVotingCsv.ts
+++ b/packages/react-app-revamp/workers/parseVotingCsv.ts
@@ -21,7 +21,7 @@ const processRowData = (row: any[]) => {
     error = "address";
   }
 
-  if (typeof numberOfVotes !== "number" || numberOfVotes >= MAX_VOTES) {
+  if (typeof numberOfVotes !== "number" || numberOfVotes >= MAX_VOTES || isNaN(numberOfVotes)) {
     error = error ? "both" : "votes";
   }
 


### PR DESCRIPTION
I've implemented an `isNaN` check for the number of votes column. This addition ensures that non numeric values are appropriately handled during the parsing phase,