### PR TITLE
chore: use initialProps in app rather than server side prop on each page

### DIFF
--- a/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
@@ -69,7 +69,7 @@ const ProposalContent: FC<ProposalContentProps> = ({ proposal }) => {
     <div
       className={`flex flex-col w-full animate-appear ${isProposalTweet ? "" : "h-96 md:h-80"} rounded-[10px] border border-neutral-11 hover:bg-neutral-1 cursor-pointer transition-colors duration-500 ease-in-out`}
     >
-      <Link href={`/contest/${chainName}/${contestAddress}/submission/${proposal.id}`} shallow scroll={false}>
+      <Link href={`/contest/${chainName}/${contestAddress}/submission/${proposal.id}`} shallow scroll={false} prefetch>
         <ProposalContentInfo
           authorAddress={proposal.authorEthereumAddress}
           rank={proposal.rank}

--- a/packages/react-app-revamp/pages/contest/[chain]/[address]/index.tsx
+++ b/packages/react-app-revamp/pages/contest/[chain]/[address]/index.tsx
@@ -2,7 +2,7 @@ import { chains, config } from "@config/wagmi";
 import getContestContractVersion from "@helpers/getContestContractVersion";
 import { getLayout } from "@layouts/LayoutViewContest";
 import { readContracts } from "@wagmi/core";
-import type { GetServerSideProps, GetServerSidePropsContext, NextPage } from "next";
+import type { NextPage } from "next";
 import Head from "next/head";
 import { parse } from "node-html-parser";
 import { Abi } from "viem";
@@ -26,6 +26,10 @@ const Page: NextPage = (props: PageProps) => {
 };
 
 const REGEX_ETHEREUM_ADDRESS = /^0x[a-fA-F0-9]{40}$/;
+
+export async function getStaticPaths() {
+  return { paths: [], fallback: true };
+}
 
 // fn to get contest details for meta tags
 async function getContestDetails(address: string, chainName: string) {
@@ -56,16 +60,11 @@ async function getContestDetails(address: string, chainName: string) {
   return results;
 }
 
-export const getServerSideProps: GetServerSideProps = async (context: GetServerSidePropsContext) => {
-  const { params, req } = context;
-  const address = Array.isArray(params?.address) ? params?.address[0] : params?.address;
-  const chain = Array.isArray(params?.chain) ? params?.chain[0] : params?.chain;
-  const cookie = req?.headers.cookie || "";
-
+export async function getStaticProps({ params }: any) {
+  const { chain, address } = params;
   if (
-    !address ||
     !REGEX_ETHEREUM_ADDRESS.test(address) ||
-    !chains.some(c => c.name.toLowerCase().replace(" ", "") === chain)
+    chains.filter((c: { name: string }) => c.name.toLowerCase().replace(" ", "") === chain).length === 0
   ) {
     return { notFound: true };
   }
@@ -74,25 +73,24 @@ export const getServerSideProps: GetServerSideProps = async (context: GetServerS
   let contestDescription = "";
 
   try {
-    const contestDetails = await getContestDetails(address, chain ?? "");
+    const contestDetails = await getContestDetails(address, chain);
     const prompt = contestDetails[1].result as string;
     const contestDescriptionRaw = prompt.split("|")[2];
 
     contestTitle = contestDetails[0].result as string;
     contestDescription = parse(contestDescriptionRaw).textContent;
-    return {
-      props: {
-        address,
-        title: contestTitle,
-        description: contestDescription,
-        cookie,
-      },
-    };
   } catch (error) {
-    console.error("Failed to retrieve title or description for meta tags:", error);
-    return { notFound: true };
+    console.error("failed to retrieve title or description for metatags:", error);
   }
-};
+
+  return {
+    props: {
+      address,
+      title: contestTitle,
+      description: contestDescription,
+    },
+  };
+}
 
 //@ts-ignore
 Page.getLayout = getLayout;

--- a/packages/react-app-revamp/pages/contest/[chain]/[address]/submission/[submission]/index.tsx
+++ b/packages/react-app-revamp/pages/contest/[chain]/[address]/submission/[submission]/index.tsx
@@ -62,15 +62,14 @@ const getChainId = (chain: string) => {
   return chainId;
 };
 
-export const getServerSideProps: GetServerSideProps = async (context: GetServerSidePropsContext) => {
-  const { params, req } = context;
-  const address = Array.isArray(params?.address) ? params?.address[0] : params?.address;
-  const chain = Array.isArray(params?.chain) ? params?.chain[0] : params?.chain;
-  const submission = Array.isArray(params?.submission) ? params?.submission[0] : params?.submission;
-  const cookie = req?.headers.cookie || "";
+export async function getStaticPaths() {
+  return { paths: [], fallback: true };
+}
+
+export async function getStaticProps({ params }: any) {
+  const { chain, address, submission } = params;
 
   if (
-    !address ||
     !REGEX_ETHEREUM_ADDRESS.test(address) ||
     !chains.some((c: { name: string }) => c.name.toLowerCase().replace(" ", "") === chain) ||
     !submission
@@ -78,21 +77,20 @@ export const getServerSideProps: GetServerSideProps = async (context: GetServerS
     return { notFound: true };
   }
 
-  const chainId = getChainId(chain ?? "");
+  const chainId = getChainId(chain);
   const { abi, version } = await getContestContractVersion(address, chainId);
 
   return {
     props: {
       address,
       chain,
-      chainId,
       submission,
       abi,
       version,
-      cookie,
+      chainId,
     },
   };
-};
+}
 
 //@ts-ignore
 Page.getLayout = getLayout;

--- a/packages/react-app-revamp/pages/contest/new/index.tsx
+++ b/packages/react-app-revamp/pages/contest/new/index.tsx
@@ -22,14 +22,3 @@ const Page: NextPage = () => {
 };
 
 export default Page;
-
-export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
-  const { req } = ctx;
-  const cookie = req?.headers.cookie || "";
-
-  return {
-    props: {
-      cookie,
-    },
-  };
-};

--- a/packages/react-app-revamp/pages/contests/index.tsx
+++ b/packages/react-app-revamp/pages/contests/index.tsx
@@ -167,17 +167,6 @@ const Page: NextPage = () => {
   );
 };
 
-export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
-  const { req } = ctx;
-  const cookie = req?.headers.cookie || "";
-
-  return {
-    props: {
-      cookie,
-    },
-  };
-};
-
 //@ts-ignore
 Page.getLayout = getLayout;
 

--- a/packages/react-app-revamp/pages/contests/live/index.tsx
+++ b/packages/react-app-revamp/pages/contests/live/index.tsx
@@ -100,17 +100,6 @@ const Page: NextPage = () => {
   );
 };
 
-export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
-  const { req } = ctx;
-  const cookie = req?.headers.cookie || "";
-
-  return {
-    props: {
-      cookie,
-    },
-  };
-};
-
 //@ts-ignore
 Page.getLayout = getLayout;
 

--- a/packages/react-app-revamp/pages/contests/past/index.tsx
+++ b/packages/react-app-revamp/pages/contests/past/index.tsx
@@ -97,17 +97,6 @@ const Page: NextPage = props => {
   );
 };
 
-export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
-  const { req } = ctx;
-  const cookie = req?.headers.cookie || "";
-
-  return {
-    props: {
-      cookie,
-    },
-  };
-};
-
 //@ts-ignore
 Page.getLayout = getLayout;
 

--- a/packages/react-app-revamp/pages/contests/upcoming/index.tsx
+++ b/packages/react-app-revamp/pages/contests/upcoming/index.tsx
@@ -89,17 +89,6 @@ const Page: NextPage = () => {
   );
 };
 
-export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
-  const { req } = ctx;
-  const cookie = req?.headers.cookie || "";
-
-  return {
-    props: {
-      cookie,
-    },
-  };
-};
-
 //@ts-ignore
 Page.getLayout = getLayout;
 

--- a/packages/react-app-revamp/pages/index.tsx
+++ b/packages/react-app-revamp/pages/index.tsx
@@ -199,15 +199,4 @@ const Page: NextPage = () => {
   );
 };
 
-export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
-  const { req } = ctx;
-  const cookie = req?.headers.cookie || "";
-
-  return {
-    props: {
-      cookie,
-    },
-  };
-};
-
 export default Page;

--- a/packages/react-app-revamp/pages/user/[address]/comments/index.tsx
+++ b/packages/react-app-revamp/pages/user/[address]/comments/index.tsx
@@ -67,23 +67,22 @@ const Page: FC<UserPageProps> = ({ address }) => {
   );
 };
 
-export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
-  const { req, params } = ctx;
-  const pathAddress = Array.isArray(params?.address) ? params?.address[0] : params?.address;
-  const cookie = req?.headers.cookie || "";
+export async function getStaticPaths() {
+  return { paths: [], fallback: true };
+}
 
-  const addressProps = await getAddressProps(pathAddress ?? "");
+export async function getStaticProps({ params }: any) {
+  const { address: pathAddress } = params;
+
+  const addressProps = await getAddressProps(pathAddress);
 
   if (addressProps.notFound) {
     return { notFound: true };
   }
 
   return {
-    props: {
-      address: addressProps.address,
-      cookie,
-    },
+    props: addressProps,
   };
-};
+}
 
 export default Page;

--- a/packages/react-app-revamp/pages/user/[address]/index.tsx
+++ b/packages/react-app-revamp/pages/user/[address]/index.tsx
@@ -105,23 +105,22 @@ const Page: NextPage = (props: UserPageProps) => {
   );
 };
 
-export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
-  const { req, params } = ctx;
-  const pathAddress = Array.isArray(params?.address) ? params?.address[0] : params?.address;
-  const cookie = req?.headers.cookie || "";
+export async function getStaticPaths() {
+  return { paths: [], fallback: true };
+}
 
-  const addressProps = await getAddressProps(pathAddress ?? "");
+export async function getStaticProps({ params }: any) {
+  const { address: pathAddress } = params;
+
+  const addressProps = await getAddressProps(pathAddress);
 
   if (addressProps.notFound) {
     return { notFound: true };
   }
 
   return {
-    props: {
-      address: addressProps.address,
-      cookie,
-    },
+    props: addressProps,
   };
-};
+}
 
 export default Page;

--- a/packages/react-app-revamp/pages/user/[address]/submissions/index.tsx
+++ b/packages/react-app-revamp/pages/user/[address]/submissions/index.tsx
@@ -67,23 +67,22 @@ const Page: FC<UserPageProps> = ({ address }) => {
   );
 };
 
-export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
-  const { req, params } = ctx;
-  const pathAddress = Array.isArray(params?.address) ? params?.address[0] : params?.address;
-  const cookie = req?.headers.cookie || "";
+export async function getStaticPaths() {
+  return { paths: [], fallback: true };
+}
 
-  const addressProps = await getAddressProps(pathAddress ?? "");
+export async function getStaticProps({ params }: any) {
+  const { address: pathAddress } = params;
+
+  const addressProps = await getAddressProps(pathAddress);
 
   if (addressProps.notFound) {
     return { notFound: true };
   }
 
   return {
-    props: {
-      address: addressProps.address,
-      cookie,
-    },
+    props: addressProps,
   };
-};
+}
 
 export default Page;

--- a/packages/react-app-revamp/pages/user/[address]/votes/index.tsx
+++ b/packages/react-app-revamp/pages/user/[address]/votes/index.tsx
@@ -67,23 +67,22 @@ const Page: FC<UserPageProps> = ({ address }) => {
   );
 };
 
-export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
-  const { req, params } = ctx;
-  const pathAddress = Array.isArray(params?.address) ? params?.address[0] : params?.address;
-  const cookie = req?.headers.cookie || "";
+export async function getStaticPaths() {
+  return { paths: [], fallback: true };
+}
 
-  const addressProps = await getAddressProps(pathAddress ?? "");
+export async function getStaticProps({ params }: any) {
+  const { address: pathAddress } = params;
+
+  const addressProps = await getAddressProps(pathAddress);
 
   if (addressProps.notFound) {
     return { notFound: true };
   }
 
   return {
-    props: {
-      address: addressProps.address,
-      cookie,
-    },
+    props: addressProps,
   };
-};
+}
 
 export default Page;


### PR DESCRIPTION
I have noticed that the prop `refetch` in `Link` component isn't being utilized when `getServerSideProps` is used within the page.

We are using now `getInitialProps` in the `_app.tsx` and that way we removed every `getServerSideProps` in each page and instead we are using `getStaticProps` which we used before. While this is a legacy API, it is better for us to use it now until we can transform app from page router to app router.

See difference by clicking on submission in contest page

From this PR - https://jokerace-edlhtp4sr-jokerace.vercel.app/contest/arbitrumone/0x1d472EeAbad83268D72A4a90d3F83e70F30EBbbF

In prod - https://www.jokerace.io/contest/optimism/0x4098e85bb0261d66f3295c4e3109d35f755d3f78

**LONG TERM SOLUTION**

Long term solution for us would be to switch from nextjs page router to app router, this requires a bit of work but we should dedicate time for it in the future, that way, we can utilize Server Components and get cookie directly from the `_app.tsx` without using `getInitialPRops`