### PR TITLE
chore: apply eth -> lens -> address order for user profile

### DIFF
--- a/packages/react-app-revamp/app/api/[[...routes]]/route.tsx
+++ b/packages/react-app-revamp/app/api/[[...routes]]/route.tsx
@@ -17,6 +17,8 @@ import { chains } from "@config/wagmi/server";
 import getContestContractVersion from "@helpers/getContestContractVersion";
 import { parseUnits } from "ethers/lib/utils";
 import { Button, Frog, TextInput } from "frog";
+import { devtools } from 'frog/dev';
+import { serveStatic } from 'frog/serve-static';
 import { handle } from "frog/vercel";
 import {
   fetchContestInitialData,
@@ -393,6 +395,9 @@ app.transaction("/vote-tx", async c => {
     value: costToVote,
   });
 });
+
+devtools(app, { serveStatic })
+
 
 export const GET = handle(app);
 export const POST = handle(app);

--- a/packages/react-app-revamp/app/api/[[...routes]]/route.tsx
+++ b/packages/react-app-revamp/app/api/[[...routes]]/route.tsx
@@ -17,8 +17,6 @@ import { chains } from "@config/wagmi/server";
 import getContestContractVersion from "@helpers/getContestContractVersion";
 import { parseUnits } from "ethers/lib/utils";
 import { Button, Frog, TextInput } from "frog";
-import { devtools } from 'frog/dev';
-import { serveStatic } from 'frog/serve-static';
 import { handle } from "frog/vercel";
 import {
   fetchContestInitialData,
@@ -395,9 +393,6 @@ app.transaction("/vote-tx", async c => {
     value: costToVote,
   });
 });
-
-devtools(app, { serveStatic })
-
 
 export const GET = handle(app);
 export const POST = handle(app);

--- a/packages/react-app-revamp/components/UI/UserProfileDisplay/index.tsx
+++ b/packages/react-app-revamp/components/UI/UserProfileDisplay/index.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @next/next/no-img-element */
 import { ROUTE_VIEW_USER } from "@config/routes";
-import { mainnet } from "@config/wagmi/custom-chains/mainnet";
 import useProfileData from "@hooks/useProfileData";
 import Link from "next/link";
 import { FC } from "react";
@@ -56,9 +55,12 @@ const UserProfileDisplay = ({
   shortenOnFallback,
   size = "small",
 }: UserProfileDisplayProps) => {
-  const { profileName, profileAvatar, isLoading, isLens } = useProfileData(ethereumAddress, shortenOnFallback);
+  const { profileName, profileAvatar, socials, isLoading } = useProfileData(
+    ethereumAddress,
+    shortenOnFallback,
+    includeSocials,
+  );
   const { avatarSizeClass, textSizeClass } = SIZES[size];
-  const etherscan = mainnet.blockExplorers?.etherscan?.url;
 
   if (textualVersion) {
     return (
@@ -94,7 +96,7 @@ const UserProfileDisplay = ({
         <img style={{ width: "100%", height: "100%", objectFit: "cover" }} src={profileAvatar} alt="avatar" />
       </div>
       {isLoading ? (
-        <>Loading profile data...</>
+        <p className={`${textSizeClass} loadingDots`}>Loading profile data</p>
       ) : (
         <div className="flex flex-col gap-1">
           <a
@@ -108,14 +110,14 @@ const UserProfileDisplay = ({
 
           {includeSocials ? (
             <div className="flex gap-1 items-center">
-              <a href={`${etherscan}/address/${ethereumAddress}`} target="_blank">
+              <a href={socials?.etherscan} target="_blank">
                 <div className="w-6 h-6 flex justify-center items-center overflow-hidden rounded-full">
                   <img className="object-cover" src="/etherscan.svg" alt="Etherscan" />
                 </div>
               </a>
 
-              {isLens ? (
-                <a href={`https://lensfrens.xyz/${profileName.replace(".lens", "")}`} target="_blank">
+              {socials?.lens ? (
+                <a href={socials.lens} target="_blank">
                   <div className="w-12 h-12 flex justify-center items-center overflow-hidden rounded-full">
                     <img className="object-cover" src="/socials/lens.svg" alt="Lens" />
                   </div>

--- a/packages/react-app-revamp/hooks/useProfileData/index.ts
+++ b/packages/react-app-revamp/hooks/useProfileData/index.ts
@@ -1,26 +1,31 @@
 import { lensClient } from "@config/lens";
 import { config } from "@config/wagmi";
+import { mainnet } from "@config/wagmi/custom-chains/mainnet";
+import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
 import { getEnsAvatar, getEnsName } from "@wagmi/core";
-import { useEffect, useState } from "react";
+import { normalize } from "viem/ens";
 
 const DEFAULT_AVATAR_URL = "/contest/user.svg";
+
+const ETHERSCAN_BASE_URL = mainnet.blockExplorers?.etherscan?.url;
+const LENSFRENS_BASE_URL = "https://lensfrens.xyz";
 
 interface ProfileData {
   profileName: string;
   profileAvatar: string;
-  isLoading: boolean;
-  isLens: boolean;
+  socials: {
+    etherscan: string;
+    lens: string;
+  };
 }
 
-const checkImageUrl = (url: string, timeout = 10000) => {
+const checkImageUrl = async (url: string): Promise<string> => {
   return new Promise((resolve, reject) => {
     const img = new Image();
-
     const timeoutId = setTimeout(() => {
       img.onload = img.onerror = null;
       reject(new Error("Timeout waiting for image to load"));
-    }, timeout);
-
+    }, 10000);
     img.onload = () => {
       clearTimeout(timeoutId);
       resolve(url);
@@ -29,73 +34,81 @@ const checkImageUrl = (url: string, timeout = 10000) => {
       clearTimeout(timeoutId);
       reject(new Error("Image loading error"));
     };
-
     img.src = url;
   });
 };
 
-const useProfileData = (ethereumAddress: string, shortenOnFallback: boolean): ProfileData => {
-  const [data, setData] = useState<ProfileData>({
-    profileName: shortenOnFallback
-      ? `${ethereumAddress.substring(0, 6)}...${ethereumAddress.slice(-3)}`
-      : ethereumAddress,
-    profileAvatar: DEFAULT_AVATAR_URL,
-    isLoading: true,
-    isLens: false,
+const fetchProfileData = async ({ queryKey }: QueryFunctionContext): Promise<ProfileData> => {
+  const [ethereumAddress, shortenOnFallback, includeSocials] = queryKey as [string, boolean, boolean];
+  let profileName = shortenOnFallback
+    ? `${ethereumAddress.substring(0, 6)}...${ethereumAddress.slice(-3)}`
+    : ethereumAddress;
+  let profileAvatar = DEFAULT_AVATAR_URL;
+  let socials = {
+    etherscan: "",
+    lens: "",
+  };
+
+  try {
+    const ensName = await getEnsName(config, { chainId: 1, address: ethereumAddress as `0x${string}` });
+    if (ensName) {
+      const ensAvatar = await getEnsAvatar(config, { name: normalize(ensName), chainId: 1 });
+      try {
+        await checkImageUrl(ensAvatar ?? DEFAULT_AVATAR_URL);
+        profileAvatar = ensAvatar ?? DEFAULT_AVATAR_URL;
+        profileName = ensName;
+      } catch {
+        profileAvatar = DEFAULT_AVATAR_URL;
+      }
+    } else {
+      const lensProfile = await lensClient.profile.fetchDefault({ for: ethereumAddress });
+      if (lensProfile?.handle) {
+        const avatarFragment = lensProfile.metadata?.picture;
+        //@ts-ignore
+        let lensAvatar = avatarFragment?.raw?.uri?.replace("ipfs://", "https://lens.infura-ipfs.io/ipfs/");
+        try {
+          await checkImageUrl(lensAvatar);
+          profileAvatar = lensAvatar;
+        } catch {
+          profileAvatar = DEFAULT_AVATAR_URL;
+        }
+        profileName = lensProfile.handle?.localName ? lensProfile.handle.localName + ".lens" : profileName;
+      }
+    }
+
+    if (includeSocials) {
+      const lensProfile = await lensClient.profile.fetchDefault({ for: ethereumAddress });
+      const handle = lensProfile?.handle?.localName;
+
+      socials = {
+        etherscan: `${ETHERSCAN_BASE_URL}/address/${ethereumAddress}`,
+        lens: handle ? `${LENSFRENS_BASE_URL}/${handle}` : "",
+      };
+    }
+  } catch (error) {
+    console.error(error);
+  }
+
+  return { profileName, profileAvatar, socials };
+};
+
+const useProfileData = (ethereumAddress: string, shortenOnFallback: boolean, includeSocials?: boolean) => {
+  const { data, isLoading, isError, error } = useQuery<ProfileData>({
+    queryKey: [ethereumAddress, shortenOnFallback, includeSocials],
+    queryFn: fetchProfileData,
+    enabled: !!ethereumAddress || !!includeSocials,
   });
 
-  useEffect(() => {
-    const fetchProfileData = async () => {
-      let profileName = shortenOnFallback
-        ? `${ethereumAddress.substring(0, 6)}...${ethereumAddress.slice(-3)}`
-        : ethereumAddress;
-      let profileAvatar = DEFAULT_AVATAR_URL;
-      let isLens = false;
-
-      try {
-        const lensProfile = await lensClient.profile.fetchDefault({ for: ethereumAddress });
-        if (lensProfile?.handle) {
-          const avatarFragment = lensProfile.metadata?.picture;
-
-          //@ts-ignore
-          let lensAvatar = avatarFragment?.raw?.uri?.replace("ipfs://", "https://lens.infura-ipfs.io/ipfs/");
-
-          if (lensAvatar) {
-            try {
-              await checkImageUrl(lensAvatar);
-              profileAvatar = lensAvatar;
-            } catch {
-              profileAvatar = DEFAULT_AVATAR_URL;
-            }
-          }
-          profileName = lensProfile.handle?.localName ? lensProfile.handle.localName + ".lens" : profileName;
-          isLens = true;
-        } else {
-          const ensName = await getEnsName(config, { chainId: 1, address: ethereumAddress as `0x${string}` });
-          if (ensName) {
-            const ensAvatar = await getEnsAvatar(config, { name: ensName, chainId: 1 });
-            if (ensAvatar) {
-              try {
-                await checkImageUrl(ensAvatar);
-                profileAvatar = ensAvatar;
-              } catch {
-                profileAvatar = DEFAULT_AVATAR_URL;
-              }
-            }
-            profileName = ensName || profileName;
-          }
-        }
-      } catch (error) {
-        console.error(error);
-      }
-
-      setData({ profileName, profileAvatar, isLoading: false, isLens });
-    };
-
-    fetchProfileData();
-  }, [ethereumAddress, shortenOnFallback]);
-
-  return data;
+  return {
+    profileName:
+      data?.profileName ??
+      (shortenOnFallback ? `${ethereumAddress.substring(0, 6)}...${ethereumAddress.slice(-3)}` : ethereumAddress),
+    profileAvatar: data?.profileAvatar ?? DEFAULT_AVATAR_URL,
+    socials: data?.socials,
+    isLoading,
+    isError,
+    error,
+  };
 };
 
 export default useProfileData;

--- a/packages/react-app-revamp/lib/frames/submission/index.ts
+++ b/packages/react-app-revamp/lib/frames/submission/index.ts
@@ -1,7 +1,7 @@
 import { serverConfig } from "@config/wagmi/server";
 import { getEnsName, readContract, readContracts } from "@wagmi/core";
 import { Abi } from "viem";
-import { EMPTY_ROOT } from "../utils";
+import { EMPTY_ROOT, fetchProfileName } from "../utils";
 
 export const targetMetadata = {
   targetAddress: "0x0000000000000000000000000000000000000000",
@@ -52,17 +52,12 @@ export const fetchContestInitialData = async (abi: Abi, chainId: number, address
   const submissionMerkleRoot = results[2].result as string;
   const submissionsOpenDate = new Date(Number(results[3].result) * 1000 + 1000);
   const submissionsClosedDate = new Date(Number(results[4].result) * 1000 + 1000);
+  const ensName = await fetchProfileName(creator);
+
   let anyoneCanSubmit = false;
-  let ensName: string | null = null;
 
   if (submissionMerkleRoot === EMPTY_ROOT) {
     anyoneCanSubmit = true;
-  }
-
-  try {
-    ensName = await getEnsName(serverConfig, { address: creator as `0x${string}`, chainId: 1 });
-  } catch (error) {
-    ensName = null;
   }
 
   return {

--- a/packages/react-app-revamp/lib/frames/utils.ts
+++ b/packages/react-app-revamp/lib/frames/utils.ts
@@ -1,4 +1,6 @@
-import { chains } from "@config/wagmi/server";
+import lensClient from "@config/lens";
+import { chains, serverConfig } from "@config/wagmi/server";
+import { getEnsName } from "@wagmi/core";
 
 export const EMPTY_ROOT = "0x0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -15,4 +17,27 @@ export const getChainId = (chain: string): number => {
   )?.id;
 
   return chainId ?? 1;
+};
+
+export const fetchProfileName = async (ethereumAddress: string): Promise<string | null> => {
+  let profileName: string | null = null;
+
+  try {
+    // attempt to fetch ENS name first
+    profileName = await getEnsName(serverConfig, { address: ethereumAddress as `0x${string}`, chainId: 1 });
+
+    // if ENS name is not available, try to fetch the Lens profile name
+    if (!profileName) {
+      const lensProfile = await lensClient.profile.fetchDefault({ for: ethereumAddress });
+      const lensName = lensProfile?.handle?.localName;
+
+      if (lensName) {
+        profileName = `${lensName}.lens`;
+      }
+    }
+  } catch (error) {
+    profileName = null;
+  }
+
+  return profileName;
 };

--- a/packages/react-app-revamp/lib/frames/voting/index.ts
+++ b/packages/react-app-revamp/lib/frames/voting/index.ts
@@ -3,7 +3,7 @@ import { MappedProposalIds } from "@hooks/useProposal/store";
 import { getProposalIdsRaw } from "@hooks/useProposal/utils";
 import { getEnsName, readContract, readContracts } from "@wagmi/core";
 import { Abi, formatEther } from "viem";
-import { EMPTY_ROOT } from "../utils";
+import { EMPTY_ROOT, fetchProfileName } from "../utils";
 
 interface RankDictionary {
   [key: string]: number;
@@ -183,14 +183,8 @@ export const fetchContestInfo = async (abi: Abi, address: string, chainId: numbe
   const contestDeadline = new Date(Number(results[2].result) * 1000 + 1000);
   const isDeleted = results[3].result;
   const proposalAuthor = results[4].result.author;
+  const ensName = await fetchProfileName(proposalAuthor);
   let anyoneCanVote = false;
-  let ensName: string | null = null;
-
-  try {
-    ensName = await getEnsName(serverConfig, { address: proposalAuthor as `0x${string}`, chainId: 1 });
-  } catch (error) {
-    ensName = null;
-  }
 
   if (votingMerkleRoot === EMPTY_ROOT) {
     anyoneCanVote = true;


### PR DESCRIPTION
Closes #1562 

We are using eth -> lens -> address order both for user profiles in our app and for frames, additionally, user profile performance should be much better ( caching is included now ) due to usage of `useQuery`