### PR TITLE
bugfix: remove padding in dialog v3 on mobile

### DIFF
--- a/packages/react-app-revamp/components/UI/DialogModalV3/index.tsx
+++ b/packages/react-app-revamp/components/UI/DialogModalV3/index.tsx
@@ -51,7 +51,7 @@ const DialogModalV3: FC<DialogModalProps> = ({
                 <Image src="/modal/modal_close.svg" width={39} height={33} alt="close" />
                 <span className="sr-only">Close modal</span>
               </button>
-              <div className={`${isMobile ? "pt-0" : "pt-20"} 2xs:pt-3 pie-3`}>{children}</div>
+              <div className={`${isMobile ? "pt-0" : "pt-3"} pie-3`}>{children}</div>
             </div>
           </Dialog.Panel>
         </div>

--- a/packages/react-app-revamp/components/UI/DialogModalV3/index.tsx
+++ b/packages/react-app-revamp/components/UI/DialogModalV3/index.tsx
@@ -37,7 +37,7 @@ const DialogModalV3: FC<DialogModalProps> = ({
       <div className="fixed inset-0 flex items-center justify-center 2xs:p-4">
         <div className="flex min-h-full w-full items-center justify-center">
           <Dialog.Panel
-            className={`text-sm mx-auto min-h-screen max-h-screen overflow-y-auto 2xs:min-h-auto 2xs:max-h-[calc(100vh-60px)] w-screen px-4 pb-6 2xs:pt-4 bg-true-black 2xs:rounded-[10px] ${className}`}
+            className={`text-sm mx-auto min-h-screen max-h-screen overflow-y-auto 2xs:min-h-auto 2xs:max-h-[calc(100vh-60px)] w-screen px-4 2xs:pt-4 bg-true-black 2xs:rounded-[10px] ${className}`}
           >
             <Dialog.Title className="sr-only">{title}</Dialog.Title>
             <div className="p-2 relative">


### PR DESCRIPTION
On mobile devices, I've noticed there is a small padding at the top and bottom, so the submission does not display full-screen.