### PR TITLE
enhancement: increase line clamp in proposal preview

### DIFF
--- a/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
@@ -73,7 +73,7 @@ const ProposalContent: FC<ProposalContentProps> = ({ proposal }) => {
         />
         <div className="flex items-center overflow-hidden px-14 h-64 md:h-52">
           <Interweave
-            className="line-clamp-6 md:line-clamp-4 markdown overflow-y-hidden text-[16px] md:text-[18px]"
+            className="line-clamp-6 md:line-clamp-5 markdown overflow-y-hidden text-[16px] md:text-[18px]"
             content={truncatedContent}
             transform={transform}
           />


### PR DESCRIPTION
This is only a small increase in the size of `line-clamp` for desktop; we won't be using `line-clamp` in the near future because we will be returning to the proposal's content truncation. This is just a small enhancement while we are here.