### PR TITLE
chore: rm smartcheck extra line removal

### DIFF
--- a/packages/forge/package.json
+++ b/packages/forge/package.json
@@ -14,6 +14,6 @@
     "forgetest": "forge test",
     "forgecoverage": "forge coverage",
     "forgebuild": "forge build",
-    "forgebuildandcopy": "forge build && copyfiles -u 1 out/Contest.sol/*.json ../react-app-revamp/contracts/bytecodeAndAbi && copyfiles -u 1 out/RewardsModule.sol/*.json ../react-app-revamp/contracts/bytecodeAndAbi/modules/ && forge flatten src/Contest.sol | tail -n +4 > ../react-app-revamp/contracts/bytecodeAndAbi/Contest.sol/flattenedContest.sol && forge flatten src/modules/RewardsModule.sol | tail -n +4 > ../react-app-revamp/contracts/bytecodeAndAbi/modules/RewardsModule.sol/flattenedRewardsModule.sol"
+    "forgebuildandcopy": "forge build && copyfiles -u 1 out/Contest.sol/*.json ../react-app-revamp/contracts/bytecodeAndAbi && copyfiles -u 1 out/RewardsModule.sol/*.json ../react-app-revamp/contracts/bytecodeAndAbi/modules/ && forge flatten src/Contest.sol > ../react-app-revamp/contracts/bytecodeAndAbi/Contest.sol/flattenedContest.sol && forge flatten src/modules/RewardsModule.sol > ../react-app-revamp/contracts/bytecodeAndAbi/modules/RewardsModule.sol/flattenedRewardsModule.sol"
   }
 }

--- a/packages/forge/test/Contest.t.sol
+++ b/packages/forge/test/Contest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.19;
 
 import "@forge-std/Test.sol";
 import "../src/Contest.sol";

--- a/packages/forge/test/RewardsModule.t.sol
+++ b/packages/forge/test/RewardsModule.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.19;
 
 import "@forge-std/Test.sol";
 import "@openzeppelin/token/ERC20/presets/ERC20PresetFixedSupply.sol";


### PR DESCRIPTION
`forge flatten` no longer includes command line compilation information in its file output so we can remove the accommodation we made for that behavior in `forge/package.json` in https://github.com/jk-labs-inc/jokerace/pull/1420/commits/343fe4b696e3dbad296304d705a486d553c8e2f4.