### PR TITLE
chore: hydrate cookie for wagmi ssr

### DIFF
--- a/packages/react-app-revamp/config/wagmi/index.ts
+++ b/packages/react-app-revamp/config/wagmi/index.ts
@@ -16,7 +16,7 @@ import {
 } from "@rainbow-me/rainbowkit/wallets";
 
 import { Transport } from "viem";
-import { createConfig, fallback, http } from "wagmi";
+import { cookieStorage, createConfig, createStorage, fallback, http } from "wagmi";
 import { aevo } from "./custom-chains/aevo";
 import { ancient8 } from "./custom-chains/ancient8";
 import { ancient8Testnet } from "./custom-chains/ancient8Testnet";
@@ -216,6 +216,8 @@ const connectors = connectorsForWallets(
       groupName: "Wallets",
       wallets: [
         metaMaskWallet,
+        walletConnectWallet,
+        coinbaseWallet,
         rainbowWallet,
         okxWallet,
         tahoWallet,
@@ -250,6 +252,10 @@ export const config = createConfig({
   connectors,
   chains,
   transports,
+  ssr: true,
+  storage: createStorage({
+    storage: cookieStorage,
+  }),
 });
 
 export const chainsImages: ChainImages = chains.reduce((acc: any, chain: any) => {

--- a/packages/react-app-revamp/pages/_app.tsx
+++ b/packages/react-app-revamp/pages/_app.tsx
@@ -1,34 +1,22 @@
-import { jokeraceTheme } from "@config/rainbowkit";
 import { config } from "@config/wagmi";
 import { Portal } from "@headlessui/react";
 import LayoutBase from "@layouts/LayoutBase";
-import { RainbowKitProvider } from "@rainbow-me/rainbowkit";
 import "@rainbow-me/rainbowkit/styles.css";
 import "@styles/globals.css";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { polyfill } from "interweave-ssr";
 import type { AppProps } from "next/app";
 import Head from "next/head";
 import { useRouter } from "next/router";
+import Providers from "providers";
 import { useEffect } from "react";
 import "react-datepicker/dist/react-datepicker.css";
 import "react-loading-skeleton/dist/skeleton.css";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.min.css";
 import "react-tooltip/dist/react-tooltip.css";
-import { WagmiProvider } from "wagmi";
+import { cookieToInitialState } from "wagmi";
 import * as gtag from "../lib/gtag";
 polyfill();
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: 0,
-      refetchOnMount: false,
-      refetchOnWindowFocus: false,
-    },
-  },
-});
 
 const isProd = process.env.NODE_ENV === "production";
 
@@ -41,6 +29,7 @@ function MyApp({ Component, pageProps }: AppProps) {
 
   //@ts-ignore
   const getLayout = Component.getLayout ?? ((page: any) => <LayoutBase>{page}</LayoutBase>);
+  const initialState = cookieToInitialState(config, pageProps.cookie);
 
   useEffect(() => {
     const handleRouteChange = (url: URL) => {
@@ -79,27 +68,23 @@ function MyApp({ Component, pageProps }: AppProps) {
         <link rel="preload" href="/gnosis.png" as="image" crossOrigin="anonymous" />
       </Head>
 
-      <WagmiProvider config={config}>
-        <QueryClientProvider client={queryClient}>
-          <RainbowKitProvider theme={jokeraceTheme} modalSize="wide">
-            {getLayout(<Component {...pageProps} />)}
-            <Portal>
-              <ToastContainer
-                position="bottom-center"
-                autoClose={4000}
-                hideProgressBar
-                closeOnClick
-                rtl={false}
-                pauseOnFocusLoss
-                draggable
-                pauseOnHover
-                theme="colored"
-                bodyClassName={() => "text-[16px] flex items-center"}
-              />
-            </Portal>
-          </RainbowKitProvider>
-        </QueryClientProvider>
-      </WagmiProvider>
+      <Providers initialState={initialState}>
+        {getLayout(<Component {...pageProps} />)}
+        <Portal>
+          <ToastContainer
+            position="bottom-center"
+            autoClose={4000}
+            hideProgressBar
+            closeOnClick
+            rtl={false}
+            pauseOnFocusLoss
+            draggable
+            pauseOnHover
+            theme="colored"
+            bodyClassName={() => "text-[16px] flex items-center"}
+          />
+        </Portal>
+      </Providers>
     </>
   );
 }

--- a/packages/react-app-revamp/pages/contest/new/index.tsx
+++ b/packages/react-app-revamp/pages/contest/new/index.tsx
@@ -1,7 +1,7 @@
 import CreateFlow from "@components/_pages/Create";
 import { ContractFactoryWrapper } from "@hooks/useContractFactory";
 import { RewardsWrapper } from "@hooks/useRewards/store";
-import type { NextPage } from "next";
+import type { GetServerSidePropsContext, NextPage } from "next";
 import Head from "next/head";
 
 const Page: NextPage = () => {
@@ -22,3 +22,14 @@ const Page: NextPage = () => {
 };
 
 export default Page;
+
+export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
+  const { req } = ctx;
+  const cookie = req?.headers.cookie || "";
+
+  return {
+    props: {
+      cookie,
+    },
+  };
+};

--- a/packages/react-app-revamp/pages/contests/index.tsx
+++ b/packages/react-app-revamp/pages/contests/index.tsx
@@ -7,7 +7,7 @@ import { getLayout } from "@layouts/LayoutContests";
 import { useQuery } from "@tanstack/react-query";
 import { getEnsAddress } from "@wagmi/core";
 import { ITEMS_PER_PAGE, getRewards, searchContests } from "lib/contests";
-import type { NextPage } from "next";
+import type { GetServerSidePropsContext, NextPage } from "next";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
@@ -165,6 +165,17 @@ const Page: NextPage = () => {
       </div>
     </>
   );
+};
+
+export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
+  const { req } = ctx;
+  const cookie = req?.headers.cookie || "";
+
+  return {
+    props: {
+      cookie,
+    },
+  };
 };
 
 //@ts-ignore

--- a/packages/react-app-revamp/pages/contests/live/index.tsx
+++ b/packages/react-app-revamp/pages/contests/live/index.tsx
@@ -5,7 +5,7 @@ import useContestSortOptions from "@hooks/useSortOptions";
 import { getLayout } from "@layouts/LayoutContests";
 import { useQuery } from "@tanstack/react-query";
 import { ITEMS_PER_PAGE, getLiveContests, getRewards } from "lib/contests";
-import type { NextPage } from "next";
+import type { GetServerSidePropsContext, NextPage } from "next";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
@@ -100,48 +100,16 @@ const Page: NextPage = () => {
   );
 };
 
-export async function getStaticProps() {
-  if (isSupabaseConfigured) {
-    const config = await import("@config/supabase");
-    const supabase = config.supabase;
+export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
+  const { req } = ctx;
+  const cookie = req?.headers.cookie || "";
 
-    const { from, to } = getPagination(0, 7);
-
-    const result = await supabase
-      .from("contests_v3")
-      .select(
-        "created_at, start_at, end_at, address, author_address, network_name, vote_start_at, featured, title, type, summary, prompt",
-        { count: "exact" },
-      )
-      .lte("start_at", new Date().toISOString())
-      .gte("end_at", new Date().toISOString())
-      .order("end_at", { ascending: true })
-      .range(from, to);
-
-    const { data, error } = result;
-
-    if (error) {
-      return {
-        props: {},
-        revalidate: 60,
-      };
-    }
-    return {
-      props: {
-        data,
-      },
-      // Next.js will attempt to re-generate the page:
-      // - When a request comes in
-      // - At most once every 60 seconds
-      revalidate: 60, // In seconds
-    };
-  }
   return {
     props: {
-      data: [],
+      cookie,
     },
   };
-}
+};
 
 //@ts-ignore
 Page.getLayout = getLayout;

--- a/packages/react-app-revamp/pages/contests/past/index.tsx
+++ b/packages/react-app-revamp/pages/contests/past/index.tsx
@@ -1,10 +1,9 @@
 import ListContests from "@components/_pages/ListContests";
 import { isSupabaseConfigured } from "@helpers/database";
-import getPagination from "@helpers/getPagination";
 import { getLayout } from "@layouts/LayoutContests";
 import { useQuery } from "@tanstack/react-query";
 import { getPastContests, getRewards, ITEMS_PER_PAGE } from "lib/contests";
-import type { NextPage } from "next";
+import type { GetServerSidePropsContext, NextPage } from "next";
 import Head from "next/head";
 import { useState } from "react";
 import { useAccount } from "wagmi";
@@ -98,47 +97,16 @@ const Page: NextPage = props => {
   );
 };
 
-export async function getStaticProps() {
-  if (isSupabaseConfigured) {
-    const config = await import("@config/supabase");
-    const supabase = config.supabase;
-    const { from, to } = getPagination(0, 7);
+export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
+  const { req } = ctx;
+  const cookie = req?.headers.cookie || "";
 
-    const result = await supabase
-      .from("contests_v3")
-      .select(
-        "created_at, start_at, end_at, address, author_address, network_name, vote_start_at, featured, title, type, summary, prompt",
-        { count: "exact" },
-      )
-      // all rows whose votes end date is < to the current date.
-      .lt("end_at", new Date().toISOString())
-      .order("end_at", { ascending: false })
-      .range(from, to);
-
-    const { data, error } = result;
-
-    if (error) {
-      return {
-        props: {},
-        revalidate: 60,
-      };
-    }
-    return {
-      props: {
-        data,
-      },
-      // Next.js will attempt to re-generate the page:
-      // - When a request comes in
-      // - At most once every 60 seconds
-      revalidate: 60, // In seconds
-    };
-  }
   return {
     props: {
-      data: [],
+      cookie,
     },
   };
-}
+};
 
 //@ts-ignore
 Page.getLayout = getLayout;

--- a/packages/react-app-revamp/pages/contests/upcoming/index.tsx
+++ b/packages/react-app-revamp/pages/contests/upcoming/index.tsx
@@ -5,7 +5,7 @@ import useContestSortOptions from "@hooks/useSortOptions";
 import { getLayout } from "@layouts/LayoutContests";
 import { useQuery } from "@tanstack/react-query";
 import { getRewards, getUpcomingContests, ITEMS_PER_PAGE } from "lib/contests";
-import type { NextPage } from "next";
+import type { GetServerSidePropsContext, NextPage } from "next";
 import Head from "next/head";
 import { useState } from "react";
 import { useAccount } from "wagmi";
@@ -89,46 +89,16 @@ const Page: NextPage = () => {
   );
 };
 
-export async function getStaticProps() {
-  if (isSupabaseConfigured) {
-    const config = await import("@config/supabase");
-    const supabase = config.supabase;
-    const { from, to } = getPagination(0, 7);
+export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
+  const { req } = ctx;
+  const cookie = req?.headers.cookie || "";
 
-    const result = await supabase
-      .from("contests_v3")
-      .select(
-        "created_at, start_at, end_at, address, author_address, network_name, vote_start_at, featured, title, type, summary, prompt",
-        { count: "exact" },
-      )
-      // all rows whose submissions start date is > to the current date.
-      .gt("start_at", new Date().toISOString())
-      .order("start_at", { ascending: false })
-      .range(from, to);
-    const { data, error } = result;
-
-    if (error) {
-      return {
-        props: {},
-        revalidate: 60,
-      };
-    }
-    return {
-      props: {
-        data,
-      },
-      // Next.js will attempt to re-generate the page:
-      // - When a request comes in
-      // - At most once every 60 seconds
-      revalidate: 60, // In seconds
-    };
-  }
   return {
     props: {
-      data: [],
+      cookie,
     },
   };
-}
+};
 
 //@ts-ignore
 Page.getLayout = getLayout;

--- a/packages/react-app-revamp/pages/index.tsx
+++ b/packages/react-app-revamp/pages/index.tsx
@@ -11,7 +11,7 @@ import { isSupabaseConfigured } from "@helpers/database";
 import useContestSortOptions from "@hooks/useSortOptions";
 import { useQuery } from "@tanstack/react-query";
 import { ITEMS_PER_PAGE, getFeaturedContests, getLiveContests, getRewards, searchContests } from "lib/contests";
-import type { NextPage } from "next";
+import type { GetServerSidePropsContext, NextPage } from "next";
 import Link from "next/link";
 import router from "next/router";
 import { useEffect, useState } from "react";
@@ -102,9 +102,7 @@ const Page: NextPage = () => {
     <>
       <div className="pl-8 pr-8 md:pl-16 md:pr-16 mt-4 md:mt-14 lg:mt-6 max-w-[1350px] 3xl:pl-28 2xl:pr-0 ">
         <div className="hidden lg:flex mb-8">
-          <p className="text-[18px] md:text-[20px] font-bold">
-            contests for communities to run, grow, and monetize
-          </p>
+          <p className="text-[18px] md:text-[20px] font-bold">contests for communities to run, grow, and monetize</p>
         </div>
 
         <div className="flex items-center gap-2 lg:hidden">
@@ -199,6 +197,17 @@ const Page: NextPage = () => {
       <Explainer />
     </>
   );
+};
+
+export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
+  const { req } = ctx;
+  const cookie = req?.headers.cookie || "";
+
+  return {
+    props: {
+      cookie,
+    },
+  };
 };
 
 export default Page;

--- a/packages/react-app-revamp/pages/user/[address]/comments/index.tsx
+++ b/packages/react-app-revamp/pages/user/[address]/comments/index.tsx
@@ -8,6 +8,7 @@ import { getUserComments } from "lib/user";
 import { CommentsResult } from "lib/user/types";
 import { FC, useState } from "react";
 import { UserPageProps } from "..";
+import { GetServerSidePropsContext } from "next";
 
 function useUserComments(userAddress: string) {
   const [page, setPage] = useState(0);
@@ -66,22 +67,23 @@ const Page: FC<UserPageProps> = ({ address }) => {
   );
 };
 
-export async function getStaticPaths() {
-  return { paths: [], fallback: true };
-}
+export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
+  const { req, params } = ctx;
+  const pathAddress = Array.isArray(params?.address) ? params?.address[0] : params?.address;
+  const cookie = req?.headers.cookie || "";
 
-export async function getStaticProps({ params }: any) {
-  const { address: pathAddress } = params;
-
-  const addressProps = await getAddressProps(pathAddress);
+  const addressProps = await getAddressProps(pathAddress ?? "");
 
   if (addressProps.notFound) {
     return { notFound: true };
   }
 
   return {
-    props: addressProps,
+    props: {
+      address: addressProps.address,
+      cookie,
+    },
   };
-}
+};
 
 export default Page;

--- a/packages/react-app-revamp/pages/user/[address]/index.tsx
+++ b/packages/react-app-revamp/pages/user/[address]/index.tsx
@@ -5,7 +5,7 @@ import useContestSortOptions from "@hooks/useSortOptions";
 import LayoutUser from "@layouts/LayoutUser";
 import { useQuery } from "@tanstack/react-query";
 import { getRewards, getUserContests, ITEMS_PER_PAGE } from "lib/contests";
-import type { NextPage } from "next";
+import type { GetServerSidePropsContext, NextPage } from "next";
 import Head from "next/head";
 import { useState } from "react";
 import { useAccount } from "wagmi";
@@ -105,22 +105,23 @@ const Page: NextPage = (props: UserPageProps) => {
   );
 };
 
-export async function getStaticPaths() {
-  return { paths: [], fallback: true };
-}
+export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
+  const { req, params } = ctx;
+  const pathAddress = Array.isArray(params?.address) ? params?.address[0] : params?.address;
+  const cookie = req?.headers.cookie || "";
 
-export async function getStaticProps({ params }: any) {
-  const { address: pathAddress } = params;
-
-  const addressProps = await getAddressProps(pathAddress);
+  const addressProps = await getAddressProps(pathAddress ?? "");
 
   if (addressProps.notFound) {
     return { notFound: true };
   }
 
   return {
-    props: addressProps,
+    props: {
+      address: addressProps.address,
+      cookie,
+    },
   };
-}
+};
 
 export default Page;

--- a/packages/react-app-revamp/pages/user/[address]/submissions/index.tsx
+++ b/packages/react-app-revamp/pages/user/[address]/submissions/index.tsx
@@ -8,6 +8,7 @@ import { getUserSubmissions } from "lib/user";
 import { SubmissionsResult } from "lib/user/types";
 import { FC, useState } from "react";
 import { UserPageProps } from "..";
+import { GetServerSidePropsContext } from "next";
 
 function useUserSubmissions(userAddress: string) {
   const [page, setPage] = useState(0);
@@ -66,22 +67,23 @@ const Page: FC<UserPageProps> = ({ address }) => {
   );
 };
 
-export async function getStaticPaths() {
-  return { paths: [], fallback: true };
-}
+export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
+  const { req, params } = ctx;
+  const pathAddress = Array.isArray(params?.address) ? params?.address[0] : params?.address;
+  const cookie = req?.headers.cookie || "";
 
-export async function getStaticProps({ params }: any) {
-  const { address: pathAddress } = params;
-
-  const addressProps = await getAddressProps(pathAddress);
+  const addressProps = await getAddressProps(pathAddress ?? "");
 
   if (addressProps.notFound) {
     return { notFound: true };
   }
 
   return {
-    props: addressProps,
+    props: {
+      address: addressProps.address,
+      cookie,
+    },
   };
-}
+};
 
 export default Page;

--- a/packages/react-app-revamp/pages/user/[address]/votes/index.tsx
+++ b/packages/react-app-revamp/pages/user/[address]/votes/index.tsx
@@ -6,6 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import { ITEMS_PER_PAGE } from "lib/contests";
 import { getUserVotes } from "lib/user";
 import { SubmissionsResult } from "lib/user/types";
+import { GetServerSidePropsContext } from "next";
 import { FC, useState } from "react";
 import { UserPageProps } from "..";
 
@@ -66,22 +67,23 @@ const Page: FC<UserPageProps> = ({ address }) => {
   );
 };
 
-export async function getStaticPaths() {
-  return { paths: [], fallback: true };
-}
+export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
+  const { req, params } = ctx;
+  const pathAddress = Array.isArray(params?.address) ? params?.address[0] : params?.address;
+  const cookie = req?.headers.cookie || "";
 
-export async function getStaticProps({ params }: any) {
-  const { address: pathAddress } = params;
-
-  const addressProps = await getAddressProps(pathAddress);
+  const addressProps = await getAddressProps(pathAddress ?? "");
 
   if (addressProps.notFound) {
     return { notFound: true };
   }
 
   return {
-    props: addressProps,
+    props: {
+      address: addressProps.address,
+      cookie,
+    },
   };
-}
+};
 
 export default Page;

--- a/packages/react-app-revamp/providers/index.tsx
+++ b/packages/react-app-revamp/providers/index.tsx
@@ -1,0 +1,27 @@
+"use client";
+import { jokeraceTheme } from "@config/rainbowkit";
+import { config } from "@config/wagmi";
+import { RainbowKitProvider } from "@rainbow-me/rainbowkit";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { FC, ReactNode } from "react";
+import { State, WagmiProvider } from "wagmi";
+
+type ProvidersProps = {
+  children: ReactNode;
+  initialState: State | undefined;
+};
+
+const Providers: FC<ProvidersProps> = ({ children, initialState }) => {
+  const queryClient = new QueryClient();
+  return (
+    <WagmiProvider config={config} initialState={initialState}>
+      <QueryClientProvider client={queryClient}>
+        <RainbowKitProvider theme={jokeraceTheme} modalSize="wide">
+          {children}
+        </RainbowKitProvider>
+      </QueryClientProvider>
+    </WagmiProvider>
+  );
+};
+
+export default Providers;


### PR DESCRIPTION
Closes #1441

Ok so this required a bit more of a codebase changes than i thought it would be.

In order to hydrate cookie for wagmi, we need to call `getServerSideProps` on each page and pass cookie for `cookieStorage` which is being initialized in the `app.tsx`, also, this means that nothing is going to be slower on our side, i also removed some redundant code which is good! 

Also, when i find some free time, i'll update wagmi docs and create an example of how to hydrate cookie for nextjs page router https://wagmi.sh/react/guides/ssr#next-js-pages-directory

So all after all, walletconnect and coinbase wallet are back in our app.