### PR TITLE
bugfix: throw error in index contest fn

### DIFF
--- a/packages/react-app-revamp/hooks/useDeployContest/index.ts
+++ b/packages/react-app-revamp/hooks/useDeployContest/index.ts
@@ -303,6 +303,7 @@ export function useDeployContest() {
       stateContestDeployment.setError(e.message);
       setIsLoading(false);
       toastError(`contest deployment failed to index in db`, e.message);
+      throw e;
     } finally {
       participantsWorker.terminate();
     }


### PR DESCRIPTION
Closes #1486 

So this was relatively easy to identify, we didn't throw an error in the `indexContest` fn where we create contest & participants in the supabase.