### PR TITLE
bugfix: add check for contact details in deploy contest fn

### DIFF
--- a/packages/react-app-revamp/hooks/useDeployContest/index.ts
+++ b/packages/react-app-revamp/hooks/useDeployContest/index.ts
@@ -73,7 +73,7 @@ export function useDeployContest() {
         DeployedContestContract.bytecode,
         signer,
       );
-      const combinedPrompt = `${prompt.summarize}|${prompt.evaluateVoters}|${prompt.contactDetails}`;
+      const combinedPrompt = `${prompt.summarize}|${prompt.evaluateVoters}|${prompt.contactDetails ?? ""}`;
       const contestInfo = type + "|" + summary + "|" + combinedPrompt;
       const votingMerkle = votingMerkleData.manual || votingMerkleData.prefilled || votingMerkleData.csv;
       const submissionMerkle =


### PR DESCRIPTION
We need to normalize empty contact details to empty string instead of undefined on deployment. This ensures consistency and prevents undefined values when contact details are not provided ( they are optional ) 