### PR TITLE
bugfix: add contest author for earnings in params tab

### DIFF
--- a/packages/react-app-revamp/components/_pages/Contest/Parameters/components/Earnings/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/Parameters/components/Earnings/index.tsx
@@ -4,12 +4,15 @@ import { FC } from "react";
 
 interface ContestParametersEarningsProps {
   charge: Charge;
+  contestAuthor: string;
   blockExplorerUrl?: string;
 }
 
-const ContestParametersEarnings: FC<ContestParametersEarningsProps> = ({ charge, blockExplorerUrl }) => {
+const ContestParametersEarnings: FC<ContestParametersEarningsProps> = ({ charge, blockExplorerUrl, contestAuthor }) => {
   const isCreatorSplitEnabled = charge.percentageToCreator > 0;
-  const creatorSplitDestination = charge.splitFeeDestination.address;
+  const creatorSplitDestination = charge.splitFeeDestination.address
+    ? charge.splitFeeDestination.address
+    : contestAuthor;
   const blockExplorerAddressUrl = blockExplorerUrl ? `${blockExplorerUrl}/address/${creatorSplitDestination}` : "";
 
   const percentageToCreatorMessage = () => {
@@ -32,7 +35,7 @@ const ContestParametersEarnings: FC<ContestParametersEarningsProps> = ({ charge,
               target="_blank"
               href={blockExplorerAddressUrl}
             >
-              {shortenEthereumAddress(creatorSplitDestination ?? "")}
+              {shortenEthereumAddress(creatorSplitDestination)}
             </a>
           </li>
         ) : null}

--- a/packages/react-app-revamp/components/_pages/Contest/Parameters/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/Parameters/index.tsx
@@ -22,6 +22,7 @@ const ContestParameters = () => {
     contestMaxProposalCount,
     votingRequirements,
     submissionMerkleRoot,
+    contestAuthor,
     votingMerkleRoot,
     anyoneCanVote,
     charge,
@@ -75,7 +76,9 @@ const ContestParameters = () => {
         votingRequirementsDescription={votingRequirements?.description}
         openConnectModal={openConnectModal}
       />
-      {charge ? <ContestParametersEarnings charge={charge} blockExplorerUrl={blockExplorerUrl} /> : null}
+      {charge ? (
+        <ContestParametersEarnings charge={charge} contestAuthor={contestAuthor} blockExplorerUrl={blockExplorerUrl} />
+      ) : null}
     </div>
   );
 };


### PR DESCRIPTION
We did not specify a `creatorSplitDestination` for every contest created before version `4.29`, so we should pass `contestAuthor` to the earnings component to show where creator earnings are going.