### PR TITLE
bugfix: reset file input after image upload in editor

### DIFF
--- a/packages/react-app-revamp/components/UI/TipTapEditorControls/index.tsx
+++ b/packages/react-app-revamp/components/UI/TipTapEditorControls/index.tsx
@@ -6,7 +6,6 @@ import {
   IconEditorListOrdered,
   IconEditorListUnordered,
   IconEditorQuote,
-  IconEditorRemoveAnchor,
 } from "@components/UI/Icons";
 import { useUploadImageStore } from "@hooks/useUploadImage";
 import { Editor } from "@tiptap/react";
@@ -44,6 +43,10 @@ export const TipTapEditorControls = (props: TipTapEditorControlsProps) => {
         }
       } catch (error) {
         console.error("Failed to upload image:", error);
+      }
+
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
       }
     }
   };


### PR DESCRIPTION
Closes #1274 

Issue was that input file reference wasn't cleared after user uploads an image in submission.