### PR TITLE
feat: anyone can vote frontend

### DIFF
--- a/packages/react-app-revamp/components/_pages/Contest/Contest/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/Contest/index.tsx
@@ -6,6 +6,7 @@ import { useContestStore } from "@hooks/useContest/store";
 import { ContestStatus, useContestStatusStore } from "@hooks/useContestStatus/store";
 import { useProposalStore } from "@hooks/useProposal/store";
 import { useSubmitProposalStore } from "@hooks/useSubmitProposal/store";
+import useUser from "@hooks/useUser";
 import { useUserStore } from "@hooks/useUser/store";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { useState } from "react";
@@ -15,10 +16,9 @@ import ContestPrompt from "../components/Prompt";
 import ProposalStatistics from "../components/ProposalStatistics";
 import ContestStickyCards from "../components/StickyCards";
 import ContestTimeline from "../components/Timeline";
-import useUser from "@hooks/useUser";
 
 const ContestTab = () => {
-  const { contestPrompt, submissionMerkleRoot } = useContestStore(state => state);
+  const { contestPrompt } = useContestStore(state => state);
   const { isConnected } = useAccount();
   const { openConnectModal } = useConnectModal();
   const { contestStatus } = useContestStatusStore(state => state);

--- a/packages/react-app-revamp/components/_pages/Contest/Parameters/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/Parameters/index.tsx
@@ -67,7 +67,7 @@ const ContestParameters = () => {
           you have{" "}
           <span className="font-bold">
             {formatNumber(currentUserAvailableVotesAmount)} vote{currentUserAvailableVotesAmount == 1 ? "" : "s"} ( 1
-            vote = {formatEther(charge?.type.costToVote ?? 0)} {nativeCurrency?.symbol})
+            vote = {formatEther(BigInt(charge?.type.costToVote ?? 0))} {nativeCurrency?.symbol})
           </span>
         </p>
       );

--- a/packages/react-app-revamp/components/_pages/Contest/components/ProposalStatistics/components/Panel/components/VotingOpenOrClosed/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/components/ProposalStatistics/components/Panel/components/VotingOpenOrClosed/index.tsx
@@ -17,8 +17,7 @@ interface ProposalStatisticsPanelVotingOpenOrClosedProps {
 const ProposalStatisticsPanelVotingOpenOrClosed: FC<ProposalStatisticsPanelVotingOpenOrClosedProps> = ({
   submissionsCount,
 }) => {
-  const router = useRouter();
-  const asPath = router.asPath;
+  const asPath = useRouter().asPath;
   const { address, chainName } = extractPathSegments(asPath);
   const chainId = chains.filter(
     (chain: { name: string }) => chain.name.toLowerCase().replace(" ", "") === chainName,
@@ -28,6 +27,7 @@ const ProposalStatisticsPanelVotingOpenOrClosed: FC<ProposalStatisticsPanelVotin
     totalVotes,
     isLoading: isTotalVotesLoading,
     isError: isTotalVotesError,
+    isAnyoneCanVote,
   } = useTotalVotesOnContestStore(state => state);
   const { fetchTotalVotesCast, retry: retryTotalVotesCast } = useTotalVotesCastOnContest(address, chainId);
   const {
@@ -60,6 +60,7 @@ const ProposalStatisticsPanelVotingOpenOrClosed: FC<ProposalStatisticsPanelVotin
   };
 
   const renderTotalVotes = () => {
+    if (isAnyoneCanVote) return "unlimited";
     if (isTotalVotesLoading)
       return <Skeleton width={50} height={16} baseColor="#706f78" highlightColor="#78FFC6" duration={1} />;
 

--- a/packages/react-app-revamp/components/_pages/Contest/components/ProposalStatistics/components/Panel/components/VotingOpenOrClosed/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/components/ProposalStatistics/components/Panel/components/VotingOpenOrClosed/index.tsx
@@ -60,7 +60,6 @@ const ProposalStatisticsPanelVotingOpenOrClosed: FC<ProposalStatisticsPanelVotin
   };
 
   const renderTotalVotes = () => {
-    if (isAnyoneCanVote) return "unlimited";
     if (isTotalVotesLoading)
       return <Skeleton width={50} height={16} baseColor="#706f78" highlightColor="#78FFC6" duration={1} />;
 
@@ -82,7 +81,7 @@ const ProposalStatisticsPanelVotingOpenOrClosed: FC<ProposalStatisticsPanelVotin
       </p>
       <span className="hidden md:block">&#8226;</span>
       <div className="flex gap-1 items-center text-[16px] text-neutral-11">
-        {renderTotalVotesCast()} out of {renderTotalVotes()} votes deployed in contest
+        {renderTotalVotesCast()} {isAnyoneCanVote ? "" : `out of ${renderTotalVotes()} `}votes deployed in contest
       </div>
     </div>
   );

--- a/packages/react-app-revamp/components/_pages/Contest/components/StickyCards/components/VotingQualifier/components/VotingQualifierMessage/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/components/StickyCards/components/VotingQualifier/components/VotingQualifierMessage/index.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/no-unescaped-entities */
 import { formatNumber } from "@helpers/formatNumber";
 import { ContestStatus } from "@hooks/useContestStatus/store";
+import { formatEther } from "ethers/lib/utils";
 import { FC } from "react";
 
 interface VotingQualifierMessageProps {
@@ -9,6 +10,8 @@ interface VotingQualifierMessageProps {
   contestStatus: ContestStatus;
   isMobile: boolean;
   isReadOnly: boolean;
+  anyoneCanVote?: boolean;
+  costToVote?: number;
 }
 
 const VotingQualifierMessage: FC<VotingQualifierMessageProps> = ({
@@ -17,10 +20,13 @@ const VotingQualifierMessage: FC<VotingQualifierMessageProps> = ({
   contestStatus,
   isMobile,
   isReadOnly,
+  anyoneCanVote,
+  costToVote,
 }) => {
   const canVote = currentUserAvailableVotesAmount > 0;
   const votingOpen = contestStatus === ContestStatus.VotingOpen;
   const outOfVotes = currentUserTotalVotesAmount > 0 && !canVote;
+  const zeroVotesOnAnyoneCanVote = currentUserTotalVotesAmount === 0 && anyoneCanVote;
 
   if (isReadOnly) return <p className="text-[16px] md:text-[24px] text-neutral-9 font-bold">vote is in read mode</p>;
 
@@ -39,6 +45,10 @@ const VotingQualifierMessage: FC<VotingQualifierMessageProps> = ({
         {isMobile ? "to use" : "to deploy"}
       </p>
     );
+  }
+
+  if (zeroVotesOnAnyoneCanVote) {
+    return <p className="text-[16px] md:text-[24px] text-neutral-9 font-bold">you have 0 votes </p>;
   }
 
   if (outOfVotes) return <p className="text-[16px] md:text-[24px] text-neutral-9 font-bold">you're out of votes :(</p>;

--- a/packages/react-app-revamp/components/_pages/Contest/components/StickyCards/components/VotingQualifier/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/components/StickyCards/components/VotingQualifier/index.tsx
@@ -1,17 +1,17 @@
 /* eslint-disable react/no-unescaped-entities */
+import { chains } from "@config/wagmi";
+import { extractPathSegments } from "@helpers/extractPath";
 import { useContestStore } from "@hooks/useContest/store";
 import { useContestStatusStore } from "@hooks/useContestStatus/store";
 import { useUserStore } from "@hooks/useUser/store";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import Image from "next/image";
+import { useRouter } from "next/router";
 import Skeleton from "react-loading-skeleton";
 import { useMediaQuery } from "react-responsive";
+import { formatEther } from "viem";
 import { useAccount } from "wagmi";
 import VotingQualifierMessage from "./components/VotingQualifierMessage";
-import { formatEther } from "ethers/lib/utils";
-import { useRouter } from "next/router";
-import { extractPathSegments } from "@helpers/extractPath";
-import { chains } from "@config/wagmi";
 
 const VotingContestQualifier = () => {
   const { anyoneCanVote, charge } = useContestStore(state => state);
@@ -26,7 +26,7 @@ const VotingContestQualifier = () => {
   const { contestStatus } = useContestStatusStore(state => state);
   const isReadOnly = useContestStore(state => state.isReadOnly);
   const isMobile = useMediaQuery({ maxWidth: 768 });
-  const costToVoteFormatted = formatEther(charge?.type.costToVote ?? 0);
+  const costToVoteFormatted = formatEther(BigInt(charge?.type.costToVote ?? 0));
   const asPath = useRouter().asPath;
   const { chainName } = extractPathSegments(asPath);
   const nativeCurrency = chains.find(chain => chain.name === chainName.toLowerCase())?.nativeCurrency;

--- a/packages/react-app-revamp/components/_pages/Create/components/Stepper/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/components/Stepper/index.tsx
@@ -25,8 +25,10 @@ const Stepper: FC<StepperProps> = ({ steps }) => {
     isSuccess,
     submissionMerkle,
     submissionRequirementsOption,
+    votingRequirementsOption,
     submissionTypeOption,
     votingMerkle,
+    votingTab,
     submissionTab,
     ...state
   } = useDeployContestStore(state => state);
@@ -46,6 +48,8 @@ const Stepper: FC<StepperProps> = ({ steps }) => {
         submissionRequirementsOption,
         submissionTypeOption,
         votingMerkle,
+        votingRequirementsOption,
+        votingTab,
         submissionTab,
       });
 

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestConfirm/components/Allowlists/components/Voters/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestConfirm/components/Allowlists/components/Voters/index.tsx
@@ -10,6 +10,11 @@ interface CreateContestConfirmVotersProps {
 
 const CreateContestConfirmVoters: FC<CreateContestConfirmVotersProps> = ({ votingMerkle, votingRequirements }) => {
   const isVotingMerklePrefilled = votingMerkle.prefilled;
+  const anyoneCanVote = votingMerkle.csv === null && votingMerkle.manual === null && votingMerkle.prefilled === null;
+
+  if (anyoneCanVote) {
+    return <li className="text-[16px] list-disc">anyone can vote</li>;
+  }
 
   if (!isVotingMerklePrefilled) {
     return <li className="text-[16px] list-disc">custom allowlist for voters</li>;

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestMonetization/components/Charge/components/Vote/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestMonetization/components/Charge/components/Vote/index.tsx
@@ -9,6 +9,7 @@ interface ContestParamsChargeVoteProps {
   type: VoteType;
   chainUnitLabel: string;
   costToVoteError: string;
+  isAnyoneCanVote: boolean;
   onCostToVoteChange?: (value: number | null) => void;
   onVoteTypeChange?: (value: VoteType) => void;
 }
@@ -18,6 +19,7 @@ const ContestParamsChargeVote: FC<ContestParamsChargeVoteProps> = ({
   type,
   chainUnitLabel,
   costToVoteError,
+  isAnyoneCanVote,
   onCostToVoteChange,
   onVoteTypeChange,
 }) => {
@@ -43,26 +45,18 @@ const ContestParamsChargeVote: FC<ContestParamsChargeVoteProps> = ({
         )}
       </p>
       <RadioGroup value={selected} onChange={handleVoteTypeChange}>
-        <div className="flex flex-col gap-4">
-          <RadioGroup.Option value={VoteType.PerTransaction}>
+        <div className={`flex ${isAnyoneCanVote ? "flex-col-reverse" : "flex-col"} gap-4`}>
+          <RadioGroup.Option value={VoteType.PerTransaction} disabled={isAnyoneCanVote}>
             {({ checked }) => (
               <div className="flex gap-4 items-start cursor-pointer">
                 <div
                   className={`flex items-center mt-1 justify-center w-6 h-6 border border-neutral-9 rounded-full transition-colors ${
                     checked ? "bg-neutral-11 border-0" : ""
-                  }`}
+                  } ${isAnyoneCanVote ? "opacity-50" : "opacity-100"}`}
                 ></div>
-                <div className="flex flex-col gap-4">
-                  <p className="text-[20px] text-neutral-9">
-                    {isMobile ? (
-                      <>
-                        a charge <i>each time</i> they vote
-                      </>
-                    ) : (
-                      <>
-                        a charge <i>each time</i> they vote (recommended)
-                      </>
-                    )}
+                <div className={`flex flex-col ${isAnyoneCanVote ? "gap-1" : "gap-4"}`}>
+                  <p className={`text-[20px] text-neutral-9 ${isAnyoneCanVote ? "opacity-50" : "opacity-100"}`}>
+                    a charge <i>each time</i> they vote {isAnyoneCanVote ? "" : "(recommended)"}
                   </p>
                   {checked ? (
                     <CreateNumberInput
@@ -72,6 +66,12 @@ const ContestParamsChargeVote: FC<ContestParamsChargeVoteProps> = ({
                       errorMessage={costToVoteError}
                       textClassName="font-bold text-center pl-0 pr-4"
                     />
+                  ) : null}
+                  {isAnyoneCanVote ? (
+                    <p className="text-[14px] text-neutral-11">
+                      <b>note:</b> in order to enable this charge, please use <br />
+                      presets or allowlists for voters instead of anyone-can-vote.
+                    </p>
                   ) : null}
                 </div>
               </div>

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestMonetization/components/Charge/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestMonetization/components/Charge/index.tsx
@@ -2,11 +2,11 @@
 import { chains } from "@config/wagmi";
 import useChargeDetails from "@hooks/useChargeDetails";
 import { useDeployContestStore } from "@hooks/useDeployContest/store";
+import { VoteType } from "@hooks/useDeployContest/types";
 import { FC, useState } from "react";
 import ContestParamsChargePercentToCreator from "./components/PercentToCreator";
 import ContestParamsChargeSubmission from "./components/Submission";
 import ContestParamsChargeVote from "./components/Vote";
-import { VoteType } from "@hooks/useDeployContest/types";
 
 interface CreateContestChargeProps {
   isConnected: boolean;
@@ -18,10 +18,11 @@ interface CreateContestChargeProps {
 const CreateContestCharge: FC<CreateContestChargeProps> = ({ isConnected, chain, onError, onUnsupportedChain }) => {
   const chainUnitLabel = chains.find(c => c.name === chain)?.nativeCurrency.symbol;
   const { isError, refetch: refetchChargeDetails, isLoading } = useChargeDetails(chain);
-  const { charge, minCharge, setCharge } = useDeployContestStore(state => state);
+  const { charge, minCharge, setCharge, votingMerkle } = useDeployContestStore(state => state);
   const { minCostToPropose, minCostToVote } = minCharge;
   const [costToProposeError, setCostToProposeError] = useState("");
   const [costToVoteError, setCostToVoteError] = useState("");
+  const isAnyoneCanVote = Object.values(votingMerkle).every(value => value === null);
 
   if (isError) {
     onError?.(true);
@@ -131,6 +132,7 @@ const CreateContestCharge: FC<CreateContestChargeProps> = ({ isConnected, chain,
           costToVoteError={costToVoteError}
           onCostToVoteChange={handleCostToVoteChange}
           onVoteTypeChange={handleVoteTypeChange}
+          isAnyoneCanVote={isAnyoneCanVote}
         />
       </div>
     </div>

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestSubmission/components/SubmissionRequirements/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestSubmission/components/SubmissionRequirements/index.tsx
@@ -65,14 +65,14 @@ const CreateSubmissionRequirements = () => {
     switch (submissionRequirementsOption.value) {
       case "erc721":
         return (
-          <div className={`${isDropdownOpen ? "opacity-50 transition-opacity duration-300 ease-in-out" : ""}`}>
+          <div className={`${isDropdownOpen ? "opacity-20 transition-opacity duration-300 ease-in-out" : ""}`}>
             <CreateSubmissionRequirementsNftSettings error={inputError} />
           </div>
         );
 
       case "erc20":
         return (
-          <div className={`${isDropdownOpen ? "opacity-50 transition-opacity duration-300 ease-in-out" : ""}`}>
+          <div className={`${isDropdownOpen ? "opacity-20 transition-opacity duration-300 ease-in-out" : ""}`}>
             <CreateSubmissionRequirementsTokenSettings error={inputError} />
           </div>
         );

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingAllowlist/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingAllowlist/index.tsx
@@ -4,7 +4,7 @@ import CreateNextButton from "@components/_pages/Create/components/Buttons/Next"
 import { useNextStep } from "@components/_pages/Create/hooks/useNextStep";
 import { validationFunctions } from "@components/_pages/Create/utils/validation";
 import { MerkleKey, SubmissionType, useDeployContestStore } from "@hooks/useDeployContest/store";
-import { SubmissionMerkle, VotingMerkle } from "@hooks/useDeployContest/types";
+import { SubmissionMerkle, VoteType, VotingMerkle } from "@hooks/useDeployContest/types";
 import { Recipient } from "lib/merkletree/generateMerkleTree";
 import { useCallback, useEffect } from "react";
 import CSVEditorVoting, { VotingFieldObject } from "./components/CSVEditor";
@@ -25,6 +25,8 @@ const CreateVotingAllowlist = () => {
     votingRequirements,
     setVotingRequirements,
     submissionTypeOption,
+    charge,
+    setCharge,
     mobileStepTitle,
     resetMobileStepTitle,
     votingTab,
@@ -138,6 +140,10 @@ const CreateVotingAllowlist = () => {
     }
 
     toastLoading("processing your allowlist...", false);
+    setCharge({
+      ...charge,
+      voteType: VoteType.PerTransaction,
+    });
     if (submittersAsVoters) {
       const submissionAllowlist: Record<string, number> = Object.keys(votingAllowlist.manual).reduce(
         (acc, address) => {

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingUploadCsv/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingUploadCsv/index.tsx
@@ -4,7 +4,7 @@ import CreateNextButton from "@components/_pages/Create/components/Buttons/Next"
 import { useNextStep } from "@components/_pages/Create/hooks/useNextStep";
 import { validationFunctions } from "@components/_pages/Create/utils/validation";
 import { MerkleKey, SubmissionType, useDeployContestStore } from "@hooks/useDeployContest/store";
-import { SubmissionMerkle, VotingMerkle } from "@hooks/useDeployContest/types";
+import { SubmissionMerkle, VoteType, VotingMerkle } from "@hooks/useDeployContest/types";
 import { Recipient } from "lib/merkletree/generateMerkleTree";
 import { useCallback, useEffect } from "react";
 import { VotingFieldObject } from "../VotingAllowlist/components/CSVEditor";
@@ -26,6 +26,8 @@ const CreateVotingCSVUploader = () => {
     submissionTypeOption,
     votingRequirements,
     setVotingRequirements,
+    setCharge,
+    charge,
     mobileStepTitle,
     resetMobileStepTitle,
     votingTab,
@@ -141,7 +143,10 @@ const CreateVotingCSVUploader = () => {
     }
 
     toastLoading("Processing your allowlist...", false);
-
+    setCharge({
+      ...charge,
+      voteType: VoteType.PerTransaction,
+    });
     if (submittersAsVoters) {
       const submissionAllowlist: Record<string, number> = Object.keys(votingAllowlist.csv).reduce(
         (acc, address) => {

--- a/packages/react-app-revamp/components/_pages/Create/utils/validation.ts
+++ b/packages/react-app-revamp/components/_pages/Create/utils/validation.ts
@@ -24,6 +24,8 @@ interface SpecialStepConditions {
   submissionRequirementsOption: Option;
   submissionTypeOption: SubmissionTypeOption;
   votingMerkle: any;
+  votingRequirementsOption: Option;
+  votingTab: number;
   submissionTab: number;
 }
 
@@ -86,8 +88,10 @@ const votingMerkleValidation = (allowList: Record<string, number>) => {
   return "";
 };
 
-const votingRequirementsValidation = (allowList: Record<string, number>) => {
-  if (!allowList || Object.keys(allowList).length === 0) {
+const votingRequirementsValidation = (allowList: { records: Record<string, number>; type?: string }) => {
+  if (allowList.type === "anyone") return "";
+
+  if (!allowList || Object.keys(allowList.records).length === 0) {
     return "Merkle tree is empty";
   }
   return "";
@@ -214,6 +218,8 @@ const handleSpecialStepConditions = (
     submissionTab,
     submissionMerkle,
     votingMerkle,
+    votingRequirementsOption,
+    votingTab,
   }: SpecialStepConditions,
 ) => {
   if (currentStep === 5) {
@@ -227,6 +233,9 @@ const handleSpecialStepConditions = (
   }
 
   if (currentStep === 6) {
+    if (votingRequirementsOption.value === "anyone" && votingTab === 0) {
+      return true;
+    }
     return Object.values(votingMerkle).some(merkle => merkle !== null);
   }
 

--- a/packages/react-app-revamp/components/_pages/DialogModalVoteForProposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalVoteForProposal/index.tsx
@@ -19,24 +19,12 @@ interface DialogModalVoteForProposalProps {
 
 export const DialogModalVoteForProposal: FC<DialogModalVoteForProposalProps> = ({ isOpen, setIsOpen, proposal }) => {
   const { downvotingAllowed, contestPrompt } = useContestStore(state => state);
-  const {
-    currentUserAvailableVotesAmount,
-    decreaseCurrentUserAvailableVotesAmount,
-    increaseCurrentUserTotalVotesCast,
-    increaseCurrentUserAvailableVotesAmount,
-    decreaseCurrentUserTotalVotesCast,
-  } = useUserStore(state => state);
+  const { currentUserAvailableVotesAmount } = useUserStore(state => state);
 
   const { castVotes, isSuccess } = useCastVotes();
 
   const onSubmitCastVotes = (amount: number, isUpvote: boolean) => {
-    decreaseCurrentUserAvailableVotesAmount(amount);
-    increaseCurrentUserTotalVotesCast(amount);
-
-    castVotes(amount, isUpvote).catch(error => {
-      increaseCurrentUserAvailableVotesAmount(amount);
-      decreaseCurrentUserTotalVotesCast(amount);
-    });
+    castVotes(amount, isUpvote);
   };
 
   useEffect(() => {

--- a/packages/react-app-revamp/components/_pages/ListContests/Contest/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListContests/Contest/index.tsx
@@ -208,7 +208,7 @@ const Contest: FC<ContestProps> = ({ contest, compact, loading, rewards, allowTo
         return "text-negative-10";
       }
     } else if (votingTimeLeft.value) {
-      if (contest.qualifiedToVote) {
+      if (contest.qualifiedToVote || contest.anyoneCanVote) {
         return "text-positive-11";
       } else {
         return "text-negative-10";
@@ -243,7 +243,7 @@ const Contest: FC<ContestProps> = ({ contest, compact, loading, rewards, allowTo
         return "you don't qualify :(";
       }
     } else if (votingTimeLeft.value) {
-      if (contest.qualifiedToVote) {
+      if (contest.qualifiedToVote || contest.anyoneCanVote) {
         return (
           <span className="flex items-center gap-1">
             you qualify! <CheckmarkIcon />
@@ -273,7 +273,7 @@ const Contest: FC<ContestProps> = ({ contest, compact, loading, rewards, allowTo
       return "you qualify to submit & vote";
     } else if (contest.qualifiedToSubmit || contest.anyoneCanSubmit) {
       return "you qualify to submit but not vote";
-    } else if (contest.qualifiedToVote) {
+    } else if (contest.qualifiedToVote || contest.anyoneCanVote) {
       return "you don't qualify to submit but you can vote";
     } else {
       return "you don't qualify to submit or vote";

--- a/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalContentAction/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalContentAction/index.tsx
@@ -1,11 +1,13 @@
 /* eslint-disable react/no-unescaped-entities */
 import ButtonV3, { ButtonSize, ButtonType } from "@components/UI/ButtonV3";
+import { chains } from "@config/wagmi";
 import { extractPathSegments } from "@helpers/extractPath";
 import { useCastVotesStore } from "@hooks/useCastVotes/store";
 import { useContestStore } from "@hooks/useContest/store";
 import { ContestStatus, useContestStatusStore } from "@hooks/useContestStatus/store";
 import { useUserStore } from "@hooks/useUser/store";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
+import { formatEther } from "ethers/lib/utils";
 import moment from "moment";
 import Link from "next/link";
 import { useRouter } from "next/router";
@@ -24,7 +26,7 @@ const ProposalContentAction: FC<ProposalActionProps> = ({ proposalId, onVotingMo
   const { chainName, address: contestAddress } = extractPathSegments(asPath);
   const { openConnectModal } = useConnectModal();
   const isMobile = useMediaQuery({ maxWidth: 768 });
-  const { votesOpen } = useContestStore(state => state);
+  const { votesOpen, anyoneCanVote, charge } = useContestStore(state => state);
   const { isConnected } = useAccount();
   const formattedVotingOpen = moment(votesOpen);
   const contestStatus = useContestStatusStore(state => state.contestStatus);
@@ -33,6 +35,9 @@ const ProposalContentAction: FC<ProposalActionProps> = ({ proposalId, onVotingMo
     useUserStore(state => state);
   const canVote = currentUserAvailableVotesAmount > 0;
   const outOfVotes = currentUserTotalVotesAmount > 0 && !canVote;
+  const costToVoteFormatted = formatEther(charge?.type.costToVote ?? 0);
+  const nativeCurrency = chains.find(chain => chain.name === chainName.toLowerCase())?.nativeCurrency;
+  const zeroVotesOnAnyoneCanVote = currentUserTotalVotesAmount === 0 && anyoneCanVote;
 
   switch (contestStatus) {
     case ContestStatus.ContestOpen:
@@ -85,6 +90,14 @@ const ProposalContentAction: FC<ProposalActionProps> = ({ proposalId, onVotingMo
             </ButtonV3>
           );
         }
+      }
+
+      if (zeroVotesOnAnyoneCanVote) {
+        return (
+          <p className="text-[16px] text-neutral-10 font-bold">
+            only wallets with at least {costToVoteFormatted} {nativeCurrency?.symbol} can play
+          </p>
+        );
       }
 
       if (outOfVotes) {

--- a/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalContentAction/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalContentAction/index.tsx
@@ -35,7 +35,7 @@ const ProposalContentAction: FC<ProposalActionProps> = ({ proposalId, onVotingMo
     useUserStore(state => state);
   const canVote = currentUserAvailableVotesAmount > 0;
   const outOfVotes = currentUserTotalVotesAmount > 0 && !canVote;
-  const costToVoteFormatted = formatEther(charge?.type.costToVote ?? 0);
+  const costToVoteFormatted = formatEther(BigInt(charge?.type.costToVote ?? 0));
   const nativeCurrency = chains.find(chain => chain.name === chainName.toLowerCase())?.nativeCurrency;
   const zeroVotesOnAnyoneCanVote = currentUserTotalVotesAmount === 0 && anyoneCanVote;
 

--- a/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
@@ -81,7 +81,7 @@ const ProposalContent: FC<ProposalContentProps> = ({ proposal }) => {
       </Link>
       <div className={`flex-shrink-0 ${canVote ? "px-7 md:px-14" : "px-14"}`}>
         <div className={`flex flex-col md:flex-row items-center ${canVote ? "" : "border-t border-primary-2"}`}>
-          <div className="flex items-center py-4 justify-between w-full md:w-1/2 text-[16px] font-bold">
+          <div className="flex items-center py-4 justify-between w-full text-[16px] font-bold">
             <ProposalContentAction proposalId={proposal.id} onVotingModalOpen={value => setIsVotingModalOpen(value)} />
           </div>
         </div>

--- a/packages/react-app-revamp/components/_pages/Submission/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Submission/index.tsx
@@ -35,21 +35,9 @@ const SubmissionPage: FC<SubmissionPageProps> = ({
   const { openConnectModal } = useConnectModal();
   const { castVotes } = useCastVotes();
   const { listProposalsIds } = useProposalStore(state => state);
-  const {
-    decreaseCurrentUserAvailableVotesAmount,
-    increaseCurrentUserAvailableVotesAmount,
-    increaseCurrentUserTotalVotesCast,
-    decreaseCurrentUserTotalVotesCast,
-  } = useUserStore(state => state);
 
   const handleCastVotes = (amount: number, isUpvote: boolean) => {
-    decreaseCurrentUserAvailableVotesAmount(amount);
-    increaseCurrentUserTotalVotesCast(amount);
-
-    castVotes(amount, isUpvote).catch(error => {
-      increaseCurrentUserAvailableVotesAmount(amount);
-      decreaseCurrentUserTotalVotesCast(amount);
-    });
+    castVotes(amount, isUpvote);
   };
 
   async function requestAccount() {

--- a/packages/react-app-revamp/hooks/useAccountChange/index.tsx
+++ b/packages/react-app-revamp/hooks/useAccountChange/index.tsx
@@ -7,10 +7,10 @@ export const useAccountChange = () => {
 
   useEffect(() => {
     const unwatch = watchAccount(config, {
-      onChange(data) {
-        if (!data.address) return;
+      onChange(account) {
+        if (!account.address) return;
 
-        setAccount(data.address);
+        setAccount(account.address);
       },
     });
 

--- a/packages/react-app-revamp/hooks/useCastVotes/index.ts
+++ b/packages/react-app-revamp/hooks/useCastVotes/index.ts
@@ -22,7 +22,7 @@ import { useAccount } from "wagmi";
 import { useCastVotesStore } from "./store";
 
 export function useCastVotes() {
-  const { canUpdateVotesInRealTime, charge, contestAbi: abi } = useContestStore(state => state);
+  const { canUpdateVotesInRealTime, charge, contestAbi: abi, anyoneCanVote } = useContestStore(state => state);
   const { updateProposal } = useProposal();
   const { listProposalsData } = useProposalStore(state => state);
   const {
@@ -80,6 +80,7 @@ export function useCastVotes() {
     try {
       const { proofs, isVerified } = await getProofs(userAddress ?? "", "vote", currentUserTotalVotesAmount.toString());
       const costToVote = calculateChargeAmount(amountOfVotes);
+      const totalVoteAmount = anyoneCanVote ? 0 : parseUnits(currentUserTotalVotesAmount.toString());
 
       let hash: `0x${string}`;
 
@@ -88,13 +89,7 @@ export function useCastVotes() {
           address: contestAddress as `0x${string}`,
           abi: abi ? abi : DeployedContestContract.abi,
           functionName: "castVote",
-          args: [
-            pickedProposal,
-            isPositive ? 0 : 1,
-            parseUnits(currentUserTotalVotesAmount.toString()),
-            parseUnits(amountOfVotes.toString()),
-            proofs,
-          ],
+          args: [pickedProposal, isPositive ? 0 : 1, totalVoteAmount, parseUnits(amountOfVotes.toString()), proofs],
           //@ts-ignore
           value: costToVote,
         });
@@ -159,7 +154,7 @@ export function useCastVotes() {
         }
       }
 
-      await updateCurrentUserVotes();
+      await updateCurrentUserVotes(anyoneCanVote);
       fetchTotalVotesCast();
       refetchCurrentUserVotesOnProposal();
       setIsLoading(false);

--- a/packages/react-app-revamp/hooks/useChargeDetails/index.ts
+++ b/packages/react-app-revamp/hooks/useChargeDetails/index.ts
@@ -1,12 +1,14 @@
 import { useDeployContestStore } from "@hooks/useDeployContest/store";
 import { VoteType } from "@hooks/useDeployContest/types";
 import { fetchChargeDetails } from "lib/monetization";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 const useChargeDetails = (chainName: string) => {
-  const { setCharge, setPrevChainRefInCharge, prevChainRefInCharge, setMinCharge } = useDeployContestStore();
+  const { setCharge, setPrevChainRefInCharge, prevChainRefInCharge, setMinCharge, votingMerkle } =
+    useDeployContestStore();
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [isError, setIsError] = useState<boolean>(false);
+  const isAnyoneCanVote = Object.values(votingMerkle).every(value => value === null);
 
   const fetchDetails = useCallback(async () => {
     setIsLoading(true);
@@ -26,7 +28,7 @@ const useChargeDetails = (chainName: string) => {
     if (details.isError) {
       setCharge({
         percentageToCreator: 50,
-        voteType: VoteType.PerTransaction,
+        voteType: isAnyoneCanVote ? VoteType.PerVote : VoteType.PerTransaction,
         type: {
           costToPropose: 0,
           costToVote: 0,
@@ -49,7 +51,7 @@ const useChargeDetails = (chainName: string) => {
 
       setCharge({
         percentageToCreator: 50,
-        voteType: VoteType.PerTransaction,
+        voteType: isAnyoneCanVote ? VoteType.PerVote : VoteType.PerTransaction,
         type: {
           costToPropose: details.minCostToPropose,
           costToVote: details.minCostToVote,
@@ -59,7 +61,7 @@ const useChargeDetails = (chainName: string) => {
 
       setPrevChainRefInCharge(chainName);
     }
-  }, [chainName, prevChainRefInCharge, setCharge, setMinCharge, setPrevChainRefInCharge]);
+  }, [chainName, isAnyoneCanVote, prevChainRefInCharge, setCharge, setMinCharge, setPrevChainRefInCharge]);
 
   useEffect(() => {
     fetchDetails();

--- a/packages/react-app-revamp/hooks/useContest/store.tsx
+++ b/packages/react-app-revamp/hooks/useContest/store.tsx
@@ -13,6 +13,12 @@ export type Reward = {
   numberOfTokens: number;
 };
 
+export enum ErrorType {
+  RPC = "RPC",
+  CONTRACT = "CONTRACT",
+  IS_NOT_JOKERACE_CONTRACT = "IS_NOT_JOKERACE_CONTRACT",
+}
+
 export interface ContestState {
   contestName: string;
   contestPrompt: string;
@@ -23,7 +29,7 @@ export interface ContestState {
   votesOpen: Date;
   votesClose: Date;
   isLoading: boolean;
-  error: string;
+  error: ErrorType | null;
   isSuccess: boolean;
   isV3: boolean;
   contestMaxProposalCount: number;
@@ -57,7 +63,7 @@ export interface ContestState {
   setVotingRequirements: (votingRequirements: VotingRequirementsSchema | null) => void;
   setSubmissionRequirements: (submissionRequirements: VotingRequirementsSchema | null) => void;
   setIsLoading: (value: boolean) => void;
-  setError: (value: string) => void;
+  setError: (value: ErrorType | null) => void;
   setIsSuccess: (value: boolean) => void;
   setIsV3: (value: boolean) => void;
   setCharge: (charge: Charge | null) => void;
@@ -81,7 +87,7 @@ export const createContestStore = () =>
     votingMerkleRoot: "",
     rewards: null,
     isLoading: true,
-    error: "",
+    error: null,
     charge: null,
     isSuccess: false,
     contestMaxProposalCount: 0,

--- a/packages/react-app-revamp/hooks/useContest/store.tsx
+++ b/packages/react-app-revamp/hooks/useContest/store.tsx
@@ -39,6 +39,7 @@ export interface ContestState {
   rewards: Reward | null;
   isReadOnly: boolean;
   isRewardsLoading: boolean;
+  anyoneCanVote: boolean;
   setSupportsRewardsModule: (value: boolean) => void;
   setCanUpdateVotesInRealTime: (value: boolean) => void;
   setDownvotingAllowed: (isAllowed: boolean) => void;
@@ -63,6 +64,7 @@ export interface ContestState {
   setIsReadOnly: (value: boolean) => void;
   setIsRewardsLoading: (value: boolean) => void;
   setContestAbi: (abi: Abi) => void;
+  setAnyoneCanVote: (value: boolean) => void;
 }
 
 export const createContestStore = () =>
@@ -92,6 +94,7 @@ export const createContestStore = () =>
     isReadOnly: false,
     supportsRewardsModule: false,
     isRewardsLoading: false,
+    anyoneCanVote: false,
     setSupportsRewardsModule: value => set({ supportsRewardsModule: value }),
     setCanUpdateVotesInRealTime: value => set({ canUpdateVotesInRealTime: value }),
     setDownvotingAllowed: isAllowed => set({ downvotingAllowed: isAllowed }),
@@ -116,6 +119,7 @@ export const createContestStore = () =>
     setIsRewardsLoading: value => set({ isRewardsLoading: value }),
     setCharge: charge => set({ charge: charge }),
     setContestAbi: abi => set({ contestAbi: abi }),
+    setAnyoneCanVote: value => set({ anyoneCanVote: value }),
   }));
 
 export const ContestContext = createContext<ReturnType<typeof createContestStore> | null>(null);

--- a/packages/react-app-revamp/hooks/useContest/v3v4/contracts.ts
+++ b/packages/react-app-revamp/hooks/useContest/v3v4/contracts.ts
@@ -11,8 +11,6 @@ export function getContracts(contractConfig: any, version: string) {
     "voteStart",
     "prompt",
     "downvotingAllowed",
-    "submissionMerkleRoot",
-    "votingMerkleRoot",
   ];
 
   const v4FunctionNames = ["percentageToCreator", "costToPropose"];

--- a/packages/react-app-revamp/hooks/useContestInfo/index.tsx
+++ b/packages/react-app-revamp/hooks/useContestInfo/index.tsx
@@ -73,7 +73,7 @@ const useContestInfo = ({
         return "text-neutral-9";
       }
 
-      if (contest.qualifiedToVote || !address) {
+      if (contest.qualifiedToVote || !address || contest.anyoneCanVote) {
         if (votingStatus === "Voting is open") {
           return "text-positive-11";
         }
@@ -93,6 +93,7 @@ const useContestInfo = ({
     contest.qualifiedToVote,
     address,
     contest.anyoneCanSubmit,
+    contest.anyoneCanVote,
   ]);
 
   useEffect(() => {
@@ -170,6 +171,10 @@ const useContestInfo = ({
         );
       }
 
+      if (contest.anyoneCanVote) {
+        return "for everyone";
+      }
+
       if (!address) {
         if (votingRequirement) {
           if (isVotingRequirementTokenLoading) {
@@ -238,6 +243,7 @@ const useContestInfo = ({
     votingRequirementToken,
     isSubmissionRequirementTokenLoading,
     isVotingRequirementTokenLoading,
+    contest.anyoneCanVote,
   ]);
 
   return { submissionClass, votingClass, submissionMessage, votingMessage };

--- a/packages/react-app-revamp/hooks/useDeployContest/index.ts
+++ b/packages/react-app-revamp/hooks/useDeployContest/index.ts
@@ -298,11 +298,11 @@ export function useDeployContest() {
       tasks.push(workerTask);
 
       await Promise.all(tasks);
-    } catch (e) {
+    } catch (e: any) {
       stateContestDeployment.setIsLoading(false);
-      stateContestDeployment.setError(error);
+      stateContestDeployment.setError(e.message);
       setIsLoading(false);
-      toastError(`contest deployment failed to index in db`, error);
+      toastError(`contest deployment failed to index in db`, e.message);
     } finally {
       participantsWorker.terminate();
     }

--- a/packages/react-app-revamp/hooks/useDeployContest/index.ts
+++ b/packages/react-app-revamp/hooks/useDeployContest/index.ts
@@ -80,7 +80,7 @@ export function useDeployContest() {
         submissionMerkleData.manual || submissionMerkleData.prefilled || submissionMerkleData.csv;
       const { type: chargeType, percentageToCreator } = charge;
       const { merkleRoot: submissionMerkleRoot = EMPTY_ROOT } = submissionMerkle || {};
-      const { merkleRoot: votingMerkleRoot } = votingMerkle || {};
+      const { merkleRoot: votingMerkleRoot = EMPTY_ROOT } = votingMerkle || {};
       const { allowedSubmissionsPerUser, maxSubmissions } = customization;
 
       // Handle allowedSubmissionsPerUser and maxSubmissions in case they are not set, they are zero, or we pass "infinity" to the contract
@@ -264,8 +264,6 @@ export function useDeployContest() {
       if (!isSupabaseConfigured) {
         throw new Error("Supabase is not configured");
       }
-
-      if (!votingMerkle) return null;
 
       const tasks = [];
 

--- a/packages/react-app-revamp/hooks/useDeployContest/store.tsx
+++ b/packages/react-app-revamp/hooks/useDeployContest/store.tsx
@@ -182,8 +182,8 @@ export const useDeployContestStore = create<DeployContestState>((set, get) => {
       label: "anyone",
     },
     votingRequirementsOption: {
-      value: "erc20",
-      label: "token holders",
+      value: "anyone",
+      label: "anyone",
     },
     votingAllowlist: {
       manual: {},
@@ -235,7 +235,7 @@ export const useDeployContestStore = create<DeployContestState>((set, get) => {
     },
     charge: {
       percentageToCreator: 50,
-      voteType: VoteType.PerTransaction,
+      voteType: VoteType.PerVote,
       type: {
         costToPropose: 0,
         costToVote: 0,

--- a/packages/react-app-revamp/hooks/useDeployContest/types/index.ts
+++ b/packages/react-app-revamp/hooks/useDeployContest/types/index.ts
@@ -35,8 +35,8 @@ export type SubmissionRequirements = {
 };
 
 export enum VoteType {
-  PerTransaction = "PerTransaction",
   PerVote = "PerVote",
+  PerTransaction = "PerTransaction",
 }
 
 export type Charge = {

--- a/packages/react-app-revamp/hooks/useGenerateProof/index.ts
+++ b/packages/react-app-revamp/hooks/useGenerateProof/index.ts
@@ -22,7 +22,7 @@ const EMPTY_ROOT = "0x0000000000000000000000000000000000000000000000000000000000
 export function useGenerateProof() {
   const { asPath } = useRouter();
   const { chainName, address: contestAddress } = extractPathSegments(asPath);
-  const { contestAbi: abi } = useContestStore(state => state);
+  const { contestAbi: abi, anyoneCanVote } = useContestStore(state => state);
   const { connector } = useAccount();
   const [chainId, setChainId] = useState(
     chains.filter((chain: { name: string }) => chain.name.toLowerCase().replace(" ", "") === chainName)?.[0]?.id,
@@ -101,7 +101,12 @@ export function useGenerateProof() {
           ...contractConfig,
           functionName: "votingMerkleRoot",
         })) as string;
-        return await generateProofs(address, numVotes, votingMerkleRoot);
+
+        if (votingMerkleRoot === EMPTY_ROOT && anyoneCanVote) {
+          return [];
+        } else {
+          return await generateProofs(address, numVotes, votingMerkleRoot);
+        }
     }
   }
 

--- a/packages/react-app-revamp/hooks/useProposal/index.ts
+++ b/packages/react-app-revamp/hooks/useProposal/index.ts
@@ -51,7 +51,6 @@ export function useProposal() {
   } = useProposalStore(state => state);
   const { asPath } = useRouter();
   const { chainName, address } = extractPathSegments(asPath);
-  const { setIsLoading, setIsSuccess, setError } = useContestStore(state => state);
   const { chain } = useAccount();
   const { error, handleError } = useError();
   const chainId = chains.filter(
@@ -235,11 +234,8 @@ export function useProposal() {
       if (paginationChunks.length) fetchProposalsPage(0, paginationChunks[0], paginationChunks.length, mappedProposals);
     } catch (e) {
       handleError(e, "Something went wrong while getting proposal ids.");
-      setError(error);
-      setIsSuccess(false);
       setIsListProposalsSuccess(false);
       setIsListProposalsLoading(false);
-      setIsLoading(false);
     }
   }
 

--- a/packages/react-app-revamp/hooks/useTotalVotes/store.tsx
+++ b/packages/react-app-revamp/hooks/useTotalVotes/store.tsx
@@ -5,10 +5,12 @@ type TotalVotesState = {
   isLoading: boolean;
   isSuccess: boolean;
   isError: boolean;
+  isAnyoneCanVote: boolean;
   setTotalVotes: (totalVotes: number) => void;
   setIsLoading: (isLoading: boolean) => void;
   setIsSuccess: (isSuccess: boolean) => void;
   setIsError: (isError: boolean) => void;
+  setIsAnyoneCanVote: (isAnyoneCanVote: boolean) => void;
 };
 
 export const useTotalVotesOnContestStore = create<TotalVotesState>(set => ({
@@ -16,8 +18,10 @@ export const useTotalVotesOnContestStore = create<TotalVotesState>(set => ({
   isLoading: false,
   isSuccess: false,
   isError: false,
+  isAnyoneCanVote: false,
   setTotalVotes: totalVotes => set({ totalVotes }),
   setIsLoading: isLoading => set({ isLoading }),
   setIsSuccess: isSuccess => set({ isSuccess }),
   setIsError: isError => set({ isError }),
+  setIsAnyoneCanVote: isAnyoneCanVote => set({ isAnyoneCanVote }),
 }));

--- a/packages/react-app-revamp/hooks/useUser/index.ts
+++ b/packages/react-app-revamp/hooks/useUser/index.ts
@@ -272,7 +272,7 @@ export function useUser() {
         }) as any,
       ]);
 
-      const costToVoteBigNum = BigNumber.from(Number(costToVote));
+      const costToVoteBigNum = BigNumber.from(costToVote);
       const userBalanceBigNum = BigNumber.from(userBalance.value);
       const currentGasPriceBigNum = BigNumber.from(gasPrice);
 

--- a/packages/react-app-revamp/hooks/useUser/store.tsx
+++ b/packages/react-app-revamp/hooks/useUser/store.tsx
@@ -21,11 +21,7 @@ interface UserState {
   setCurrentUserAvailableVotesAmount: (amount: number) => void;
   setCurrentUserTotalVotesAmount: (amount: number) => void;
   setContestMaxNumberSubmissionsPerUser: (amount: number) => void;
-  decreaseCurrentUserAvailableVotesAmount: (amount: number) => void;
   increaseCurrentUserProposalCount: () => void;
-  increaseCurrentUserAvailableVotesAmount: (amount: number) => void;
-  increaseCurrentUserTotalVotesCast: (amount: number) => void;
-  decreaseCurrentUserTotalVotesCast: (amount: number) => void;
   setCurrentUserProposalCount: (amount: number) => void;
   setIsCurrentUserSubmitQualificationLoading: (value: boolean) => void;
   setIsCurrentUserSubmitQualificationSuccess: (value: boolean) => void;
@@ -61,14 +57,6 @@ export const createUserStore = () =>
     setCurrentUserTotalVotesAmount: amount => set({ currentUserTotalVotesAmount: amount }),
     setContestMaxNumberSubmissionsPerUser: amount => set({ contestMaxNumberSubmissionsPerUser: amount }),
     setCurrentUserProposalCount: amount => set({ currentUserProposalCount: amount }),
-    decreaseCurrentUserAvailableVotesAmount: (amount: number) =>
-      set(state => ({ currentUserAvailableVotesAmount: state.currentUserAvailableVotesAmount - amount })),
-    increaseCurrentUserAvailableVotesAmount: (amount: number) =>
-      set(state => ({ currentUserAvailableVotesAmount: state.currentUserAvailableVotesAmount + amount })),
-    increaseCurrentUserTotalVotesCast: (amount: number) =>
-      set(state => ({ currentUserTotalVotesCast: state.currentUserTotalVotesCast + amount })),
-    decreaseCurrentUserTotalVotesCast: (amount: number) =>
-      set(state => ({ currentUserTotalVotesCast: state.currentUserTotalVotesCast - amount })),
     increaseCurrentUserProposalCount: () =>
       set(state => ({ currentUserProposalCount: state.currentUserProposalCount + 1 })),
     setIsCurrentUserSubmitQualificationLoading: value => set({ isCurrentUserSubmitQualificationLoading: value }),

--- a/packages/react-app-revamp/layouts/LayoutViewContest/components/Error/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/components/Error/index.tsx
@@ -1,0 +1,57 @@
+import { ROUTE_VIEW_CONTESTS } from "@config/routes";
+import { ErrorType } from "@hooks/useContest/store";
+import Link from "next/link";
+import { FC } from "react";
+
+interface LayoutViewContestErrorProps {
+  error: ErrorType;
+  bugReportLink: string;
+}
+
+const LayoutViewContestError: FC<LayoutViewContestErrorProps> = ({ error, bugReportLink }) => {
+  if (error === ErrorType.RPC) {
+    return (
+      <div className="flex flex-col gap-6 m-auto animate-appear">
+        <h1 className="text-[40px] lg:text-[40px] font-sabo text-negative-10 text-center">ruh-roh!</h1>
+        <p className="text-[16px] font-bold text-neutral-11 text-center">
+          it looks like we can’t connect to the chain to load this contest—please check the link as well as any malware
+          blockers you have installed, or try on another browser or device. <br />
+          if that doesn’t work,{" "}
+          <a href={bugReportLink} target="no_blank" className="text-primary-10">
+            please file a bug report so we can look into this
+          </a>
+        </p>
+      </div>
+    );
+  }
+
+  if (error === ErrorType.CONTRACT) {
+    return (
+      <div className="flex flex-col gap-6 m-auto animate-appear">
+        <h1 className="text-[40px] lg:text-[40px] font-sabo text-negative-10 text-center">ruh-roh!</h1>
+        <p className="text-[16px] font-bold text-neutral-11 text-center">
+          we were unable to fetch this contest — please check url to make sure it’s accurate <i>or</i> search for
+          contests{" "}
+          <Link href={ROUTE_VIEW_CONTESTS} className="text-primary-10">
+            here
+          </Link>
+        </p>
+      </div>
+    );
+  }
+
+  if (error === ErrorType.IS_NOT_JOKERACE_CONTRACT) {
+    return (
+      <div className="flex flex-col gap-6 m-auto animate-appear">
+        <h1 className="text-[40px] lg:text-[40px] font-sabo text-negative-10 text-center">ruh-roh!</h1>
+        <p className="text-[16px] font-bold text-neutral-11 text-center">
+          looks like this contract wasn’t deployed through Jokerace. Please check the contract address and try again.
+        </p>
+      </div>
+    );
+  }
+
+  return null;
+};
+
+export default LayoutViewContestError;

--- a/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
@@ -58,11 +58,9 @@ const LayoutViewContest = (props: any) => {
     rewards,
     isReadOnly,
     isRewardsLoading,
-    submissionMerkleRoot,
   } = useContestStore(state => state);
   const accountChanged = useAccountChange();
   const { checkIfCurrentUserQualifyToVote, checkIfCurrentUserQualifyToSubmit } = useUser();
-  const { contestMaxNumberSubmissionsPerUser } = useUserStore(state => state);
   const { setContestStatus } = useContestStatusStore(state => state);
   const { displayReloadBanner } = useContestEvents();
   const [tab, setTab] = useState<Tab>(Tab.Contest);
@@ -116,17 +114,12 @@ const LayoutViewContest = (props: any) => {
   useEffect(() => {
     const fetchUserData = async () => {
       if (accountChanged) {
-        if (accountAddress === accountChanged) return;
-
-        await Promise.all([
-          checkIfCurrentUserQualifyToSubmit(submissionMerkleRoot, contestMaxNumberSubmissionsPerUser),
-          checkIfCurrentUserQualifyToVote(),
-        ]);
+        await Promise.all([checkIfCurrentUserQualifyToSubmit(), checkIfCurrentUserQualifyToVote()]);
       }
     };
 
     fetchUserData();
-  }, [accountChanged, accountAddress]);
+  }, [accountChanged]);
 
   useEffect(() => {
     fetchContestInfo();

--- a/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
@@ -21,7 +21,7 @@ import { RefreshIcon } from "@heroicons/react/outline";
 import { useAccountChange } from "@hooks/useAccountChange";
 import { CastVotesWrapper } from "@hooks/useCastVotes/store";
 import { useContest } from "@hooks/useContest";
-import { ContestWrapper, useContestStore } from "@hooks/useContest/store";
+import { ContestWrapper, ErrorType, useContestStore } from "@hooks/useContest/store";
 import useContestEvents from "@hooks/useContestEvents";
 import { ContestStatus, useContestStatusStore } from "@hooks/useContestStatus/store";
 import { ContractFactoryWrapper } from "@hooks/useContractFactory";
@@ -41,6 +41,7 @@ import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
 import { useMediaQuery } from "react-responsive";
 import { useAccount, useAccountEffect } from "wagmi";
 import { getLayout as getBaseLayout } from "./../LayoutBase";
+import LayoutViewContestError from "./components/Error";
 
 const LayoutViewContest = (props: any) => {
   const { asPath, pathname, reload } = useRouter();
@@ -65,7 +66,7 @@ const LayoutViewContest = (props: any) => {
   const { displayReloadBanner } = useContestEvents();
   const [tab, setTab] = useState<Tab>(Tab.Contest);
   const isMobile = useMediaQuery({ maxWidth: 768 });
-  const bugReportLink = populateBugReportLink(url?.href ?? "", accountAddress ?? "", error);
+  const bugReportLink = populateBugReportLink(url?.href ?? "", accountAddress ?? "", error ?? "");
 
   useAccountEffect({
     onConnect(data) {
@@ -151,34 +152,7 @@ const LayoutViewContest = (props: any) => {
   }, [tab]);
 
   if (error && !isLoading) {
-    if (error.includes("RPC")) {
-      return (
-        <div className="flex flex-col gap-6 m-auto animate-appear">
-          <h1 className="text-[40px] lg:text-[40px] font-sabo text-negative-10 text-center">ruh-roh!</h1>
-          <p className="text-[16px] font-bold text-neutral-11 text-center">
-            it looks like we can’t connect to the chain to load this contest—please check the link as well as any
-            malware blockers you have installed, or try on another browser or device. <br />
-            if that doesn’t work,{" "}
-            <a href={bugReportLink} target="no_blank" className="text-primary-10">
-              please file a bug report so we can look into this
-            </a>
-          </p>
-        </div>
-      );
-    } else {
-      return (
-        <div className="flex flex-col gap-6 m-auto animate-appear">
-          <h1 className="text-[40px] lg:text-[40px] font-sabo text-negative-10 text-center">ruh-roh!</h1>
-          <p className="text-[16px] font-bold text-neutral-11 text-center">
-            we were unable to fetch this contest — please check url to make sure it's accurate <i>or</i> search for
-            contests{" "}
-            <Link href={ROUTE_VIEW_CONTESTS} className="text-primary-10">
-              here
-            </Link>
-          </p>
-        </div>
-      );
-    }
+    return <LayoutViewContestError error={error} bugReportLink={bugReportLink} />;
   }
 
   return (

--- a/packages/react-app-revamp/lib/contests/index.ts
+++ b/packages/react-app-revamp/lib/contests/index.ts
@@ -8,9 +8,11 @@ import { BigNumber, ethers, utils } from "ethers";
 import moment from "moment";
 import { SearchOptions } from "types/search";
 import { sortContests } from "./utils/sortContests";
+import { compareVersions } from "compare-versions";
 
 export const ITEMS_PER_PAGE = 7;
 export const EMPTY_ROOT = "0x0000000000000000000000000000000000000000000000000000000000000000";
+const ANYONE_CAN_VOTE_VERSION = "4.27";
 
 interface ContestReward {
   contestAddress: string;
@@ -127,8 +129,9 @@ const updateContestWithUserQualifications = async (contest: any, userAddress: st
   const updatedContest = {
     ...contest,
     anyoneCanSubmit: anyoneCanSubmit,
+    anyoneCanVote: anyoneCanVote,
     qualifiedToSubmit: !anyoneCanSubmit ? participantData.can_submit : undefined,
-    qualifiedToVote: participantData.num_votes > 0,
+    qualifiedToVote: !anyoneCanVote ? participantData.num_votes > 0 : undefined,
   };
 
   return updatedContest;

--- a/packages/react-app-revamp/lib/contests/index.ts
+++ b/packages/react-app-revamp/lib/contests/index.ts
@@ -112,9 +112,11 @@ const fetchParticipantData = async (contestAddress: string, userAddress: string,
   return data && data.length > 0 ? data[0] : null;
 };
 
+//TODO: update contests with anyone can vote
 const updateContestWithUserQualifications = async (contest: any, userAddress: string) => {
-  const { submissionMerkleRoot, network_name, address } = contest;
+  const { submissionMerkleRoot, network_name, address, votingMerkleRoot } = contest;
   const anyoneCanSubmit = submissionMerkleRoot === EMPTY_ROOT;
+  const anyoneCanVote = votingMerkleRoot === EMPTY_ROOT;
 
   let participantData = { can_submit: anyoneCanSubmit, num_votes: 0 };
   if (userAddress) {

--- a/packages/react-app-revamp/lib/contests/index.ts
+++ b/packages/react-app-revamp/lib/contests/index.ts
@@ -491,3 +491,25 @@ export async function getUpcomingContests(
   }
   return { data: [], count: 0 };
 }
+
+export async function checkIfContestExists(address: string, networkName: string) {
+  if (isSupabaseConfigured) {
+    const config = await import("@config/supabase");
+    const supabase = config.supabase;
+    try {
+      const { data, error } = await supabase
+        .from("contests_v3")
+        .select("address")
+        .eq("address", address)
+        .eq("network_name", networkName);
+      if (error) {
+        throw new Error(error.message);
+      }
+      return data.length > 0;
+    } catch (e) {
+      console.error(e);
+      return false;
+    }
+  }
+  return false;
+}

--- a/packages/react-app-revamp/workers/indexContestParticipants.ts
+++ b/packages/react-app-revamp/workers/indexContestParticipants.ts
@@ -11,24 +11,26 @@ interface EventData {
 self.onmessage = async (event: MessageEvent<EventData>) => {
   try {
     const { contestData, votingMerkle, submissionMerkle } = event.data;
+    const { networkName, contractAddress } = contestData;
 
     const submitters = submissionMerkle ? submissionMerkle.submitters : [];
-    const voterSet = new Set(votingMerkle.voters.map(voter => voter.address));
+    const voters = votingMerkle ? votingMerkle.voters : [];
     const submitterSet = new Set(submitters.map(submitter => submitter.address));
+    const voterSet = new Set(voters.map(voter => voter.address));
 
     // Combine voters and submitters, removing duplicates
     const allParticipants = Array.from(
-      new Set([...votingMerkle.voters.map(voter => voter.address), ...submitters.map(submitter => submitter.address)]),
+      new Set([...voters.map(voter => voter.address), ...submitters.map(submitter => submitter.address)]),
     );
 
     const everyoneCanSubmit = submitters.length === 0;
     await indexContestParticipantsV3(
-      contestData.contractAddress,
+      contractAddress,
       allParticipants,
       voterSet,
       submitterSet,
-      votingMerkle.voters,
-      contestData.networkName,
+      voters,
+      networkName,
       everyoneCanSubmit,
     );
 


### PR DESCRIPTION
got `feat/full-stack-anyone-can-vote` up to speed with `staging` then squashed `feat/anyone-can-vote-frontend` (#1449) into this branch to capture your changes @nakedfool 

- [x] add and default to anyone can vote option (voting merkle root is 0) on voting allowlist page
- [x] rule that pay per vote must be the chosen option on the monetization page if anyone can vote
- [x] pages other than the create flow ( contest page )
- [x] make it so that only contests deployed from our site (we have them in supabase) can be interacted w on our site (do not want to be prompting users w txns on a contract we aren't sure of the bytecode of, phishing risk is huge)
- [x] add anyone can vote for contests