### PR TITLE
feat: keep track of rewards tokens from supabase

### DIFF
--- a/packages/react-app-revamp/components/ChargeLayout/components/CommisionDetails/index.tsx
+++ b/packages/react-app-revamp/components/ChargeLayout/components/CommisionDetails/index.tsx
@@ -15,7 +15,7 @@ const ChargeLayoutCommisionDetails: FC<ChargeLayoutCommisionDetailsProps> = ({
 }) => {
   if (splitFeeDestination.type === SplitFeeDestinationType.NoSplit) {
     return (
-      <ul className="flex flex-col gap-2 pl-2 mt-2 list-bullet-points animate-appear">
+      <ul className="flex flex-col gap-2 pl-2 mt-2 list-bullet-points animate-reveal">
         <div className="flex items-center">
           <li className="text-[16px] text-neutral-9">jokerace commission</li>
           <p className="text-[16px] text-neutral-9 ml-auto">
@@ -27,7 +27,7 @@ const ChargeLayoutCommisionDetails: FC<ChargeLayoutCommisionDetailsProps> = ({
   }
 
   return (
-    <ul className="flex flex-col gap-2 pl-2 mt-2 list-bullet-points animate-appear">
+    <ul className="flex flex-col gap-2 pl-2 mt-2 list-bullet-points animate-reveal">
       <>
         <div className="flex items-center">
           <li className="text-[16px] text-neutral-9">creator commission</li>

--- a/packages/react-app-revamp/components/Comments/components/Comment/index.tsx
+++ b/packages/react-app-revamp/components/Comments/components/Comment/index.tsx
@@ -22,7 +22,7 @@ const Comment: FC<CommentProps> = ({ comment, selectedCommentIds, toggleCommentS
   const isSelected = selectedCommentIds.includes(comment.id);
 
   return (
-    <div className="flex flex-col gap-4 animate-appear">
+    <div className="flex flex-col gap-4 animate-reveal">
       <div className="flex flex-col gap-2">
         <div className="flex justify-between">
           <UserProfileDisplay ethereumAddress={comment.author} shortenOnFallback />

--- a/packages/react-app-revamp/components/Share/index.tsx
+++ b/packages/react-app-revamp/components/Share/index.tsx
@@ -2,7 +2,6 @@ import { Menu, Transition } from "@headlessui/react";
 import { MediaQuery } from "@helpers/mediaQuery";
 import { generateLensShareUrlForContest, generateTwitterShareUrlForContest, generateUrlToCopy } from "@helpers/share";
 import { DuplicateIcon } from "@heroicons/react/outline";
-import { Reward } from "@hooks/useContest/store";
 import Image from "next/image";
 import { FC, Fragment } from "react";
 
@@ -14,10 +13,9 @@ interface ShareDropdownProps {
   contestName: string;
   contestAddress: string;
   chain: string;
-  rewards?: Reward | null;
 }
 
-const ShareDropdown: FC<ShareDropdownProps> = ({ contestName, contestAddress, chain, rewards }) => {
+const ShareDropdown: FC<ShareDropdownProps> = ({ contestName, contestAddress, chain }) => {
   return (
     <Menu as="div" className="relative inline-block text-left">
       <MediaQuery maxWidth={768}>
@@ -45,7 +43,7 @@ const ShareDropdown: FC<ShareDropdownProps> = ({ contestName, contestAddress, ch
             {({ active }) => (
               <a
                 target="_blank"
-                href={generateLensShareUrlForContest(contestName, contestAddress, chain, rewards)}
+                href={generateLensShareUrlForContest(contestName, contestAddress, chain)}
                 className={classNames(
                   active ? "bg-neutral-3 text-gray-900" : "text-gray-700",
                   "flex items-center text-[16px] gap-1 px-4 py-2 hover:bg-gray-100 hover:text-gray-900 border-b border-neutral-3",
@@ -60,7 +58,7 @@ const ShareDropdown: FC<ShareDropdownProps> = ({ contestName, contestAddress, ch
           <Menu.Item>
             {({ active }) => (
               <a
-                href={generateTwitterShareUrlForContest(contestName, contestAddress, chain, rewards)}
+                href={generateTwitterShareUrlForContest(contestName, contestAddress, chain)}
                 target="_blank"
                 className={classNames(
                   active ? "bg-neutral-3 text-gray-900" : "text-gray-700",

--- a/packages/react-app-revamp/components/TokenSearchModal/components/NftList/index.tsx
+++ b/packages/react-app-revamp/components/TokenSearchModal/components/NftList/index.tsx
@@ -29,7 +29,7 @@ const NftsSearchList: FC<NftsSearchListProps> = ({ selectedChain, searchValue, i
   }
 
   return (
-    <div className={`flex flex-col gap-6 animate-appear`}>
+    <div className={`flex flex-col gap-6 animate-reveal`}>
       {nfts.map(nft => (
         <TokenSearchListNft
           key={nft.address}

--- a/packages/react-app-revamp/components/TokenSearchModal/components/TokenList/index.tsx
+++ b/packages/react-app-revamp/components/TokenSearchModal/components/TokenList/index.tsx
@@ -35,7 +35,7 @@ const TokenSearchList: FC<TokenSearchTokenListProps> = ({
   }
 
   return (
-    <div className="flex flex-col gap-6 animate-appear">
+    <div className="flex flex-col gap-6 animate-reveal">
       {tokens.map(token => (
         <TokenSearchListToken
           key={token.address}

--- a/packages/react-app-revamp/components/TokenSearchModal/components/UserTokens/index.tsx
+++ b/packages/react-app-revamp/components/TokenSearchModal/components/UserTokens/index.tsx
@@ -35,7 +35,7 @@ const TokenSearchModalUserTokens: FC<TokenSearchModalUserTokensProps> = ({
   if (!tokens) return null;
 
   return (
-    <div className="flex flex-col gap-6 animate-appear">
+    <div className="flex flex-col gap-6 animate-reveal">
       {tokens.map(token => (
         <TokenSearchListToken
           key={token.address}

--- a/packages/react-app-revamp/components/UI/UserProfileDisplay/index.tsx
+++ b/packages/react-app-revamp/components/UI/UserProfileDisplay/index.tsx
@@ -96,7 +96,7 @@ const UserProfileDisplay = ({
         <img style={{ width: "100%", height: "100%", objectFit: "cover" }} src={profileAvatar} alt="avatar" />
       </div>
       {isLoading ? (
-        <p className={`${textSizeClass} loadingDots`}>Loading profile data</p>
+        <p className={`${textSizeClass} animate-flicker-infinite`}>Loading profile data</p>
       ) : (
         <div className="flex flex-col gap-1">
           <a

--- a/packages/react-app-revamp/components/_pages/Contest/Contest/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/Contest/index.tsx
@@ -14,7 +14,6 @@ import { useAccount } from "wagmi";
 import ContestPrompt from "../components/Prompt";
 import ProposalStatistics from "../components/ProposalStatistics";
 import ContestStickyCards from "../components/StickyCards";
-import ContestTimeline from "../components/Timeline";
 
 const ContestTab = () => {
   const { contestPrompt } = useContestStore(state => state);
@@ -71,7 +70,7 @@ const ContestTab = () => {
   };
 
   return (
-    <div>
+    <div className="animate-reveal">
       <div className="mt-8">
         <ContestPrompt prompt={contestPrompt} type="page" />
       </div>
@@ -89,7 +88,7 @@ const ContestTab = () => {
 
           {!isContestLoading && !isListProposalsLoading && isContestSuccess && isListProposalsSuccess && (
             <div
-              className={`animate-appear ${contestStatus !== ContestStatus.SubmissionOpen ? "mt-4" : "mt-0"} ${
+              className={`animate-reveal ${contestStatus !== ContestStatus.SubmissionOpen ? "mt-4" : "mt-0"} ${
                 blurProposals ? "blurProposals" : ""
               }`}
             >

--- a/packages/react-app-revamp/components/_pages/Contest/Extensions/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/Extensions/index.tsx
@@ -19,7 +19,7 @@ const ContestExtensions = () => {
     return <div className="text-neutral-11 text-[20px] normal-case">hmm what’s this page doing here? 👀</div>;
 
   return (
-    <div className="flex flex-col gap-8">
+    <div className="flex flex-col gap-8 animate-reveal">
       {isMobile ? (
         <p className="text-neutral-11 text-[16px] normal-case">
           extensions are integrations with other services <br />

--- a/packages/react-app-revamp/components/_pages/Contest/Parameters/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/Parameters/index.tsx
@@ -46,7 +46,7 @@ const ContestParameters = () => {
   const anyoneCanSubmit = submissionMerkleRoot === EMPTY_ROOT;
 
   return (
-    <div className="flex flex-col gap-16">
+    <div className="flex flex-col gap-16 animate-reveal">
       <ContestParametersTimeline
         submissionsOpen={formattedSubmissionsOpen}
         votesOpen={formattedVotesOpen}

--- a/packages/react-app-revamp/components/_pages/Contest/Rewards/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/Rewards/index.tsx
@@ -139,7 +139,7 @@ const ContestRewards = () => {
   }
 
   return (
-    <>
+    <div className="animate-reveal">
       {!isLoading && isSuccess && (
         <>
           {rewardsStore.isLoading && <Loader>Loading rewards</Loader>}
@@ -153,6 +153,7 @@ const ContestRewards = () => {
                     <a
                       className="text-positive-11 text-[16px] font-bold underline break-all"
                       href={`${rewardsStore?.rewards?.blockExplorers?.url}address/${rewardsStore?.rewards?.contractAddress}`}
+                      target="_blank"
                     >
                       {rewardsStore?.rewards?.contractAddress}
                     </a>
@@ -267,7 +268,7 @@ const ContestRewards = () => {
           />
         </>
       )}
-    </>
+    </div>
   );
 };
 

--- a/packages/react-app-revamp/components/_pages/Contest/Rewards/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/Rewards/index.tsx
@@ -37,6 +37,7 @@ const ContestRewards = () => {
     sortingEnabled,
     contestMaxProposalCount,
     downvotingAllowed,
+    rewardsModuleAddress,
   } = useContestStore(state => state);
   const {
     version,
@@ -51,8 +52,8 @@ const ContestRewards = () => {
   const rewardsStore = useRewardsStore(state => state);
   const { getContestRewardsModule } = useRewardsModule();
   const { address: accountAddress } = useAccount();
-  const { unpaidTokens } = useUnpaidRewardTokens();
-  const { paidTokens } = usePaidRewardTokens();
+  const { unpaidTokens } = useUnpaidRewardTokens("rewards-module-unpaid-tokens", rewardsModuleAddress);
+  const { paidTokens } = usePaidRewardTokens("rewards-module-paid-tokens", rewardsModuleAddress);
   const creator = contestAuthorEthereumAddress === accountAddress;
 
   useAccountEffect({

--- a/packages/react-app-revamp/components/_pages/Contest/Rewards/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/Rewards/index.tsx
@@ -16,6 +16,8 @@ import useContractVersion from "@hooks/useContractVersion";
 import { useDeployRewardsStore } from "@hooks/useDeployRewards/store";
 import useRewardsModule from "@hooks/useRewards";
 import { useRewardsStore } from "@hooks/useRewards/store";
+import usePaidRewardTokens from "@hooks/useRewardsTokens/usePaidRewardsTokens";
+import { useUnpaidRewardTokens } from "@hooks/useRewardsTokens/useUnpaidRewardsTokens";
 import { compareVersions } from "compare-versions";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -49,6 +51,8 @@ const ContestRewards = () => {
   const rewardsStore = useRewardsStore(state => state);
   const { getContestRewardsModule } = useRewardsModule();
   const { address: accountAddress } = useAccount();
+  const { unpaidTokens } = useUnpaidRewardTokens();
+  const { paidTokens } = usePaidRewardTokens();
   const creator = contestAuthorEthereumAddress === accountAddress;
 
   useAccountEffect({
@@ -228,7 +232,7 @@ const ContestRewards = () => {
                     key={index}
                     chainId={chainId}
                     payee={payee}
-                    erc20Tokens={rewardsStore.rewards.balance}
+                    erc20Tokens={unpaidTokens ?? []}
                     contractRewardsModuleAddress={rewardsStore.rewards.contractAddress}
                     abiRewardsModule={rewardsStore.rewards.abi}
                   />
@@ -244,7 +248,7 @@ const ContestRewards = () => {
                     key={index}
                     chainId={chainId}
                     payee={payee}
-                    erc20Tokens={rewardsStore.rewards.balance}
+                    erc20Tokens={paidTokens ?? []}
                     contractRewardsModuleAddress={rewardsStore.rewards.contractAddress}
                     abiRewardsModule={rewardsStore.rewards.abi}
                     showPreviouslyDistributedTable

--- a/packages/react-app-revamp/components/_pages/Contest/components/RewardsInfo/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/components/RewardsInfo/index.tsx
@@ -1,0 +1,159 @@
+import { chains, config } from "@config/wagmi";
+import { extractPathSegments } from "@helpers/extractPath";
+import usePaidRewardTokens from "@hooks/useRewardsTokens/usePaidRewardsTokens";
+import useUnpaidRewardTokens from "@hooks/useRewardsTokens/useUnpaidRewardsTokens";
+import { readContract } from "@wagmi/core";
+import { usePathname } from "next/navigation";
+import { FC, useEffect, useState } from "react";
+import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
+import { useMediaQuery } from "react-responsive";
+import { Abi, erc20Abi } from "viem";
+import { useReadContract } from "wagmi";
+
+interface ContestRewardsInfoProps {
+  rewardsModuleAddress: string;
+  rewardsAbi: Abi;
+}
+
+const ContestRewardsInfo: FC<ContestRewardsInfoProps> = ({ rewardsModuleAddress, rewardsAbi }) => {
+  const pathname = usePathname();
+  const { chainName } = extractPathSegments(pathname);
+  const chainId = chains.filter(
+    (chain: { name: string }) => chain.name.toLowerCase().replace(" ", "") === chainName.toLowerCase(),
+  )?.[0]?.id;
+  const nativeCurrency = chains.filter(
+    (chain: { name: string }) => chain.name.toLowerCase().replace(" ", "") === chainName.toLowerCase(),
+  )?.[0]?.nativeCurrency.symbol;
+  const isMobile = useMediaQuery({ maxWidth: 768 });
+  const {
+    unpaidTokens,
+    isLoading: isUnpaidTokensLoading,
+    isError: isUnpaidTokensError,
+    refetchUnpaidTokens,
+  } = useUnpaidRewardTokens("rewards-info-unpaid-tokens", rewardsModuleAddress, true);
+  const {
+    paidTokens,
+    isLoading: isPaidTokensLoading,
+    isError: isPaidTokensError,
+    refetchPaidTokens,
+  } = usePaidRewardTokens("rewards-info-paid-tokens", rewardsModuleAddress, true);
+
+  const {
+    data: payees,
+    isLoading: isPayeesDataLoading,
+    isError: isPayeesDataError,
+    refetch: refetchPayees,
+  } = useReadContract({
+    address: rewardsModuleAddress as `0x${string}`,
+    abi: rewardsAbi,
+    chainId: chainId,
+    functionName: "getPayees",
+  }) as { data: bigint[]; isLoading: boolean; isError: boolean; refetch: () => void };
+
+  const [tokenSymbols, setTokenSymbols] = useState<string[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const currentToken = unpaidTokens ? unpaidTokens[currentIndex] : null;
+  const currentSymbol = tokenSymbols[currentIndex];
+  const isLoading = isUnpaidTokensLoading || isPaidTokensLoading || isPayeesDataLoading;
+  const isError = isUnpaidTokensError || isPaidTokensError || isPayeesDataError;
+
+  useEffect(() => {
+    const fetchTokenSymbols = async () => {
+      if (!unpaidTokens || isUnpaidTokensLoading) return;
+
+      const symbols = await Promise.all(
+        unpaidTokens.map(async token => {
+          if (token.contractAddress === "native") {
+            return nativeCurrency;
+          } else {
+            const symbol = readContract(config, {
+              address: token.contractAddress as `0x${string}`,
+              chainId: chainId,
+              abi: erc20Abi,
+              functionName: "symbol",
+            });
+            return symbol;
+          }
+        }),
+      );
+      setTokenSymbols(symbols);
+    };
+
+    fetchTokenSymbols();
+  }, [unpaidTokens, isUnpaidTokensLoading, nativeCurrency, chainId]);
+
+  useEffect(() => {
+    if (unpaidTokens && unpaidTokens.length > 0) {
+      const interval = setInterval(() => {
+        setCurrentIndex(prevIndex => (prevIndex + 1) % unpaidTokens.length);
+      }, 3000);
+
+      return () => clearInterval(interval);
+    }
+  }, [unpaidTokens]);
+
+  const determineErrorFunction = () => {
+    if (isUnpaidTokensError) {
+      return refetchUnpaidTokens;
+    }
+
+    if (isPaidTokensError) {
+      return refetchPaidTokens;
+    }
+
+    if (isPayeesDataError) {
+      return refetchPayees;
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <SkeletonTheme baseColor="#000000" highlightColor="#212121" duration={1}>
+        <Skeleton
+          borderRadius={10}
+          className="h-8 shrink-0 p-2 border border-neutral-11"
+          width={isMobile ? 100 : 200}
+        />
+      </SkeletonTheme>
+    );
+  }
+
+  if (isError) {
+    return (
+      <p className="text-[16px] text-negative-11 font-bold normal-case">
+        there was an issue while loading rewards,{" "}
+        <span className="underline" onClick={determineErrorFunction}>
+          please try again
+        </span>
+      </p>
+    );
+  }
+
+  if (unpaidTokens?.length === 0 && paidTokens && paidTokens?.length > 0) {
+    return (
+      <div className="flex shrink-0 h-8 p-4 items-center bg-neutral-0 border border-positive-11 rounded-[10px] text-[16px] font-bold text-positive-11">
+        rewards paid out!
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {currentToken ? (
+        <div className="flex shrink-0 h-8 w-52 max-w-56 p-4 justify-center items-center bg-neutral-0 border border-transparent rounded-[10px] text-[16px] font-bold text-neutral-11 overflow-hidden">
+          <span className="truncate flex items-center">
+            {currentToken.tokenBalance} $
+            <span className="uppercase mr-1 truncate inline-block overflow-hidden">{currentSymbol}</span>
+            {!isMobile ? (
+              <>
+                to {payees.length} {payees.length > 1 ? "winners" : "winner"}
+              </>
+            ) : null}
+          </span>
+        </div>
+      ) : null}
+    </>
+  );
+};
+
+export default ContestRewardsInfo;

--- a/packages/react-app-revamp/components/_pages/Contest/components/StickyCards/components/VotingQualifier/components/VotingQualifierMessage/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/components/StickyCards/components/VotingQualifier/components/VotingQualifierMessage/index.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/no-unescaped-entities */
 import { formatNumber } from "@helpers/formatNumber";
 import { ContestStatus } from "@hooks/useContestStatus/store";
-import { formatEther } from "ethers/lib/utils";
 import { FC } from "react";
 
 interface VotingQualifierMessageProps {

--- a/packages/react-app-revamp/components/_pages/Create/components/Error/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/components/Error/index.tsx
@@ -6,7 +6,7 @@ interface ErrorMessageProps {
 
 const ErrorMessage: FC<ErrorMessageProps> = ({ error }) => {
   return (
-    <div className="h-1 animate-fadeIn">
+    <div className="h-1 animate-reveal">
       <p className="text-[16px] text-negative-11 font-bold">{error}</p>
     </div>
   );

--- a/packages/react-app-revamp/components/_pages/Create/components/RequirementsSettings/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/components/RequirementsSettings/index.tsx
@@ -129,7 +129,7 @@ const CreateRequirementsSettings: FC<CreateRequirementsSettingsProps> = ({
   };
 
   return (
-    <div className="animate-appear md:ml-4 md:pl-4 md:border-l border-true-white mt-4">
+    <div className="animate-reveal md:ml-4 md:pl-4 md:border-l border-true-white mt-4">
       <div className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <div className="flex gap-3 items-center">
@@ -201,7 +201,7 @@ const CreateRequirementsSettings: FC<CreateRequirementsSettingsProps> = ({
               </Tooltip>
             </div>
             {error?.tokenAddressError ? (
-              <p className="text-negative-11 text-[14px] font-bold animate-fadeIn">{error.tokenAddressError}</p>
+              <p className="text-negative-11 text-[14px] font-bold animate-reveal">{error.tokenAddressError}</p>
             ) : null}
           </div>
         </div>
@@ -244,7 +244,7 @@ const CreateRequirementsSettings: FC<CreateRequirementsSettingsProps> = ({
                   onChange={onPowerTypeChange}
                 />
               </div>
-              <p className="text-negative-11 text-[14px] font-bold animate-fadeIn">{error?.powerValueError}</p>
+              <p className="text-negative-11 text-[14px] font-bold animate-reveal">{error?.powerValueError}</p>
             </div>
           </div>
         ) : null}

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestStart/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestStart/index.tsx
@@ -28,7 +28,7 @@ const CreateContestStart: FC<CreateContestStartProps> = ({ onClick }) => {
   };
 
   return (
-    <div className="flex flex-col gap-10 lg:ml-[300px] mt-6 md:mt-24 animate-fadeIn">
+    <div className="flex flex-col gap-10 lg:ml-[300px] mt-6 md:mt-24 animate-reveal">
       <div className="flex flex-col gap-2">
         <p className="text-true-white text-[24px] font-bold">{stepTitle}</p>
         <div className="flex flex-col gap-4">

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingAllowlist/components/CSVEditor/CSVParseError/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingAllowlist/components/CSVEditor/CSVParseError/index.tsx
@@ -17,7 +17,7 @@ const CSVParseError: FC<CSVParseErrorProps> = ({ type, step }) => {
       case "missingColumns":
       case "unexpectedHeaders":
         return (
-          <div className="flex flex-col text-[16px] animate-fadeIn">
+          <div className="flex flex-col text-[16px] animate-reveal">
             {step === "voting" ? (
               <p className=" text-negative-11">
                 Ruh-roh! CSV couldn’t be imported.{" "}
@@ -46,7 +46,7 @@ const CSVParseError: FC<CSVParseErrorProps> = ({ type, step }) => {
         );
       case "limitExceeded":
         return (
-          <div className="flex flex-col text-[16px] animate-fadeIn">
+          <div className="flex flex-col text-[16px] animate-reveal">
             <p className=" text-negative-11">
               Ruh-roh! CSV file has too many rows.{" "}
               <span className="font-bold">The maximum number of rows allowed is {formatNumber(MAX_ROWS)}</span>
@@ -55,7 +55,7 @@ const CSVParseError: FC<CSVParseErrorProps> = ({ type, step }) => {
         );
       case "allZero":
         return (
-          <div className="flex flex-col text-[16px] animate-fadeIn">
+          <div className="flex flex-col text-[16px] animate-reveal">
             <p className=" text-negative-11">
               Ruh-roh! All votes in the CSV file are 0.{" "}
               <span className="font-bold">CSV should have at least one vote above zero.</span>

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingRequirements/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingRequirements/index.tsx
@@ -143,7 +143,7 @@ const CreateVotingRequirements = () => {
       default:
         return (
           <div className={`${isDropdownOpen ? "opacity-20 transition-opacity duration-300 ease-in-out" : ""}`}>
-            <p className="text-[16px] animate-reveal">
+            <p className="text-[16px] animate-appear">
               <b>note: </b>by letting anyone vote, you’ll need to set a <br />
               charge-per-vote to prevent bots from voting.
             </p>

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingRequirements/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestVoting/components/VotingRequirements/index.tsx
@@ -143,7 +143,7 @@ const CreateVotingRequirements = () => {
       default:
         return (
           <div className={`${isDropdownOpen ? "opacity-20 transition-opacity duration-300 ease-in-out" : ""}`}>
-            <p className="text-[16px] animate-appear">
+            <p className="text-[16px] animate-reveal">
               <b>note: </b>by letting anyone vote, you’ll need to set a <br />
               charge-per-vote to prevent bots from voting.
             </p>

--- a/packages/react-app-revamp/components/_pages/DialogCheckBalanceRewardsModule/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogCheckBalanceRewardsModule/index.tsx
@@ -6,8 +6,8 @@ import { useContestStore } from "@hooks/useContest/store";
 import { useRewardsStore } from "@hooks/useRewards/store";
 import { useTokenBalance } from "@hooks/useTokenBalance";
 import { useWithdrawReward, useWithdrawRewardStore } from "@hooks/useWithdrawRewards";
-import { utils } from "ethers";
 import { FC, useEffect, useState } from "react";
+import { formatUnits } from "viem";
 import { useAccount } from "wagmi";
 import CreateTextInput from "../Create/components/TextInput";
 
@@ -114,7 +114,7 @@ export const DialogCheckBalanceRewardsModule: FC<DialogCheckBalanceRewardsModule
         {queryTokenBalance?.symbol && !tokenAlreadyAdded && (
           <ul className="flex gap-6 text-[16px] pt-6 font-bold list-explainer animate-appear">
             <li className="flex items-center uppercase">
-              {parseFloat(utils.formatUnits(queryTokenBalance.value, queryTokenBalance.decimals))} $
+              {parseFloat(formatUnits(queryTokenBalance.value, queryTokenBalance.decimals))} $
               {queryTokenBalance?.symbol}
             </li>
             <div className="flex gap-2">

--- a/packages/react-app-revamp/components/_pages/DialogModalProposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalProposal/index.tsx
@@ -139,7 +139,7 @@ const DialogModalProposal: FC<DialogModalProposalProps> = ({
         {isProposalLoading ? (
           <p className="loadingDots font-sabo text-[18px] mt-8 text-neutral-9">loading submission info</p>
         ) : (
-          <div className="animate-fadeIn flex flex-col gap-12">
+          <div className="animate-reveal flex flex-col gap-12">
             {proposalData?.proposal ? (
               <div className="flex flex-col gap-4">
                 {proposalData.proposal.rank > 0 && (

--- a/packages/react-app-revamp/components/_pages/DialogWithdrawFundsFromRewardsModule/ButtonWithdraw.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogWithdrawFundsFromRewardsModule/ButtonWithdraw.tsx
@@ -1,5 +1,5 @@
 import ButtonV3, { ButtonSize } from "@components/UI/ButtonV3";
-import { utils } from "ethers";
+import { formatUnits } from "viem";
 
 interface ButtonWithdrawErc20RewardProps {
   queryTokenBalance: any;
@@ -16,9 +16,7 @@ export const ButtonWithdraw = (props: ButtonWithdrawErc20RewardProps) => {
     <li className="flex items-center">
       <section className="flex justify-between w-full md:w-[650px]">
         <p>
-          {queryTokenBalance?.decimals <= 18
-            ? parseFloat(utils.formatEther(queryTokenBalance.data.value))
-            : parseFloat(utils.formatUnits(queryTokenBalance.data.value, queryTokenBalance.data.decimals))}{" "}
+          {parseFloat(formatUnits(queryTokenBalance.data.value, queryTokenBalance.data.decimals))}{" "}
           <span className="uppercase">${queryTokenBalance.data.symbol}</span>
         </p>
         <ButtonV3

--- a/packages/react-app-revamp/components/_pages/ListContests/Contest/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListContests/Contest/index.tsx
@@ -431,18 +431,25 @@ const Contest: FC<ContestProps> = ({ contest, compact, loading, rewards, allowTo
             )}
           </div>
           <div className="flex flex-col">
-            <p className={`font-bold w-full ${contestReward ? "text-neutral-11" : "text-neutral-9"} `}>
-              {rewardsLoading || loading ? (
-                <Skeleton />
-              ) : contestReward ? (
-                <>
-                  {contestReward.token.value} <span className="uppercase">${contestReward.token.symbol}</span>
-                </>
-              ) : (
-                "No rewards"
-              )}
-            </p>
-            {contestReward && (
+            {rewardsLoading || loading ? (
+              <Skeleton />
+            ) : (
+              <>
+                {contestReward && contestReward.token ? (
+                  <p className="font-bold w-full text-neutral-11">
+                    {contestReward.token.value} <span className="uppercase">${contestReward.token.symbol}</span>
+                  </p>
+                ) : contestReward && contestReward.rewardsPaidOut ? (
+                  <p className="font-bold w-full text-positive-11">
+                    rewards <br /> paid out!
+                  </p>
+                ) : (
+                  <p className="font-bold w-full text-neutral-9">no rewards</p>
+                )}
+              </>
+            )}
+
+            {contestReward && contestReward.token && (
               <p>
                 {rewardsLoading || loading ? (
                   <Skeleton />
@@ -517,12 +524,14 @@ const Contest: FC<ContestProps> = ({ contest, compact, loading, rewards, allowTo
                     <li>
                       <Skeleton width={100} />
                     </li>
-                  ) : contestReward ? (
+                  ) : contestReward && contestReward.token ? (
                     <li>
                       {contestReward.token.value}
                       <span className="uppercase"> ${contestReward.token.symbol} </span>
                       to {contestReward.winners} {contestReward.winners > 1 ? "winners" : "winner"}
                     </li>
+                  ) : contestReward && contestReward.rewardsPaidOut ? (
+                    <li>rewards paid out! </li>
                   ) : null}
                 </>
               )}

--- a/packages/react-app-revamp/components/_pages/ListProposals/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListProposals/index.tsx
@@ -102,25 +102,28 @@ export const ListProposals = () => {
 
           return (
             <div key={index} className="relative">
-              {proposal.netVotes > 0 ? (
-                <div className="absolute top-0 right-0 -mr-2 -mt-4 p-4 z-10 h-7 rounded-[16px] bg-true-black flex items-center justify-center text-[16px] font-bold text-neutral-11 border border-neutral-11">
-                  {formatNumber(proposal.netVotes)} vote{proposal.netVotes !== 1 ? "s" : ""}
-                </div>
-              ) : null}
-              <ProposalContent
-                proposal={{
-                  id: proposal.id,
-                  authorEthereumAddress: proposal.author,
-                  content: proposal.description,
-                  exists: proposal.exists,
-                  isContentImage: proposal.isContentImage,
-                  tweet: proposal.tweet,
-                  votes: proposal.netVotes,
-                  rank: proposal.rank,
-                  isTied: proposal.isTied,
-                  commentsCount: proposal.commentsCount,
-                }}
-              />
+              <div className="relative p-1">
+                {proposal.netVotes > 0 ? (
+                  <div className="absolute top-0 right-0 transform translate-y-[-16px] p-4 z-10 h-7 rounded-[16px] bg-true-black flex items-center justify-center text-[16px] font-bold text-neutral-11 border border-neutral-11">
+                    {formatNumber(proposal.netVotes)} vote{proposal.netVotes !== 1 ? "s" : ""}
+                  </div>
+                ) : null}
+                <ProposalContent
+                  proposal={{
+                    id: proposal.id,
+                    authorEthereumAddress: proposal.author,
+                    content: proposal.description,
+                    exists: proposal.exists,
+                    isContentImage: proposal.isContentImage,
+                    tweet: proposal.tweet,
+                    votes: proposal.netVotes,
+                    rank: proposal.rank,
+                    isTied: proposal.isTied,
+                    commentsCount: proposal.commentsCount,
+                  }}
+                />
+              </div>
+
               {allowDelete && (
                 <div
                   className="absolute cursor-pointer -bottom-0 right-0 z-10"

--- a/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
@@ -67,7 +67,7 @@ const ProposalContent: FC<ProposalContentProps> = ({ proposal }) => {
 
   return (
     <div
-      className={`flex flex-col w-full animate-appear ${isProposalTweet ? "" : "h-96 md:h-80"} rounded-[10px] border border-neutral-11 hover:bg-neutral-1 cursor-pointer transition-colors duration-500 ease-in-out`}
+      className={`flex flex-col w-full animate-reveal ${isProposalTweet ? "" : "h-96 md:h-80"} rounded-[10px] border border-neutral-11 hover:bg-neutral-1 cursor-pointer transition-colors duration-500 ease-in-out`}
     >
       <Link href={`/contest/${chainName}/${contestAddress}/submission/${proposal.id}`} shallow scroll={false} prefetch>
         <ProposalContentInfo

--- a/packages/react-app-revamp/components/_pages/Rewards/components/Withdraw/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Rewards/components/Withdraw/index.tsx
@@ -11,7 +11,10 @@ interface ContestWithdrawRewardsProps {
 
 const ContestWithdrawRewards: FC<ContestWithdrawRewardsProps> = ({ rewardsStore }) => {
   const { chain } = useAccount();
-  const { unpaidTokens } = useUnpaidRewardTokens("rewards-module-unpaid-tokens", rewardsStore.rewards.contractAddress);
+  const { unpaidTokens } = useUnpaidRewardTokens(
+    "rewards-module-unpaid-tokens",
+    rewardsStore?.rewards?.contractAddress,
+  );
   const nativeTokenBalance = useBalance({
     address: rewardsStore?.rewards?.contractAddress as `0x${string}`,
     chainId: chain?.id,

--- a/packages/react-app-revamp/components/_pages/Rewards/components/Withdraw/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Rewards/components/Withdraw/index.tsx
@@ -1,7 +1,7 @@
 import ButtonWithdrawERC20Reward from "@components/_pages/DialogWithdrawFundsFromRewardsModule/ButtonWithdrawERC20Reward";
 import ButtonWithdrawNativeReward from "@components/_pages/DialogWithdrawFundsFromRewardsModule/ButtonWithdrawNativeReward";
-import { ZERO_BALANCE } from "@components/_pages/RewardsDistributionTable/components";
 import { Tab } from "@headlessui/react";
+import useUnpaidRewardTokens from "@hooks/useRewardsTokens/useUnpaidRewardsTokens";
 import { FC, Fragment } from "react";
 import { useAccount, useBalance } from "wagmi";
 
@@ -11,6 +11,7 @@ interface ContestWithdrawRewardsProps {
 
 const ContestWithdrawRewards: FC<ContestWithdrawRewardsProps> = ({ rewardsStore }) => {
   const { chain } = useAccount();
+  const { unpaidTokens } = useUnpaidRewardTokens();
   const nativeTokenBalance = useBalance({
     address: rewardsStore?.rewards?.contractAddress as `0x${string}`,
     chainId: chain?.id,
@@ -35,26 +36,19 @@ const ContestWithdrawRewards: FC<ContestWithdrawRewardsProps> = ({ rewardsStore 
         </Tab.List>
         <Tab.Panels>
           <Tab.Panel>
-            {rewardsStore.rewards.balance &&
-            rewardsStore.rewards.balance?.some(
-              (token: { tokenBalance: string }) => token.tokenBalance !== ZERO_BALANCE,
-            ) ? (
+            {unpaidTokens && unpaidTokens.length > 0 ? (
               <ul className="flex flex-col gap-3 pl-4 text-[16px] font-bold list-explainer">
-                {rewardsStore?.rewards.balance
-                  ?.filter((token: { tokenBalance: string }) => token.tokenBalance !== ZERO_BALANCE)
-                  .map((token: { contractAddress: string }, index: number) => (
-                    <ButtonWithdrawERC20Reward
-                      key={index}
-                      contractRewardsModuleAddress={rewardsStore.rewards.contractAddress}
-                      abiRewardsModule={rewardsStore.rewards.abi}
-                      tokenAddress={token.contractAddress}
-                    />
-                  ))}
+                {unpaidTokens.map((token, index) => (
+                  <ButtonWithdrawERC20Reward
+                    key={index}
+                    contractRewardsModuleAddress={rewardsStore.rewards.contractAddress}
+                    abiRewardsModule={rewardsStore.rewards.abi}
+                    tokenAddress={token.contractAddress}
+                  />
+                ))}
               </ul>
             ) : (
-              <>
-                <p className="italic text-[16px]  text-neutral-11">No balance found for ERC20 tokens.</p>
-              </>
+              <p className="italic text-[16px] text-neutral-11">No balance found for ERC20 tokens.</p>
             )}
           </Tab.Panel>
           <Tab.Panel>

--- a/packages/react-app-revamp/components/_pages/Rewards/components/Withdraw/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Rewards/components/Withdraw/index.tsx
@@ -11,7 +11,7 @@ interface ContestWithdrawRewardsProps {
 
 const ContestWithdrawRewards: FC<ContestWithdrawRewardsProps> = ({ rewardsStore }) => {
   const { chain } = useAccount();
-  const { unpaidTokens } = useUnpaidRewardTokens();
+  const { unpaidTokens } = useUnpaidRewardTokens("rewards-module-unpaid-tokens", rewardsStore.rewards.contractAddress);
   const nativeTokenBalance = useBalance({
     address: rewardsStore?.rewards?.contractAddress as `0x${string}`,
     chainId: chain?.id,

--- a/packages/react-app-revamp/components/_pages/RewardsDistributionTable/components/Reward/components/PreviouslyDistributedReward/index.tsx
+++ b/packages/react-app-revamp/components/_pages/RewardsDistributionTable/components/Reward/components/PreviouslyDistributedReward/index.tsx
@@ -1,5 +1,5 @@
-import { formatUnits } from "ethers/lib/utils";
 import Skeleton from "react-loading-skeleton";
+import { formatUnits } from "viem";
 
 interface PreviouslyDistributedRewardProps {
   queryTokenBalance: any;

--- a/packages/react-app-revamp/components/_pages/RewardsDistributionTable/components/index.tsx
+++ b/packages/react-app-revamp/components/_pages/RewardsDistributionTable/components/index.tsx
@@ -10,7 +10,7 @@ import { PayeeNativeReward } from "./NativeReward";
 
 export const ZERO_BALANCE = "0x0000000000000000000000000000000000000000000000000000000000000000";
 
-type ERC20Token = {
+export type ERC20Token = {
   contractAddress: string;
   tokenBalance: string;
   decimals: number;

--- a/packages/react-app-revamp/components/_pages/Submission/Mobile/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Submission/Mobile/index.tsx
@@ -99,7 +99,7 @@ const SubmissionPageMobileLayout: FC<SubmissionPageMobileLayoutProps> = ({
         {isProposalLoading ? (
           <p className="loadingDots font-sabo text-[18px] mt-12 text-neutral-9">loading submission info</p>
         ) : (
-          <div className="animate-fadeIn flex flex-col gap-8">
+          <div className="animate-reveal flex flex-col gap-8">
             <div className="flex flex-col gap-4">
               {proposalData?.proposal ? (
                 <div className="flex flex-col gap-4">

--- a/packages/react-app-revamp/config/wagmi/custom-chains/sepolia.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/sepolia.ts
@@ -18,8 +18,8 @@ export const sepolia: Chain = {
     },
   },
   blockExplorers: {
-    etherscan: { name: "Sepolia Etherscan", url: "https://sepolia.etherscan/" },
-    default: { name: "Sepolia Otterscan", url: "https://sepolia.otterscan/" },
+    etherscan: { name: "Sepolia Etherscan", url: "https://sepolia.etherscan.io/" },
+    default: { name: "Sepolia Etherscan", url: "https://sepolia.etherscan.io/" },
   },
   testnet: true,
 };

--- a/packages/react-app-revamp/helpers/getTokenDecimals.ts
+++ b/packages/react-app-revamp/helpers/getTokenDecimals.ts
@@ -1,0 +1,40 @@
+import { config } from "@config/wagmi";
+import { readContract } from "@wagmi/core";
+import { erc20Abi } from "viem";
+
+export const getTokenDecimals = async (tokenAddress: string, chainId: number) => {
+  try {
+    const decimals = (await readContract(config, {
+      address: tokenAddress as `0x${string}`,
+      abi: erc20Abi,
+      chainId: chainId,
+      functionName: "decimals",
+    })) as number;
+
+    return decimals;
+  } catch {
+    return null;
+  }
+};
+
+export const getTokenDecimalsBatch = async (
+  tokenAddresses: string[],
+  chainId: number,
+): Promise<{ [address: string]: number }> => {
+  const decimalsPromises = tokenAddresses.map(async address => {
+    const decimals = await getTokenDecimals(address, chainId);
+    return { address, decimals };
+  });
+
+  const decimalsArray = await Promise.all(decimalsPromises);
+
+  return decimalsArray.reduce(
+    (acc, { address, decimals }) => {
+      if (decimals !== null) {
+        acc[address] = decimals;
+      }
+      return acc;
+    },
+    {} as { [address: string]: number },
+  );
+};

--- a/packages/react-app-revamp/helpers/share.ts
+++ b/packages/react-app-revamp/helpers/share.ts
@@ -1,4 +1,3 @@
-import { Reward } from "@hooks/useContest/store";
 import { copyToClipboard } from "./copyToClipboard";
 
 interface UrlParams {
@@ -18,36 +17,21 @@ const buildUrl = (baseUrl: string, params: UrlParams): string => {
   return `${baseUrl}${query}`;
 };
 
-const contestShareText = (contestName: string, rewards?: Reward | null) => {
-  let rewardsText =
-    rewards && rewards.token && rewards.token.value && rewards.token.symbol
-      ? ` to win ${rewards.token.value}$${rewards.token.symbol}`
-      : "";
-
-  return `Come play ${contestName} on @jokerace_io with me${rewardsText}!\n`;
+const contestShareText = (contestName: string) => {
+  return `Come play ${contestName} on @jokerace_io with me!\n`;
 };
 
-export const generateLensShareUrlForContest = (
-  contestName: string,
-  contestAddress: string,
-  chain: string,
-  rewards?: Reward | null,
-) => {
+export const generateLensShareUrlForContest = (contestName: string, contestAddress: string, chain: string) => {
   const params = {
-    text: contestShareText(contestName, rewards),
+    text: contestShareText(contestName),
     url: `${BASE_JOKERACE_URL}${chain}/${contestAddress}`,
   };
   return buildUrl(BASE_LENSTER_URL, params);
 };
 
-export const generateTwitterShareUrlForContest = (
-  contestName: string,
-  contestAddress: string,
-  chain: string,
-  rewards?: Reward | null,
-) => {
+export const generateTwitterShareUrlForContest = (contestName: string, contestAddress: string, chain: string) => {
   const params = {
-    text: contestShareText(contestName, rewards),
+    text: contestShareText(contestName),
     url: `${BASE_JOKERACE_URL}${chain}/${contestAddress}`,
   };
   return buildUrl(BASE_TWITTER_URL, params);

--- a/packages/react-app-revamp/hooks/useContest/index.ts
+++ b/packages/react-app-revamp/hooks/useContest/index.ts
@@ -3,7 +3,6 @@ import { isAlchemyConfigured } from "@helpers/alchemy";
 import { isSupabaseConfigured } from "@helpers/database";
 import { extractPathSegments } from "@helpers/extractPath";
 import getContestContractVersion from "@helpers/getContestContractVersion";
-import getRewardsModuleContractVersion from "@helpers/getRewardsModuleContractVersion";
 import { MAX_MS_TIMEOUT } from "@helpers/timeout";
 import { ContestStatus, useContestStatusStore } from "@hooks/useContestStatus/store";
 import { SplitFeeDestinationType, VoteType } from "@hooks/useDeployContest/types";
@@ -12,17 +11,17 @@ import useProposal from "@hooks/useProposal";
 import { useProposalStore } from "@hooks/useProposal/store";
 import useUser from "@hooks/useUser";
 import { useUserStore } from "@hooks/useUser/store";
-import { GetBalanceReturnType, readContract, readContracts } from "@wagmi/core";
+import { readContract, readContracts } from "@wagmi/core";
 import { compareVersions } from "compare-versions";
 import { differenceInMilliseconds, differenceInMinutes, isBefore, minutesToMilliseconds } from "date-fns";
-import { utils } from "ethers";
-import { checkIfContestExists, fetchFirstToken, fetchNativeBalance, fetchTokenBalances } from "lib/contests";
+import { checkIfContestExists } from "lib/contests";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
 import { Abi } from "viem";
 import { ErrorType, useContestStore } from "./store";
 import { getV1Contracts } from "./v1/contracts";
 import { getContracts } from "./v3v4/contracts";
+import getRewardsModuleContractVersion from "@helpers/getRewardsModuleContractVersion";
 
 interface ContractConfigResult {
   contractConfig: {
@@ -63,16 +62,16 @@ export function useContest() {
     setIsV3,
     setVotesClose,
     setVotesOpen,
-    setRewards,
     setSubmissionsOpen,
     setCanUpdateVotesInRealTime,
     setCharge,
     setVotingRequirements,
     setContestAbi,
     setSubmissionRequirements,
-    setIsRewardsLoading,
     setSortingEnabled,
     setVersion,
+    setRewardsModuleAddress,
+    setRewardsAbi,
   } = useContestStore(state => state);
   const { setIsListProposalsSuccess, setIsListProposalsLoading, setListProposalsIds } = useProposalStore(
     state => state,
@@ -232,18 +231,13 @@ export function useContest() {
     });
   }
 
-  async function fetchV3ContestInfo(
-    contractConfig: ContractConfig,
-    contestRewardModuleAddress: string | undefined,
-    version: string,
-  ) {
+  async function fetchV3ContestInfo(contractConfig: ContractConfig, version: string) {
     try {
       setIsListProposalsLoading(false);
 
       await Promise.all([
         fetchContestContractData(contractConfig, version),
         processUserQualifications(),
-        processRewardData(contestRewardModuleAddress),
         processRequirementsData(),
       ]);
     } catch (e) {
@@ -251,7 +245,6 @@ export function useContest() {
       setError(ErrorType.CONTRACT);
       setIsLoading(false);
       setIsListProposalsLoading(false);
-      setIsRewardsLoading(false);
     }
   }
 
@@ -332,34 +325,37 @@ export function useContest() {
 
       const { contractConfig, version } = abiResult;
 
-      let contestRewardModuleAddress: string | undefined;
+      let contestRewardModuleAddress = "";
 
       if (contractConfig.abi?.filter((el: { name: string }) => el.name === "officialRewardsModule").length > 0) {
         contestRewardModuleAddress = (await readContract(config, {
           ...contractConfig,
           functionName: "officialRewardsModule",
           args: [],
-        })) as any;
-        if (contestRewardModuleAddress?.toString() == "0x0000000000000000000000000000000000000000") {
+        })) as string;
+        if (contestRewardModuleAddress === "0x0000000000000000000000000000000000000000") {
           setSupportsRewardsModule(false);
-          contestRewardModuleAddress = undefined;
+          contestRewardModuleAddress = "";
         } else {
           setSupportsRewardsModule(true);
-          contestRewardModuleAddress = contestRewardModuleAddress?.toString();
         }
       } else {
         setSupportsRewardsModule(false);
-        contestRewardModuleAddress = undefined;
+        contestRewardModuleAddress = "";
       }
 
+      setRewardsModuleAddress(contestRewardModuleAddress);
+
       if (contestRewardModuleAddress) {
-        setIsRewardsLoading(true);
+        const abiRewardsModule = await getRewardsModuleContractVersion(contestRewardModuleAddress, chainId);
+        //@ts-ignore
+        setRewardsAbi(abiRewardsModule);
       }
 
       if (compareVersions(version, "3.0") == -1) {
         await fetchV1ContestInfo(contractConfig, version);
       } else {
-        await fetchV3ContestInfo(contractConfig, contestRewardModuleAddress, version);
+        await fetchV3ContestInfo(contractConfig, version);
       }
     } catch (error) {
       console.error("An error occurred while fetching data:", error);
@@ -399,60 +395,60 @@ export function useContest() {
     }
   }
 
-  /**
-   * Fetch reward data from the rewards module contract
-   * @param contestRewardModuleAddress
-   * @returns
-   */
-  async function processRewardData(contestRewardModuleAddress: string | undefined) {
-    if (!contestRewardModuleAddress) return;
+  // /**
+  //  * Fetch reward data from the rewards module contract
+  //  * @param contestRewardModuleAddress
+  //  * @returns
+  //  */
+  // async function processRewardData(contestRewardModuleAddress: string) {
+  //   if (!contestRewardModuleAddress) return;
 
-    const abiRewardsModule = await getRewardsModuleContractVersion(contestRewardModuleAddress, chainId);
+  //   const abiRewardsModule = await getRewardsModuleContractVersion(contestRewardModuleAddress, chainId);
 
-    if (!abiRewardsModule) {
-      setRewards(null);
-    } else {
-      const winners = (await readContract(config, {
-        address: contestRewardModuleAddress as `0x${string}`,
-        abi: abiRewardsModule,
-        chainId: chainId,
-        functionName: "getPayees",
-      })) as any[];
+  //   if (!abiRewardsModule) {
+  //     setRewards(null);
+  //   } else {
+  //     const winners = (await readContract(config, {
+  //       address: contestRewardModuleAddress as `0x${string}`,
+  //       abi: abiRewardsModule,
+  //       chainId: chainId,
+  //       functionName: "getPayees",
+  //     })) as any[];
 
-      let rewardToken: GetBalanceReturnType | null = null;
-      let erc20Tokens: any = null;
+  //     let rewardToken: GetBalanceReturnType | null = null;
+  //     let erc20Tokens: any = null;
 
-      rewardToken = await fetchNativeBalance(contestRewardModuleAddress, chainId);
+  //     rewardToken = await fetchNativeBalance(contestRewardModuleAddress, chainId);
 
-      if (!rewardToken || rewardToken.value.toString() == "0") {
-        try {
-          erc20Tokens = await fetchTokenBalances(chainName, contestRewardModuleAddress);
+  //     if (!rewardToken || rewardToken.value.toString() == "0") {
+  //       try {
+  //         erc20Tokens = await fetchTokenBalances(chainName, contestRewardModuleAddress);
 
-          if (erc20Tokens && erc20Tokens.length > 0) {
-            rewardToken = await fetchFirstToken(contestRewardModuleAddress, chainId, erc20Tokens[0].contractAddress);
-          }
-        } catch (e) {
-          console.error("Error fetching token balances:", e);
-          return;
-        }
-      }
+  //         if (erc20Tokens && erc20Tokens.length > 0) {
+  //           rewardToken = await fetchFirstToken(contestRewardModuleAddress, chainId, erc20Tokens[0].contractAddress);
+  //         }
+  //       } catch (e) {
+  //         console.error("Error fetching token balances:", e);
+  //         return;
+  //       }
+  //     }
 
-      if (rewardToken) {
-        setRewards({
-          token: {
-            symbol: rewardToken.symbol,
-            value: parseFloat(utils.formatUnits(rewardToken.value, rewardToken.decimals)),
-          },
-          winners: winners.length,
-          numberOfTokens: erc20Tokens?.length ?? 1,
-        });
-      } else {
-        setRewards(null);
-      }
+  //     if (rewardToken) {
+  //       setRewards({
+  //         token: {
+  //           symbol: rewardToken.symbol,
+  //           value: parseFloat(formatUnits(rewardToken.value, rewardToken.decimals)),
+  //         },
+  //         winners: winners.length,
+  //         numberOfTokens: erc20Tokens?.length ?? 1,
+  //       });
+  //     } else {
+  //       setRewards(null);
+  //     }
 
-      setIsRewardsLoading(false);
-    }
-  }
+  //     setIsRewardsLoading(false);
+  //   }
+  // }
 
   return {
     getContractConfig,

--- a/packages/react-app-revamp/hooks/useContest/store.tsx
+++ b/packages/react-app-revamp/hooks/useContest/store.tsx
@@ -4,15 +4,6 @@ import { createContext, useContext, useRef } from "react";
 import { Abi } from "viem";
 import { createStore, useStore } from "zustand";
 
-export type Reward = {
-  token: {
-    symbol: string;
-    value: number;
-  };
-  winners: number;
-  numberOfTokens: number;
-};
-
 export enum ErrorType {
   RPC = "RPC",
   CONTRACT = "CONTRACT",
@@ -42,11 +33,11 @@ export interface ContestState {
   charge: Charge | null;
   votingRequirements: VotingRequirementsSchema | null;
   submissionRequirements: VotingRequirementsSchema | null;
-  rewards: Reward | null;
   isReadOnly: boolean;
-  isRewardsLoading: boolean;
   anyoneCanVote: boolean;
   version: string;
+  rewardsModuleAddress: string;
+  rewardsAbi: Abi | null;
   setSupportsRewardsModule: (value: boolean) => void;
   setCanUpdateVotesInRealTime: (value: boolean) => void;
   setDownvotingAllowed: (isAllowed: boolean) => void;
@@ -58,7 +49,6 @@ export interface ContestState {
   setSubmissionsOpen: (datetime: Date) => void;
   setVotesOpen: (datetime: Date) => void;
   setVotesClose: (datetime: Date) => void;
-  setRewards: (rewards: Reward | null) => void;
   setSubmissionsMerkleRoot: (merkleRoot: string) => void;
   setVotingMerkleRoot: (merkleRoot: string) => void;
   setVotingRequirements: (votingRequirements: VotingRequirementsSchema | null) => void;
@@ -69,10 +59,11 @@ export interface ContestState {
   setIsV3: (value: boolean) => void;
   setCharge: (charge: Charge | null) => void;
   setIsReadOnly: (value: boolean) => void;
-  setIsRewardsLoading: (value: boolean) => void;
   setContestAbi: (abi: Abi) => void;
   setAnyoneCanVote: (value: boolean) => void;
   setVersion: (version: string) => void;
+  setRewardsModuleAddress: (address: string) => void;
+  setRewardsAbi: (abi: Abi | null) => void;
 }
 
 export const createContestStore = () =>
@@ -87,7 +78,6 @@ export const createContestStore = () =>
     votesClose: new Date(),
     submissionMerkleRoot: "",
     votingMerkleRoot: "",
-    rewards: null,
     isLoading: true,
     error: null,
     charge: null,
@@ -101,9 +91,10 @@ export const createContestStore = () =>
     isV3: false,
     isReadOnly: false,
     supportsRewardsModule: false,
-    isRewardsLoading: false,
     anyoneCanVote: false,
     version: "",
+    rewardsModuleAddress: "",
+    rewardsAbi: null,
     setSupportsRewardsModule: value => set({ supportsRewardsModule: value }),
     setCanUpdateVotesInRealTime: value => set({ canUpdateVotesInRealTime: value }),
     setDownvotingAllowed: isAllowed => set({ downvotingAllowed: isAllowed }),
@@ -119,17 +110,17 @@ export const createContestStore = () =>
     setVotesClose: datetime => set({ votesClose: datetime }),
     setSubmissionsMerkleRoot: merkleRoot => set({ submissionMerkleRoot: merkleRoot }),
     setVotingMerkleRoot: merkleRoot => set({ votingMerkleRoot: merkleRoot }),
-    setRewards: rewards => set({ rewards: rewards }),
     setVotingRequirements: votingRequirements => set({ votingRequirements: votingRequirements }),
     setSubmissionRequirements: submissionRequirements => set({ submissionRequirements: submissionRequirements }),
     setIsLoading: value => set({ isLoading: value }),
     setError: value => set({ error: value }),
     setIsSuccess: value => set({ isSuccess: value }),
-    setIsRewardsLoading: value => set({ isRewardsLoading: value }),
     setCharge: charge => set({ charge: charge }),
     setContestAbi: abi => set({ contestAbi: abi }),
     setAnyoneCanVote: value => set({ anyoneCanVote: value }),
     setVersion: version => set({ version: version }),
+    setRewardsModuleAddress: address => set({ rewardsModuleAddress: address }),
+    setRewardsAbi: abi => set({ rewardsAbi: abi }),
   }));
 
 export const ContestContext = createContext<ReturnType<typeof createContestStore> | null>(null);

--- a/packages/react-app-revamp/hooks/useDistributeRewards/index.tsx
+++ b/packages/react-app-revamp/hooks/useDistributeRewards/index.tsx
@@ -45,7 +45,7 @@ export const useDistributeRewards = (
   const asPath = usePathname();
   const { chainName, address: contestAddress } = extractPathSegments(asPath ?? "");
   const { setIsLoading, refetch, setRefetch } = useDistributeRewardStore(state => state);
-  const tokenDataRes = useToken({ address: tokenAddress as `0x${string}`, chainId });
+  const tokenDataRes = useBalance({ address: tokenAddress as `0x${string}`, chainId });
   const tokenData = tokenType === "erc20" ? tokenDataRes.data : null;
   const { handleError } = useError();
 

--- a/packages/react-app-revamp/hooks/useDistributeRewards/index.tsx
+++ b/packages/react-app-revamp/hooks/useDistributeRewards/index.tsx
@@ -102,15 +102,19 @@ export const useDistributeRewards = (
       setIsLoading(false);
       toastSuccess("Funds distributed successfully!");
 
-      updateRewardAnalytics({
-        contest_address: contestAddress,
-        rewards_module_address: contractRewardsModuleAddress,
-        network_name: chainName,
-        amount: amountReleasableFormatted,
-        operation: "distribute",
-        token_address: tokenAddress ? tokenAddress : null,
-        created_at: Math.floor(Date.now() / 1000),
-      });
+      try {
+        await updateRewardAnalytics({
+          contest_address: contestAddress,
+          rewards_module_address: contractRewardsModuleAddress,
+          network_name: chainName,
+          amount: amountReleasableFormatted,
+          operation: "distribute",
+          token_address: tokenAddress ? tokenAddress : null,
+          created_at: Math.floor(Date.now() / 1000),
+        });
+      } catch (error) {
+        console.error("Error while updating reward analytics", error);
+      }
     } catch (error) {
       handleError(error, "Error while releasing token");
       setIsLoading(false);

--- a/packages/react-app-revamp/hooks/useDistributeRewards/index.tsx
+++ b/packages/react-app-revamp/hooks/useDistributeRewards/index.tsx
@@ -81,7 +81,10 @@ export const useDistributeRewards = (
   const handleDistributeRewards = async () => {
     setIsLoading(true);
     toastLoading(`Distributing funds...`);
+
     try {
+      const amountReleasable = await queryRankRewardsReleasable.refetch();
+      const amountReleasableFormatted = transform(amountReleasable.data as bigint, tokenType, tokenData);
       const hash = await writeContract(config, {
         address: contractRewardsModuleAddress as `0x${string}`,
         abi: abiRewardsModule,
@@ -94,8 +97,6 @@ export const useDistributeRewards = (
 
       await queryTokenBalance.refetch();
       await queryRankRewardsReleasable.refetch();
-      const amountReleased = await queryRankRewardsReleased.refetch();
-      const amountReleasedFormatted = transform(amountReleased.data as bigint, tokenType, tokenData);
 
       setIsLoading(false);
       toastSuccess("Funds distributed successfully!");
@@ -104,7 +105,7 @@ export const useDistributeRewards = (
         contest_address: contestAddress,
         rewards_module_address: contractRewardsModuleAddress,
         network_name: chainName,
-        amount: amountReleasedFormatted,
+        amount: amountReleasableFormatted,
         operation: "distribute",
         token_address: tokenAddress ? tokenAddress : null,
         created_at: Math.floor(Date.now() / 1000),

--- a/packages/react-app-revamp/hooks/useDistributeRewards/index.tsx
+++ b/packages/react-app-revamp/hooks/useDistributeRewards/index.tsx
@@ -45,7 +45,8 @@ export const useDistributeRewards = (
   const asPath = usePathname();
   const { chainName, address: contestAddress } = extractPathSegments(asPath ?? "");
   const { setIsLoading, refetch, setRefetch } = useDistributeRewardStore(state => state);
-  const tokenDataRes = useBalance({ address: tokenAddress as `0x${string}`, chainId });
+  const tokenDataRes = useToken({ address: tokenAddress as `0x${string}`, chainId });
+
   const tokenData = tokenType === "erc20" ? tokenDataRes.data : null;
   const { handleError } = useError();
 
@@ -81,10 +82,10 @@ export const useDistributeRewards = (
   const handleDistributeRewards = async () => {
     setIsLoading(true);
     toastLoading(`Distributing funds...`);
+    const amountReleasable = await queryRankRewardsReleasable.refetch();
+    const amountReleasableFormatted = transform(amountReleasable.data as bigint, tokenType, tokenData);
 
     try {
-      const amountReleasable = await queryRankRewardsReleasable.refetch();
-      const amountReleasableFormatted = transform(amountReleasable.data as bigint, tokenType, tokenData);
       const hash = await writeContract(config, {
         address: contractRewardsModuleAddress as `0x${string}`,
         abi: abiRewardsModule,

--- a/packages/react-app-revamp/hooks/useFundRewards/index.ts
+++ b/packages/react-app-revamp/hooks/useFundRewards/index.ts
@@ -108,8 +108,6 @@ export function useFundRewardsModule() {
         chainId: chainId,
         hash: hash,
       });
-
-      handleRefetchBalanceRewardsModule();
     } else {
       const amountBigInt = BigInt(amount);
 
@@ -129,19 +127,24 @@ export function useFundRewardsModule() {
       });
     }
 
-    setIsLoading(false);
-    setIsSuccess(true);
+    try {
+      await updateRewardAnalytics({
+        contest_address: contestAddress,
+        rewards_module_address: rewardsContractAddress,
+        network_name: chainName,
+        amount: parseFloat(utils.formatUnits(amount, decimals)),
+        operation: "deposit",
+        token_address: tokenAddress?.startsWith("$") ? null : tokenAddress,
+        created_at: Math.floor(Date.now() / 1000),
+      });
+    } catch (error) {
+      console.error("Error while updating reward analytics", error);
+    }
 
     handleRefetchBalanceRewardsModule();
-    updateRewardAnalytics({
-      contest_address: contestAddress,
-      rewards_module_address: rewardsContractAddress,
-      network_name: chainName,
-      amount: parseFloat(utils.formatUnits(amount, decimals)),
-      operation: "deposit",
-      token_address: tokenAddress?.startsWith("$") ? null : tokenAddress,
-      created_at: Math.floor(Date.now() / 1000),
-    });
+
+    setIsLoading(false);
+    setIsSuccess(true);
 
     return {
       hash: receipt.transactionHash,

--- a/packages/react-app-revamp/hooks/useRewards/index.ts
+++ b/packages/react-app-revamp/hooks/useRewards/index.ts
@@ -20,7 +20,7 @@ export function useRewardsModule() {
   const chainId = chains.filter(
     (chain: { name: string }) => chain.name.toLowerCase().replace(" ", "") === contestChainName.toLowerCase(),
   )?.[0]?.id;
-  const { refetchUnpaidTokens } = useUnpaidRewardTokens();
+  const { refetchUnpaidTokens } = useUnpaidRewardTokens("rewards-module-unpaid-tokens", rewards?.contractAddress);
 
   const handleRefetchBalanceRewardsModule = () => {
     refetchUnpaidTokens();

--- a/packages/react-app-revamp/hooks/useRewardsTokens/usePaidRewardsTokens/index.ts
+++ b/packages/react-app-revamp/hooks/useRewardsTokens/usePaidRewardsTokens/index.ts
@@ -18,7 +18,7 @@ export const usePaidRewardTokens = (queryKey: string, rewardsModuleAddress: stri
     queryKey: [queryKey, rewardsModuleAddress],
     queryFn: async () => {
       if (rewardsModuleAddress) {
-        const paidBalances = await getPaidBalances(rewardsModuleAddress, includeNative);
+        const paidBalances = await getPaidBalances(rewardsModuleAddress, chainName.toLowerCase(), includeNative);
 
         const tokenAddresses = [...new Set(paidBalances.map(token => token.tokenAddress))];
         const tokenDecimals = await getTokenDecimalsBatch(tokenAddresses, chainId);

--- a/packages/react-app-revamp/hooks/useRewardsTokens/usePaidRewardsTokens/index.ts
+++ b/packages/react-app-revamp/hooks/useRewardsTokens/usePaidRewardsTokens/index.ts
@@ -1,0 +1,50 @@
+import { ERC20Token } from "@components/_pages/RewardsDistributionTable/components";
+import { chains } from "@config/wagmi";
+import { isSupabaseConfigured } from "@helpers/database";
+import { extractPathSegments } from "@helpers/extractPath";
+import { getTokenDecimalsBatch } from "@helpers/getTokenDecimals";
+import { useRewardsStore } from "@hooks/useRewards/store";
+import { useQuery } from "@tanstack/react-query";
+import { getPaidBalances } from "lib/rewards";
+import { usePathname } from "next/navigation";
+
+export const usePaidRewardTokens = () => {
+  const asPath = usePathname();
+  const { chainName } = extractPathSegments(asPath);
+  const chainId = chains.filter(
+    (chain: { name: string }) => chain.name.toLowerCase().replace(" ", "") === chainName.toLowerCase(),
+  )?.[0]?.id;
+  const { rewards } = useRewardsStore(state => state);
+  const rewardsModuleAddress = rewards?.contractAddress;
+
+  const { refetch, data } = useQuery({
+    queryKey: ["paid-reward-tokens", rewardsModuleAddress],
+    queryFn: async () => {
+      if (rewardsModuleAddress) {
+        const paidBalances = await getPaidBalances(rewardsModuleAddress);
+
+        const tokenAddresses = [...new Set(paidBalances.map(token => token.tokenAddress))];
+        const tokenDecimals = await getTokenDecimalsBatch(tokenAddresses, chainId);
+
+        const formattedBalances = paidBalances.map(
+          (token): ERC20Token => ({
+            contractAddress: token.tokenAddress,
+            tokenBalance: token.balance.toString(),
+            decimals: tokenDecimals[token.tokenAddress] || 18,
+          }),
+        );
+
+        return formattedBalances;
+      }
+      return [];
+    },
+    enabled: !!rewardsModuleAddress && !!isSupabaseConfigured,
+  });
+
+  return {
+    refetchPaidTokens: refetch,
+    paidTokens: data,
+  };
+};
+
+export default usePaidRewardTokens;

--- a/packages/react-app-revamp/hooks/useRewardsTokens/useUnpaidRewardsTokens/index.ts
+++ b/packages/react-app-revamp/hooks/useRewardsTokens/useUnpaidRewardsTokens/index.ts
@@ -18,7 +18,7 @@ export const useUnpaidRewardTokens = (queryKey: string, rewardsModuleAddress: st
     queryKey: [queryKey, rewardsModuleAddress],
     queryFn: async () => {
       if (rewardsModuleAddress) {
-        const netBalances = await getNetBalances(rewardsModuleAddress, includeNative);
+        const netBalances = await getNetBalances(rewardsModuleAddress, chainName.toLowerCase(), includeNative);
 
         const tokenAddresses = [...new Set(netBalances.map(token => token.tokenAddress))];
         const tokenDecimals = await getTokenDecimalsBatch(tokenAddresses, chainId);

--- a/packages/react-app-revamp/hooks/useRewardsTokens/useUnpaidRewardsTokens/index.ts
+++ b/packages/react-app-revamp/hooks/useRewardsTokens/useUnpaidRewardsTokens/index.ts
@@ -1,0 +1,50 @@
+import { ERC20Token } from "@components/_pages/RewardsDistributionTable/components";
+import { chains } from "@config/wagmi";
+import { isSupabaseConfigured } from "@helpers/database";
+import { extractPathSegments } from "@helpers/extractPath";
+import { getTokenDecimalsBatch } from "@helpers/getTokenDecimals";
+import { useRewardsStore } from "@hooks/useRewards/store";
+import { useQuery } from "@tanstack/react-query";
+import { getNetBalances } from "lib/rewards";
+import { usePathname } from "next/navigation";
+
+export const useUnpaidRewardTokens = () => {
+  const asPath = usePathname();
+  const { chainName } = extractPathSegments(asPath);
+  const chainId = chains.filter(
+    (chain: { name: string }) => chain.name.toLowerCase().replace(" ", "") === chainName.toLowerCase(),
+  )?.[0]?.id;
+  const { rewards, setRewards } = useRewardsStore(state => state);
+  const rewardsModuleAddress = rewards?.contractAddress;
+
+  const { refetch, data } = useQuery({
+    queryKey: ["unpaid-reward-tokens", rewardsModuleAddress],
+    queryFn: async () => {
+      if (rewardsModuleAddress) {
+        const netBalances = await getNetBalances(rewardsModuleAddress);
+
+        const tokenAddresses = [...new Set(netBalances.map(token => token.tokenAddress))];
+        const tokenDecimals = await getTokenDecimalsBatch(tokenAddresses, chainId);
+
+        const formattedBalances = netBalances.map(
+          (token): ERC20Token => ({
+            contractAddress: token.tokenAddress,
+            tokenBalance: token.balance.toString(),
+            decimals: tokenDecimals[token.tokenAddress] || 18,
+          }),
+        );
+
+        return formattedBalances;
+      }
+      return [];
+    },
+    enabled: !!rewardsModuleAddress && !!isSupabaseConfigured,
+  });
+
+  return {
+    refetchUnpaidTokens: refetch,
+    unpaidTokens: data,
+  };
+};
+
+export default useUnpaidRewardTokens;

--- a/packages/react-app-revamp/hooks/useWithdrawRewards/index.tsx
+++ b/packages/react-app-revamp/hooks/useWithdrawRewards/index.tsx
@@ -62,15 +62,19 @@ export const useWithdrawReward = (
 
       const amountWithdrawnFormatted = transform(queryTokenBalance.data.value, tokenType, queryTokenBalance.data);
 
-      updateRewardAnalytics({
-        contest_address: contestAddress,
-        rewards_module_address: contractRewardsModuleAddress,
-        network_name: chainName,
-        amount: amountWithdrawnFormatted,
-        operation: "withdraw",
-        token_address: tokenAddress ? tokenAddress : null,
-        created_at: Math.floor(Date.now() / 1000),
-      });
+      try {
+        await updateRewardAnalytics({
+          contest_address: contestAddress,
+          rewards_module_address: contractRewardsModuleAddress,
+          network_name: chainName,
+          amount: amountWithdrawnFormatted,
+          operation: "withdraw",
+          token_address: tokenAddress ? tokenAddress : null,
+          created_at: Math.floor(Date.now() / 1000),
+        });
+      } catch (error) {
+        console.error("error updating reward analytics", error);
+      }
     } catch (error: any) {
       handleError(error, `something went wrong and the funds couldn't be withdrawn`);
       setIsLoading(false);

--- a/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
@@ -6,6 +6,7 @@ import ButtonV3 from "@components/UI/ButtonV3";
 import Loader from "@components/UI/Loader";
 import UserProfileDisplay from "@components/UI/UserProfileDisplay";
 import ContestTab from "@components/_pages/Contest/Contest";
+import ContestExtensions from "@components/_pages/Contest/Extensions";
 import ContestParameters from "@components/_pages/Contest/Parameters";
 import ContestRewards from "@components/_pages/Contest/Rewards";
 import ContestTabs, { Tab } from "@components/_pages/Contest/components/Tabs";
@@ -29,11 +30,10 @@ import Image from "next/image";
 import { usePathname, useRouter } from "next/navigation";
 import { useUrl } from "nextjs-current-url";
 import { ReactNode, useEffect, useMemo, useState } from "react";
-import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
 import { useMediaQuery } from "react-responsive";
 import { useAccount, useAccountEffect } from "wagmi";
 import LayoutViewContestError from "./components/Error";
-import ContestExtensions from "@components/_pages/Contest/Extensions";
+import ContestRewardsInfo from "@components/_pages/Contest/components/RewardsInfo";
 
 const LayoutViewContest = ({ children }: { children: React.ReactNode }) => {
   const { refresh } = useRouter();
@@ -49,9 +49,9 @@ const LayoutViewContest = ({ children }: { children: React.ReactNode }) => {
     votesOpen,
     contestAuthorEthereumAddress,
     contestName,
-    rewards,
     isReadOnly,
-    isRewardsLoading,
+    rewardsModuleAddress,
+    rewardsAbi,
   } = useContestStore(state => state);
   const accountChanged = useAccountChange();
   const { checkIfCurrentUserQualifyToVote, checkIfCurrentUserQualifyToSubmit } = useUser();
@@ -206,29 +206,10 @@ const LayoutViewContest = ({ children }: { children: React.ReactNode }) => {
                         textualVersion={isMobile}
                       />
 
-                      {isRewardsLoading && (
-                        <SkeletonTheme baseColor="#000000" highlightColor="#212121" duration={1}>
-                          <Skeleton
-                            borderRadius={10}
-                            className="h-8 shrink-0 p-2 border border-neutral-11"
-                            width={isMobile ? 100 : 200}
-                          />
-                        </SkeletonTheme>
-                      )}
+                      {rewardsModuleAddress && rewardsAbi ? (
+                        <ContestRewardsInfo rewardsModuleAddress={rewardsModuleAddress} rewardsAbi={rewardsAbi} />
+                      ) : null}
 
-                      {rewards && !isRewardsLoading && (
-                        <div className="flex shrink-0 h-8 p-4 items-center bg-neutral-0 border border-transparent rounded-[10px] text-[16px] font-bold text-neutral-11">
-                          {rewards?.token.value} $
-                          <span className="uppercase mr-1 truncate inline-block overflow-hidden max-w-[50px] md:max-w-[100px]">
-                            {rewards?.token.symbol}
-                          </span>
-                          {!isMobile ? (
-                            <>
-                              to {rewards.winners} {rewards.winners > 1 ? "winners" : "winner"}
-                            </>
-                          ) : null}
-                        </div>
-                      )}
                       {isMobile ? (
                         <div
                           className="w-8 h-8 flex items-center rounded-[10px] border border-neutral-11"
@@ -241,12 +222,8 @@ const LayoutViewContest = ({ children }: { children: React.ReactNode }) => {
                           <Image src="/forward.svg" alt="share" className="m-auto" width={15} height={13} />
                         </div>
                       ) : (
-                        <ShareDropdown
-                          contestAddress={address}
-                          chain={chainName}
-                          contestName={contestName}
-                          rewards={rewards}
-                        />
+                        //TODO: pass rewards to share?
+                        <ShareDropdown contestAddress={address} chain={chainName} contestName={contestName} />
                       )}
                       <div
                         className="standalone-pwa w-8 h-8 items-center rounded-[10px] border border-neutral-11 cursor-pointer"

--- a/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
@@ -122,26 +122,22 @@ const LayoutViewContest = ({ children }: { children: React.ReactNode }) => {
   const renderTabs = useMemo<ReactNode>(() => {
     switch (tab) {
       case Tab.Contest:
-        return (
-          <div className="animate-apppear">
-            <ContestTab />
-          </div>
-        );
+        return <ContestTab />;
       case Tab.Rewards:
         return (
-          <div className="mt-8 animate-appear">
+          <div className="mt-8">
             <ContestRewards />
           </div>
         );
       case Tab.Parameters:
         return (
-          <div className="mt-8 animate-appear">
+          <div className="mt-8">
             <ContestParameters />
           </div>
         );
       case Tab.Extensions:
         return (
-          <div className="mt-8 animate-appear">
+          <div className="mt-8">
             <ContestExtensions />
           </div>
         );
@@ -196,7 +192,7 @@ const LayoutViewContest = ({ children }: { children: React.ReactNode }) => {
                     </ButtonV3>
                   </div>
                 )}
-                <div className="animate-appear pt-3 md:pt-0">
+                <div className="animate-reveal pt-3 md:pt-0">
                   <div className="flex flex-col mt-6 md:mt-10 gap-4">
                     <p className="text-[16px] md:text-[31px] text-primary-10 font-sabo break-all">{contestName}</p>
                     <div className="flex flex-row gap-3 md:gap-4 items-center">

--- a/packages/react-app-revamp/lib/contests/index.ts
+++ b/packages/react-app-revamp/lib/contests/index.ts
@@ -4,9 +4,9 @@ import getContestContractVersion from "@helpers/getContestContractVersion";
 import getPagination from "@helpers/getPagination";
 import getRewardsModuleContractVersion from "@helpers/getRewardsModuleContractVersion";
 import { getBalance, readContract } from "@wagmi/core";
-import { utils } from "ethers";
 import moment from "moment";
 import { SearchOptions } from "types/search";
+import { formatUnits } from "viem";
 import { sortContests } from "./utils/sortContests";
 
 export const ITEMS_PER_PAGE = 7;
@@ -183,7 +183,7 @@ const processContestRewardsData = async (contestAddress: string, contestChainNam
               chain: contestChainName,
               token: {
                 symbol: rewardToken.symbol,
-                value: parseFloat(utils.formatUnits(rewardToken.value, rewardToken.decimals)),
+                value: parseFloat(formatUnits(rewardToken.value, rewardToken.decimals)),
               },
               winners: winners.length,
               numberOfTokens: erc20Tokens?.length ?? 1,

--- a/packages/react-app-revamp/lib/contests/index.ts
+++ b/packages/react-app-revamp/lib/contests/index.ts
@@ -141,7 +141,7 @@ const processContestRewardsData = async (
           let rewardsPaidOut = false;
 
           if (!rewardToken || Number(rewardToken.value) === 0) {
-            erc20Tokens = await getNetBalances(contestRewardModuleAddress);
+            erc20Tokens = await getNetBalances(contestRewardModuleAddress, contestChainName.toLowerCase());
 
             if (erc20Tokens && erc20Tokens.length > 0) {
               rewardToken = await fetchFirstToken(contestRewardModuleAddress, chainId, erc20Tokens[0].tokenAddress);
@@ -161,7 +161,11 @@ const processContestRewardsData = async (
               rewardsPaidOut: rewardsPaidOut,
             };
           } else {
-            const paidBalances = await getPaidBalances(contestRewardModuleAddress, true);
+            const paidBalances = await getPaidBalances(
+              contestRewardModuleAddress,
+              contestChainName.toLowerCase(),
+              true,
+            );
             rewardsPaidOut = paidBalances && paidBalances.length > 0;
 
             reward = {

--- a/packages/react-app-revamp/lib/rewards/index.ts
+++ b/packages/react-app-revamp/lib/rewards/index.ts
@@ -63,7 +63,7 @@ export const getPaidBalances = async (
 
     const { data: transactions, error: transactionError } = await supabase
       .from("analytics_rewards_v3")
-      .select("token_address, amount_paid_out, amount_withdrawn")
+      .select("token_address, amount_paid_out")
       .eq("rewards_module_address", rewardsModuleAddress)
       .eq("network_name", networkName);
 
@@ -82,9 +82,6 @@ export const getPaidBalances = async (
           if (transaction.amount_paid_out) {
             acc[tokenAddress].balance += transaction.amount_paid_out;
           }
-          if (transaction.amount_withdrawn) {
-            acc[tokenAddress].balance = 0;
-          }
         }
 
         return acc;
@@ -92,7 +89,6 @@ export const getPaidBalances = async (
       {} as { [key: string]: RewardToken },
     );
 
-    // Return tokens with positive balance
     return Object.values(balances).filter(token => token.balance > 0);
   }
 

--- a/packages/react-app-revamp/lib/rewards/index.ts
+++ b/packages/react-app-revamp/lib/rewards/index.ts
@@ -1,0 +1,40 @@
+import { isSupabaseConfigured } from "@helpers/database";
+
+export const getUnpaidRewardTokens = async (rewardsModuleAddress: string) => {
+  if (isSupabaseConfigured) {
+    const config = await import("@config/supabase");
+    const supabase = config.supabase;
+
+    const { data: tokens, error } = await supabase
+      .from("analytics_rewards_v3")
+      .select("token_address")
+      .eq("rewards_module_address", rewardsModuleAddress)
+      .not("amount_paid_in", "is", null)
+      .is("amount_paid_out", null);
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    return tokens;
+  }
+};
+
+export const getPaidRewardTokens = async (rewardsModuleAddress: string) => {
+  if (isSupabaseConfigured) {
+    const config = await import("@config/supabase");
+    const supabase = config.supabase;
+
+    const { data: tokens, error } = await supabase
+      .from("analytics_rewards_v3")
+      .select("token_address")
+      .eq("rewards_module_address", rewardsModuleAddress)
+      .not("amount_paid_out", "is", null);
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    return tokens;
+  }
+};

--- a/packages/react-app-revamp/lib/rewards/index.ts
+++ b/packages/react-app-revamp/lib/rewards/index.ts
@@ -5,7 +5,10 @@ export interface RewardToken {
   balance: number;
 }
 
-export const getNetBalances = async (rewardsModuleAddress: string): Promise<RewardToken[]> => {
+export const getNetBalances = async (
+  rewardsModuleAddress: string,
+  includeNative: boolean = false,
+): Promise<RewardToken[]> => {
   if (isSupabaseConfigured) {
     const config = await import("@config/supabase");
     const supabase = config.supabase;
@@ -21,7 +24,7 @@ export const getNetBalances = async (rewardsModuleAddress: string): Promise<Rewa
 
     const balances = fundings.reduce(
       (acc, transaction) => {
-        const tokenAddress = transaction.token_address;
+        const tokenAddress = transaction.token_address || (includeNative ? "native" : null);
         if (tokenAddress) {
           if (!acc[tokenAddress]) {
             acc[tokenAddress] = { tokenAddress, balance: 0 };
@@ -44,7 +47,10 @@ export const getNetBalances = async (rewardsModuleAddress: string): Promise<Rewa
   return [];
 };
 
-export const getPaidBalances = async (rewardsModuleAddress: string): Promise<RewardToken[]> => {
+export const getPaidBalances = async (
+  rewardsModuleAddress: string,
+  includeNative: boolean = false,
+): Promise<RewardToken[]> => {
   if (isSupabaseConfigured) {
     const config = await import("@config/supabase");
     const supabase = config.supabase;
@@ -60,7 +66,7 @@ export const getPaidBalances = async (rewardsModuleAddress: string): Promise<Rew
 
     const balances = transactions.reduce(
       (acc, transaction) => {
-        const tokenAddress = transaction.token_address;
+        const tokenAddress = transaction.token_address || (includeNative ? "native" : null);
         if (tokenAddress) {
           if (!acc[tokenAddress]) {
             acc[tokenAddress] = { tokenAddress, balance: 0 };

--- a/packages/react-app-revamp/lib/rewards/index.ts
+++ b/packages/react-app-revamp/lib/rewards/index.ts
@@ -7,6 +7,7 @@ export interface RewardToken {
 
 export const getNetBalances = async (
   rewardsModuleAddress: string,
+  networkName: string,
   includeNative: boolean = false,
 ): Promise<RewardToken[]> => {
   if (isSupabaseConfigured) {
@@ -16,7 +17,8 @@ export const getNetBalances = async (
     const { data: fundings, error: fundingError } = await supabase
       .from("analytics_rewards_v3")
       .select("token_address, amount_paid_in, amount_paid_out, amount_withdrawn")
-      .eq("rewards_module_address", rewardsModuleAddress);
+      .eq("rewards_module_address", rewardsModuleAddress)
+      .eq("network_name", networkName);
 
     if (fundingError) {
       throw new Error(fundingError.message);
@@ -52,6 +54,7 @@ export const getNetBalances = async (
 
 export const getPaidBalances = async (
   rewardsModuleAddress: string,
+  networkName: string,
   includeNative: boolean = false,
 ): Promise<RewardToken[]> => {
   if (isSupabaseConfigured) {
@@ -61,7 +64,8 @@ export const getPaidBalances = async (
     const { data: transactions, error: transactionError } = await supabase
       .from("analytics_rewards_v3")
       .select("token_address, amount_paid_out, amount_withdrawn")
-      .eq("rewards_module_address", rewardsModuleAddress);
+      .eq("rewards_module_address", rewardsModuleAddress)
+      .eq("network_name", networkName);
 
     if (transactionError) {
       throw new Error(transactionError.message);

--- a/packages/react-app-revamp/lib/rewards/index.ts
+++ b/packages/react-app-revamp/lib/rewards/index.ts
@@ -1,40 +1,81 @@
 import { isSupabaseConfigured } from "@helpers/database";
 
-export const getUnpaidRewardTokens = async (rewardsModuleAddress: string) => {
+export interface RewardToken {
+  tokenAddress: string;
+  balance: number;
+}
+
+export const getNetBalances = async (rewardsModuleAddress: string): Promise<RewardToken[]> => {
   if (isSupabaseConfigured) {
     const config = await import("@config/supabase");
     const supabase = config.supabase;
 
-    const { data: tokens, error } = await supabase
+    const { data: fundings, error: fundingError } = await supabase
       .from("analytics_rewards_v3")
-      .select("token_address")
-      .eq("rewards_module_address", rewardsModuleAddress)
-      .not("amount_paid_in", "is", null)
-      .is("amount_paid_out", null);
+      .select("token_address, amount_paid_in, amount_paid_out")
+      .eq("rewards_module_address", rewardsModuleAddress);
 
-    if (error) {
-      throw new Error(error.message);
+    if (fundingError) {
+      throw new Error(fundingError.message);
     }
 
-    return tokens;
+    const balances = fundings.reduce(
+      (acc, transaction) => {
+        const tokenAddress = transaction.token_address;
+        if (tokenAddress) {
+          if (!acc[tokenAddress]) {
+            acc[tokenAddress] = { tokenAddress, balance: 0 };
+          }
+          if (transaction.amount_paid_in) {
+            acc[tokenAddress].balance += transaction.amount_paid_in;
+          }
+          if (transaction.amount_paid_out) {
+            acc[tokenAddress].balance -= transaction.amount_paid_out;
+          }
+        }
+        return acc;
+      },
+      {} as { [key: string]: RewardToken },
+    );
+
+    return Object.values(balances).filter(token => token.balance > 0);
   }
+
+  return [];
 };
 
-export const getPaidRewardTokens = async (rewardsModuleAddress: string) => {
+export const getPaidBalances = async (rewardsModuleAddress: string): Promise<RewardToken[]> => {
   if (isSupabaseConfigured) {
     const config = await import("@config/supabase");
     const supabase = config.supabase;
 
-    const { data: tokens, error } = await supabase
+    const { data: transactions, error: transactionError } = await supabase
       .from("analytics_rewards_v3")
-      .select("token_address")
-      .eq("rewards_module_address", rewardsModuleAddress)
-      .not("amount_paid_out", "is", null);
+      .select("token_address, amount_paid_in, amount_paid_out")
+      .eq("rewards_module_address", rewardsModuleAddress);
 
-    if (error) {
-      throw new Error(error.message);
+    if (transactionError) {
+      throw new Error(transactionError.message);
     }
 
-    return tokens;
+    const balances = transactions.reduce(
+      (acc, transaction) => {
+        const tokenAddress = transaction.token_address;
+        if (tokenAddress) {
+          if (!acc[tokenAddress]) {
+            acc[tokenAddress] = { tokenAddress, balance: 0 };
+          }
+          if (transaction.amount_paid_out) {
+            acc[tokenAddress].balance += transaction.amount_paid_out;
+          }
+        }
+        return acc;
+      },
+      {} as { [key: string]: RewardToken },
+    );
+
+    return Object.values(balances).filter(token => token.balance > 0);
   }
+
+  return [];
 };

--- a/packages/react-app-revamp/supabase_schemas/analytics_contest_participants_v3 .sql
+++ b/packages/react-app-revamp/supabase_schemas/analytics_contest_participants_v3 .sql
@@ -6,11 +6,11 @@ create table
     network_name character varying not null,
     proposal_id character varying null,
     vote_amount numeric null,
-    created_at int4 null,
+    created_at integer null,
     deleted boolean null default false,
+    percentage_to_creator numeric null,
     amount_sent numeric null,
-    percentage_to_creator numeric null 
-    comment_id character varying null
+    comment_id character varying null,
     constraint analytics_contest_participants_v3_pkey primary key (uuid)
   ) tablespace pg_default;
 

--- a/packages/react-app-revamp/supabase_schemas/analytics_rewards_v3.sql
+++ b/packages/react-app-revamp/supabase_schemas/analytics_rewards_v3.sql
@@ -1,12 +1,19 @@
-create table public.analytics_rewards_v3 (
-    uuid uuid not null default gen_random_uuid(),
+create table
+  public.analytics_rewards_v3 (
+    uuid uuid not null default gen_random_uuid (),
     contest_address character varying not null,
     rewards_module_address character varying not null,
     network_name character varying not null,
-    token_address character varying default null,
-    amount_paid_in numeric null,   
+    token_address character varying null,
+    amount_paid_in numeric null,
     amount_paid_out numeric null,
-    created_at int4 null,
-    amount_withdrawn numeric null
+    created_at integer null,
+    amount_withdrawn numeric null,
     constraint analytics_rewards_v3_pkey primary key (uuid)
+  ) tablespace pg_default;
+
+create index if not exists idx_analytics_rewards_v3_rew_net_token on public.analytics_rewards_v3 using btree (
+  rewards_module_address,
+  network_name,
+  token_address
 ) tablespace pg_default;

--- a/packages/react-app-revamp/supabase_schemas/chain_params.sql
+++ b/packages/react-app-revamp/supabase_schemas/chain_params.sql
@@ -1,7 +1,8 @@
-create table 
+create table
   public.chain_params (
-    uuid uuid not null default gen_random_uuid (),
+    id uuid not null default gen_random_uuid (),
     network_name character varying not null,
     min_cost_to_propose numeric not null,
-    min_cost_to_vote numeric not null
-) tablespace pg_default;
+    min_cost_to_vote numeric not null,
+    constraint chain_params_pkey primary key (id)
+  ) tablespace pg_default;

--- a/packages/react-app-revamp/supabase_schemas/contests_v3.sql
+++ b/packages/react-app-revamp/supabase_schemas/contests_v3.sql
@@ -13,14 +13,14 @@ create table
     summary character varying null,
     prompt character varying null,
     uuid uuid not null default gen_random_uuid (),
-    votingMerkleRoot character varying null,
-    submissionMerkleRoot character varying null,
+    "votingMerkleRoot" character varying null,
+    "submissionMerkleRoot" character varying null,
     hidden boolean null default false,
-    voting_requirements json null default null,
-    submission_requirements json null default null,
+    voting_requirements json null,
+    submission_requirements json null,
     cost_to_propose numeric null,
     percentage_to_creator numeric null,
-    cost_to_vote numeric null
+    cost_to_vote numeric null,
     constraint contests_v3_pkey primary key (uuid)
   ) tablespace pg_default;
 

--- a/packages/react-app-revamp/supabase_schemas/extensions.sql
+++ b/packages/react-app-revamp/supabase_schemas/extensions.sql
@@ -1,6 +1,7 @@
 create table
   public.extensions (
     id uuid not null default gen_random_uuid (),
-    name character varying not null,
+    name text not null,
     enabled boolean not null,
+    constraint extensions_pkey primary key (id)
   ) tablespace pg_default;

--- a/packages/react-app-revamp/supabase_schemas/user_permissions.sql
+++ b/packages/react-app-revamp/supabase_schemas/user_permissions.sql
@@ -1,7 +1,7 @@
 create table
   public.user_permissions (
     id uuid not null default gen_random_uuid (),
-    allowlist_max_size integer not null,
     user_address character varying not null,
+    allowlist_max_size integer not null,
     constraint user_permissions_pkey primary key (id)
   ) tablespace pg_default;

--- a/packages/react-app-revamp/tailwind.config.js
+++ b/packages/react-app-revamp/tailwind.config.js
@@ -302,6 +302,16 @@ module.exports = {
           "0%, 100%": { opacity: "1" },
           "50%": { opacity: "0.5" },
         },
+        reveal: {
+          "0%": {
+            mask: "linear-gradient(90deg, #000 25%, #000000e6 50%, #00000000) 150% 0 / 400% no-repeat",
+            opacity: ".2",
+          },
+          "100%": {
+            mask: "linear-gradient(90deg, #000 25%, #000000e6 50%, #00000000) 0 / 400% no-repeat",
+            opacity: "1",
+          },
+        },
       },
       scale: {
         120: "1.1",
@@ -323,6 +333,7 @@ module.exports = {
         swingInLeft: "swingInLeft 0.5s cubic-bezier(0.175, 0.885, 0.320, 1.275) both",
         flicker: "flicker 1s linear",
         "flicker-infinite": "flicker 1s linear infinite",
+        reveal: "reveal 1s ease-in-out",
       },
 
       height: {

--- a/packages/react-app-revamp/tailwind.config.js
+++ b/packages/react-app-revamp/tailwind.config.js
@@ -322,6 +322,7 @@ module.exports = {
         shakeTop: "shakeTop 0.8s cubic-bezier(0.455, 0.030, 0.515, 0.955) both",
         swingInLeft: "swingInLeft 0.5s cubic-bezier(0.175, 0.885, 0.320, 1.275) both",
         flicker: "flicker 1s linear",
+        "flicker-infinite": "flicker 1s linear infinite",
       },
 
       height: {


### PR DESCRIPTION
Closes #454
- [x]  add lib for net and paid balances for erc20 tokens
- [x]  implement erc20 tokens in the rewards tab on contest page
- [x]  add new visual on the contest page for rewards
- [x]  add erc20 info on the list of contests too
- [x] add new `animate-reveal` animation for a better transition on rewards and overall in app ( out of scope but added because i found it very appealing ) 
- [x]  make an index on `rewards_module_address`, `network_name`, `token_address`

Here is some of the UI updates
| Rewards unpaid  | Rewards paid out|
| ------------- | ------------- |
| ![payouts](https://github.com/jk-labs-inc/jokerace/assets/18723426/85a1e45e-cd58-4d3a-aa82-a85b5bb3cd5f)  |![rewards-paid-out](https://github.com/jk-labs-inc/jokerace/assets/18723426/16b0f9fe-69ce-4ca4-b33a-d8bb25019497)  |



