### PR TITLE
chore: fix language in voting widget

### DIFF
--- a/packages/react-app-revamp/components/ChargeLayout/components/Vote/index.tsx
+++ b/packages/react-app-revamp/components/ChargeLayout/components/Vote/index.tsx
@@ -23,7 +23,7 @@ const ChargeLayoutVote: FC<ChargeLayoutVoteProps> = ({
   insufficientBalance,
   amountOfVotes,
 }) => {
-  const chargeLabel = chargeType === VoteType.PerVote ? "charge for each vote" : "vote charge";
+  const chargeLabel = chargeType === VoteType.PerVote ? "charge per vote" : "vote charge";
   const isPerVote = chargeType === VoteType.PerVote;
   const [totalCharge, setTotalCharge] = useState("0");
 


### PR DESCRIPTION
![image](https://github.com/jk-labs-inc/jokerace/assets/18723426/de076c19-13e0-4cd9-927d-1e1477d4b5fd)

It looks too long when we say "charge for each vote" and this PR is reverting it to "charge per vote"