### PR TITLE
chore: add mona lisa for missing chain logo

### DIFF
--- a/packages/react-app-revamp/components/_pages/ListContests/Contest/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListContests/Contest/index.tsx
@@ -280,8 +280,6 @@ const Contest: FC<ContestProps> = ({ contest, compact, loading, rewards, allowTo
     }
   };
 
-  console.log(chainsImages, contest.network_name);
-
   return (
     <SkeletonTheme baseColor="#706f78" highlightColor="#FFE25B" duration={1}>
       {allowToHide ? (

--- a/packages/react-app-revamp/components/_pages/ListContests/Contest/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListContests/Contest/index.tsx
@@ -280,6 +280,8 @@ const Contest: FC<ContestProps> = ({ contest, compact, loading, rewards, allowTo
     }
   };
 
+  console.log(chainsImages, contest.network_name);
+
   return (
     <SkeletonTheme baseColor="#706f78" highlightColor="#FFE25B" duration={1}>
       {allowToHide ? (

--- a/packages/react-app-revamp/config/wagmi/custom-chains/arbitrumOne.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/arbitrumOne.ts
@@ -4,6 +4,7 @@ export const arbitrumOne: Chain = {
   id: 42161,
   name: "arbitrumone",
   network: "arbitrumone",
+  iconUrl: "/arbitrum.svg",
   nativeCurrency: {
     decimals: 18,
     name: "ETH",

--- a/packages/react-app-revamp/config/wagmi/custom-chains/arbitrumOneTestnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/arbitrumOneTestnet.ts
@@ -4,6 +4,7 @@ export const arbitrumOneTestnet: Chain = {
   id: 42161,
   name: "arbitrumoneTestnet",
   network: "arbitrumoneTestnet",
+  iconUrl: "/arbitrum.svg",
   nativeCurrency: {
     decimals: 18,
     name: "ETH",

--- a/packages/react-app-revamp/config/wagmi/custom-chains/artheraTestnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/artheraTestnet.ts
@@ -4,6 +4,7 @@ export const artheraTestnet: Chain = {
   id: 10243,
   name: "artheraTestnet",
   network: "artheraTestnet",
+  iconUrl: "/contest/mona-lisa-moustache.png",
   nativeCurrency: {
     decimals: 18,
     name: "Arthera",

--- a/packages/react-app-revamp/config/wagmi/custom-chains/astriaDusk2.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/astriaDusk2.ts
@@ -4,6 +4,7 @@ export const astriaDusk2: Chain = {
   id: 912559,
   name: "astriaDusk2",
   network: "astriaDusk2",
+  iconUrl: "/contest/mona-lisa-moustache.png",
   nativeCurrency: {
     decimals: 18,
     name: "RIA",

--- a/packages/react-app-revamp/config/wagmi/custom-chains/avaxCChain.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/avaxCChain.ts
@@ -4,6 +4,7 @@ export const avaxCChain: Chain = {
   id: 43114,
   name: "Avalanche",
   network: "avaxCChain",
+  iconUrl: "/avalanche.png",
   nativeCurrency: {
     decimals: 18,
     name: "AVAX",

--- a/packages/react-app-revamp/config/wagmi/custom-chains/base.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/base.ts
@@ -4,6 +4,7 @@ export const base: Chain = {
   id: 8453,
   name: "base",
   network: "base",
+  iconUrl: "/base.svg",
   nativeCurrency: {
     decimals: 18,
     name: "Ether",

--- a/packages/react-app-revamp/config/wagmi/custom-chains/baseTestnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/baseTestnet.ts
@@ -4,6 +4,7 @@ export const baseTestnet: Chain = {
   id: 84531,
   name: "baseTestnet",
   network: "baseTestnet",
+  iconUrl: "/base.svg",
   nativeCurrency: {
     decimals: 18,
     name: "Ether",

--- a/packages/react-app-revamp/config/wagmi/custom-chains/berachainTestnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/berachainTestnet.ts
@@ -4,6 +4,7 @@ export const berachainTestnet: Chain = {
   id: 80085,
   name: "berachainTestnet",
   network: "berachainTestnet",
+  iconUrl: "/contest/mona-lisa-moustache.png",
   nativeCurrency: {
     decimals: 18,
     name: "BERA",

--- a/packages/react-app-revamp/config/wagmi/custom-chains/bnb.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/bnb.ts
@@ -4,6 +4,7 @@ export const bnb: Chain = {
   id: 56,
   name: "bnb",
   network: "bnb",
+  iconUrl: "/contest/mona-lisa-moustache.png",
   nativeCurrency: {
     decimals: 18,
     name: "BNB",

--- a/packages/react-app-revamp/config/wagmi/custom-chains/frameTestnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/frameTestnet.ts
@@ -4,6 +4,7 @@ export const frameTestnet: Chain = {
   id: 68840142,
   name: "frameTestnet",
   network: "frameTestnet",
+  iconUrl: "/contest/mona-lisa-moustache.png",
   nativeCurrency: {
     decimals: 18,
     name: "ETH",

--- a/packages/react-app-revamp/config/wagmi/custom-chains/goerli.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/goerli.ts
@@ -4,6 +4,7 @@ export const goerli: Chain = {
   id: 5,
   name: "goerli",
   network: "goerli",
+  iconUrl: "/ethereum.svg",
   nativeCurrency: {
     decimals: 18,
     name: "ETH",

--- a/packages/react-app-revamp/config/wagmi/custom-chains/holesky.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/holesky.ts
@@ -4,6 +4,7 @@ export const holesky: Chain = {
   id: 17000,
   name: "holesky",
   network: "holesky",
+  iconUrl: "/contest/mona-lisa-moustache.png",
   nativeCurrency: {
     decimals: 18,
     name: "Ether",

--- a/packages/react-app-revamp/config/wagmi/custom-chains/neonDevnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/neonDevnet.ts
@@ -4,6 +4,7 @@ export const neonDevnet: Chain = {
   id: 245022926,
   name: "neonDevnet",
   network: "neonDevnet",
+  iconUrl: "/contest/mona-lisa-moustache.png",
   nativeCurrency: {
     decimals: 18,
     name: "NEON",

--- a/packages/react-app-revamp/config/wagmi/custom-chains/proteus.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/proteus.ts
@@ -4,6 +4,7 @@ export const proteus: Chain = {
   id: 88002,
   name: "proteus",
   network: "proteus",
+  iconUrl: "/contest/mona-lisa-moustache.png",
   nativeCurrency: {
     decimals: 18,
     name: "tZBC",

--- a/packages/react-app-revamp/config/wagmi/custom-chains/redstoneHolesky.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/redstoneHolesky.ts
@@ -4,6 +4,7 @@ export const redstoneHolesky: Chain = {
   id: 17001,
   name: "redstoneHolesky",
   network: "redstoneHolesky",
+  iconUrl: "/contest/mona-lisa-moustache.png",
   nativeCurrency: {
     decimals: 18,
     name: "Ether",

--- a/packages/react-app-revamp/config/wagmi/custom-chains/ronin.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/ronin.ts
@@ -4,6 +4,7 @@ export const ronin: Chain = {
   id: 2020,
   name: "ronin",
   network: "ronin",
+  iconUrl: "/contest/mona-lisa-moustache.png",
   nativeCurrency: {
     decimals: 18,
     name: "RON",

--- a/packages/react-app-revamp/config/wagmi/custom-chains/roninTestnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/roninTestnet.ts
@@ -4,6 +4,7 @@ export const roninTestnet: Chain = {
   id: 2021,
   name: "roninTestnet",
   network: "roninTestnet",
+  iconUrl: "/contest/mona-lisa-moustache.png",
   nativeCurrency: {
     decimals: 18,
     name: "tRON",

--- a/packages/react-app-revamp/config/wagmi/custom-chains/taikoTestnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/taikoTestnet.ts
@@ -4,6 +4,7 @@ export const taikoTestnet: Chain = {
   id: 167007,
   name: "taikoTestnet",
   network: "taikoTestnet",
+  iconUrl: "/contest/mona-lisa-moustache.png",
   nativeCurrency: {
     decimals: 18,
     name: "ETH",

--- a/packages/react-app-revamp/config/wagmi/custom-chains/x1Testnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/x1Testnet.ts
@@ -4,6 +4,7 @@ export const x1Testnet: Chain = {
   id: 195,
   name: "x1Testnet",
   network: "x1Testnet",
+  iconUrl: "/contest/mona-lisa-moustache.png",
   nativeCurrency: {
     decimals: 18,
     name: "OKB",

--- a/packages/react-app-revamp/config/wagmi/index.ts
+++ b/packages/react-app-revamp/config/wagmi/index.ts
@@ -1,4 +1,4 @@
-import { connectorsForWallets } from "@rainbow-me/rainbowkit";
+import { Chain, connectorsForWallets } from "@rainbow-me/rainbowkit";
 import {
   argentWallet,
   bitKeepWallet,
@@ -16,7 +16,7 @@ import {
 } from "@rainbow-me/rainbowkit/wallets";
 import { luksoWallet } from "./custom-wallets/luksoWallet";
 
-import { Chain, configureChains, createConfig } from "wagmi";
+import { configureChains, createConfig } from "wagmi";
 import { jsonRpcProvider } from "wagmi/providers/jsonRpc";
 import { arbitrumOne } from "./custom-chains/arbitrumOne";
 import { artheraTestnet } from "./custom-chains/artheraTestnet";
@@ -212,64 +212,9 @@ export const config = createConfig({
   webSocketPublicClient,
 });
 
-export const chainsImages: ChainImages = {
-  avalanche: "/avalanche.png",
-  harmony: "/harmony.png",
-  arbitrum: "/arbitrum.svg",
-  arbitrumone: "/arbitrum.svg",
-  arbitrumrinkeby: "/arbitrum.svg",
-  optimismkovan: "/optimism.svg",
-  optimism: "/optimism.svg",
-  ethereum: "/ethereum.svg",
-  hardhat: "/hardhat.svg",
-  rinkeby: "/ethereum.svg",
-  ropsten: "/ethereum.svg",
-  sepolia: "/ethereum.svg",
-  localhost: "/ethereum.svg",
-  goerli: "/ethereum.svg",
-  kovan: "/ethereum.svg",
-  polygon: "/polygon.svg",
-  polygontestnet: "/polygon.svg",
-  polygonzktestnet: "/polygon.svg",
-  polygonzk: "/polygon.svg",
-  scroll: "/scroll.svg",
-  scrolltestnet: "/scroll.svg",
-  base: "/base.svg",
-  gnosis: "/gnosis.png",
-  gnosistestnet: "/gnosis.png",
-  publicgoodsnetwork: "/publicgoodsnetwork.svg",
-  publicgoodsnetworktestnet: "/publicgoodsnetwork.svg",
-  lootchain: "/lootchain.svg",
-  lootchaintestnet: "/lootchain.svg",
-  celo: "/celo.svg",
-  celotestnet: "/celo.svg",
-  evmos: "/evmos.svg",
-  evmostestnet: "/evmos.svg",
-  linea: "/linea.svg",
-  lineatestnet: "/linea.svg",
-  littestnet: "/lit.svg",
-  lukso: "/lukso.svg",
-  luksotestnet: "/lukso.svg",
-  mantaPacific: "/mantaPacific.svg",
-  mantle: "/mantle.svg",
-  mantletestnet: "/mantle.svg",
-  nautilusChain: "/nautilusChain.png",
-  near: "/aurora.svg",
-  neartestnet: "/aurora.svg",
-  zetatestnet: "/zeta.svg",
-  zora: "/zora.png",
-  qchain: "/qchain.svg",
-  qchaintestnet: "/qchain.svg",
-  eos: "/eos.svg",
-  eostestnet: "/eos.svg",
-  fuse: "/fuse.svg",
-  kroma: "/kroma.svg",
-  mainnet: "/ethereum.svg",
-  quartz: "/quartz.svg",
-  unique: "/unique.svg",
-  vitruveo: "/vitruveo.svg",
-  mode: "/mode.svg",
-  modetestnet: "/mode.svg",
-  fantom: "/fantom.svg",
-  fantomtestnet: "/fantom.svg",
-};
+export const chainsImages: ChainImages = totalChains.reduce((acc, chain) => {
+  if (chain.name && chain.iconUrl) {
+    acc[chain.name.toLowerCase()] = chain.iconUrl as string;
+  }
+  return acc;
+}, {} as ChainImages);


### PR DESCRIPTION
In this PR, the default logo for any chain for which we do not currently have a logo is mona lisa.

If we don't currently have a logo, all we have to do is apply `/contest/mona-lisa-moustache.png` to the `iconUrl` property when we add chain later on.

Example here:
```
export const artheraTestnet: Chain = {
  id: 10243,
  name: "artheraTestnet",
  network: "artheraTestnet",
  iconUrl: "/contest/mona-lisa-moustache.png",
  nativeCurrency: {
    decimals: 18,
    name: "Arthera",
    symbol: "AA",
  },
  rpcUrls: {
    public: { http: ["https://rpc-test.arthera.net"] },
    default: { http: ["https://rpc-test.arthera.net"] },
  },
  blockExplorers: {
    etherscan: { name: "Arthera Testnet Scan", url: "https://explorer-test.arthera.net" },
    default: { name: "Arthera Testnet Scan", url: "https://explorer-test.arthera.net" },
  },
  testnet: true,
};

```