### PR TITLE
bugfix: use chain from submission requirements in contests list

### DIFF
--- a/packages/react-app-revamp/components/_pages/ListContests/Contest/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListContests/Contest/index.tsx
@@ -80,7 +80,7 @@ const Contest: FC<ContestProps> = ({ contest, compact, loading, rewards, allowTo
   const { tokenSymbol: submissionRequirementToken, isLoading: isSubmissionRequirementTokenLoading } = useTokenDetails(
     submissionRequirement?.type,
     submissionRequirement?.tokenAddress,
-    votingRequirement?.chain,
+    submissionRequirement?.chain,
   );
 
   const getContestUrl = (contest: { network_name: string; address: string }) => {
@@ -233,7 +233,8 @@ const Contest: FC<ContestProps> = ({ contest, compact, loading, rewards, allowTo
           <p>
             for{" "}
             <span className="uppercase">
-              {submissionRequirement?.type === "erc20" ? "$" : ""} {submissionRequirementToken}
+              {submissionRequirement?.type === "erc20" ? "$" : ""}
+              {submissionRequirementToken}
             </span>{" "}
             holders
           </p>

--- a/packages/react-app-revamp/hooks/useContestInfo/index.tsx
+++ b/packages/react-app-revamp/hooks/useContestInfo/index.tsx
@@ -48,7 +48,7 @@ const useContestInfo = ({
   const { tokenSymbol: submissionRequirementToken, isLoading: isSubmissionRequirementTokenLoading } = useTokenDetails(
     submissionRequirement?.type,
     submissionRequirement?.tokenAddress,
-    votingRequirement?.chain,
+    submissionRequirement?.chain,
   );
 
   useEffect(() => {
@@ -127,7 +127,8 @@ const useContestInfo = ({
             <p>
               for{" "}
               <span className="uppercase">
-                {submissionRequirement?.type === "erc20" ? "$" : ""} {submissionRequirementToken}
+                {submissionRequirement?.type === "erc20" ? "$" : ""}
+                {submissionRequirementToken}
               </span>{" "}
               holders
             </p>
@@ -145,7 +146,8 @@ const useContestInfo = ({
           <p>
             for{" "}
             <span className="uppercase">
-              {submissionRequirement?.type === "erc20" ? "$" : ""} {submissionRequirementToken}
+              {submissionRequirement?.type === "erc20" ? "$" : ""}
+              {submissionRequirementToken}
             </span>{" "}
             holders
           </p>

--- a/packages/react-app-revamp/hooks/useTokenDetails/index.ts
+++ b/packages/react-app-revamp/hooks/useTokenDetails/index.ts
@@ -5,12 +5,13 @@ import { Abi } from "viem";
 
 const useTokenDetails = (tokenType: string, tokenAddress: string, chain: string) => {
   const [tokenSymbol, setTokenSymbol] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isSuccess, setIsSuccess] = useState<boolean>(false);
   const chainId = chains.find(c => c.name === chain)?.id;
 
   useEffect(() => {
     if (!tokenAddress || !chainId || !tokenType) return;
+    setIsLoading(true);
 
     const fetchTokenDetails = async () => {
       try {


### PR DESCRIPTION
I noticed that there is an infinite loading skeleton for the [Demo hack by DAO](https://jokerace.xyz/contest/optimism/0x897B3F3aa54A5a62FaC7BAb0Ac41DF26b6546145) contest in the list of contests for the submission requirements.

It looks like we were passing chain from `votingRequirements` rather than `submissionRequirements` in the list of contests.

![image](https://github.com/jk-labs-inc/jokerace/assets/18723426/9d04b643-2ca2-44d6-bcb3-9e6d3603ccc8)