### PR TITLE
enhancement: add unexpected headers error in csv parse

### DIFF
--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestSubmission/components/SubmissionAllowlist/components/CSVEditor/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestSubmission/components/SubmissionAllowlist/components/CSVEditor/index.tsx
@@ -101,16 +101,11 @@ const CSVEditorSubmission: FC<CSVEditorProps> = ({ onChange }) => {
     const results = await parseSubmissionCsv(file, address);
 
     switch (results.error?.kind) {
+      case "unexpectedHeaders":
       case "missingColumns":
-        setParseError("missingColumns");
-        addEmptyFields();
-        return;
       case "limitExceeded":
-        setParseError("limitExceeded");
-        addEmptyFields();
-        return;
       case "duplicates":
-        setParseError("duplicates");
+        setParseError(results.error?.kind);
         addEmptyFields();
         return;
       default:

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingAllowlist/components/CSVEditor/CSVParseError/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingAllowlist/components/CSVEditor/CSVParseError/index.tsx
@@ -2,7 +2,7 @@ import { MAX_ROWS } from "@helpers/csvConstants";
 import { formatNumber } from "@helpers/formatNumber";
 import { FC, ReactNode, useMemo } from "react";
 
-export type ParseError = "missingColumns" | "limitExceeded" | "duplicates" | "allZero" | "";
+export type ParseError = "unexpectedHeaders" | "missingColumns" | "limitExceeded" | "duplicates" | "allZero" | "";
 
 interface CSVParseErrorProps {
   step: "voting" | "submission";
@@ -15,6 +15,7 @@ const CSVParseError: FC<CSVParseErrorProps> = ({ type, step }) => {
 
     switch (type) {
       case "missingColumns":
+      case "unexpectedHeaders":
         return (
           <div className="flex flex-col text-[16px] animate-fadeIn">
             {step === "voting" ? (

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingAllowlist/components/CSVEditor/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingAllowlist/components/CSVEditor/index.tsx
@@ -126,6 +126,7 @@ const CSVEditorVoting: FC<CSVEditorProps> = ({ onChange }) => {
     const results = await parseCsvVoting(file, address);
 
     switch (results.error?.kind) {
+      case "unexpectedHeaders":
       case "missingColumns":
       case "limitExceeded":
       case "duplicates":

--- a/packages/react-app-revamp/helpers/csvTypes.ts
+++ b/packages/react-app-revamp/helpers/csvTypes.ts
@@ -10,6 +10,7 @@ export type SubmissionInvalidEntry = {
 };
 
 export type CommonValidationError =
+  | { kind: "unexpectedHeaders" }
   | { kind: "missingColumns" }
   | { kind: "limitExceeded" }
   | { kind: "duplicates" }

--- a/packages/react-app-revamp/workers/parseSubmissionCsv.ts
+++ b/packages/react-app-revamp/workers/parseSubmissionCsv.ts
@@ -21,6 +21,7 @@ self.onmessage = async (event: MessageEvent) => {
   const addressData: string[] = [];
   const invalidEntries: SubmissionInvalidEntry[] = [];
   const addresses: Set<string> = new Set();
+  const unexpectedHeaders = ["address"];
 
   if (data.length > MAX_ROWS) {
     if (userAddress) {
@@ -33,6 +34,17 @@ self.onmessage = async (event: MessageEvent) => {
       self.postMessage({ data: {}, invalidEntries, error: { kind: "limitExceeded" } });
       return;
     }
+  }
+
+  if (data[0].some((value: any) => unexpectedHeaders.includes(value.toString().toLowerCase()))) {
+    self.postMessage({
+      data: {},
+      invalidEntries,
+      error: {
+        kind: "unexpectedHeaders",
+      },
+    });
+    return;
   }
 
   const expectedColumns = 1;

--- a/packages/react-app-revamp/workers/parseVotingCsv.ts
+++ b/packages/react-app-revamp/workers/parseVotingCsv.ts
@@ -33,6 +33,7 @@ self.onmessage = async (event: MessageEvent<ParseVotingCsvPayload>) => {
   const votesData: Record<string, number> = {};
   const invalidEntries: VotingInvalidEntry[] = [];
   const addresses: Set<string> = new Set();
+  const unexpectedHeaders = ["address", "number of votes", "numVotes"];
   let roundedZeroCount = 0;
 
   if (data.length > MAX_ROWS) {
@@ -46,6 +47,17 @@ self.onmessage = async (event: MessageEvent<ParseVotingCsvPayload>) => {
       self.postMessage({ data: {}, invalidEntries, error: { kind: "limitExceeded" } });
       return;
     }
+  }
+
+  if (data[0].some((value: any) => unexpectedHeaders.includes(value.toString().toLowerCase()))) {
+    self.postMessage({
+      data: {},
+      invalidEntries,
+      error: {
+        kind: "unexpectedHeaders",
+      },
+    });
+    return;
   }
 
   if (data[0].length !== 2) {


### PR DESCRIPTION
I tried to trigger behaviour in #1209, but i was unable to do it in any way. I believe we should close it for now.
First off, you can only apply for the waitlist at this time; you are unable to download Arc for Windows.

Secondly, i took the user address that they gave in the issue as the one that went on to create the contest, therefore i extracted the CSV file from that contest that contained 62k addresses. While i was there, i discovered that even though headers are not allowed, we do not raise a typical error if they are included, but rather we show it in the preview ( we should raise typical error in case of headers imo ) 

Therefore, i went ahead and added catch for the unexpected headers when CSV is being parsed.