### PR TITLE
chore: update test solidity version

### DIFF
--- a/packages/forge/test/Contest.t.sol
+++ b/packages/forge/test/Contest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.19;
 
 import "@forge-std/Test.sol";
 import "../src/Contest.sol";

--- a/packages/forge/test/RewardsModule.t.sol
+++ b/packages/forge/test/RewardsModule.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.19;
 
 import "@forge-std/Test.sol";
 import "@openzeppelin/token/ERC20/presets/ERC20PresetFixedSupply.sol";


### PR DESCRIPTION
forgot to update test pragmas when we standardized all contracts to `0.8.19` so doing that now.