### PR TITLE
bugfix: use name or symbol for token details in params tab

### DIFF
--- a/packages/react-app-revamp/hooks/useTokenDetails/index.ts
+++ b/packages/react-app-revamp/hooks/useTokenDetails/index.ts
@@ -16,21 +16,28 @@ const useTokenDetails = (tokenType: string, tokenAddress: string, chain: string)
     const fetchTokenDetails = async () => {
       try {
         const abi = tokenType === "erc20" ? erc20ABI : erc721ABI;
-        const symbol = (await readContract({
+        const contractConfig = {
           address: tokenAddress as `0x${string}`,
           abi: abi as unknown as Abi,
           chainId: chainId,
+        };
+
+        let tokenSymbolOrName = (await readContract({
+          ...contractConfig,
           functionName: "symbol",
         })) as string;
 
-        setTokenSymbol(symbol);
-        setIsSuccess(true);
-      } catch (err: any) {
-        if (tokenType === "erc20") {
-          setTokenSymbol("ERC20 TOKEN");
-        } else {
-          setTokenSymbol("NFT");
+        if (!tokenSymbolOrName) {
+          tokenSymbolOrName = (await readContract({
+            ...contractConfig,
+            functionName: "name",
+          })) as string;
         }
+
+        setTokenSymbol(tokenSymbolOrName);
+        setIsSuccess(true);
+      } catch (err) {
+        setTokenSymbol(tokenType === "erc20" ? "ERC20 TOKEN" : "NFT");
       } finally {
         setIsLoading(false);
       }


### PR DESCRIPTION
I've noticed that there isn't symbol for the voting requirement NFT on [this](https://www.jokerace.io/contest/base/0x594663fea4763c5d92f0ac298897f99860f60e29) contest

You can check it by going to the params tab, it is returning an empty string for the symbol, therefore, if symbol is empty we will try to retrieve name for that token.