### PR TITLE
chore: revert #1664 and change to +3 with latest foundryup

### DIFF
--- a/packages/forge/package.json
+++ b/packages/forge/package.json
@@ -14,6 +14,6 @@
     "forgetest": "forge test",
     "forgecoverage": "forge coverage",
     "forgebuild": "forge build",
-    "forgebuildandcopy": "forge build && copyfiles -u 1 out/Contest.sol/*.json ../react-app-revamp/contracts/bytecodeAndAbi && copyfiles -u 1 out/RewardsModule.sol/*.json ../react-app-revamp/contracts/bytecodeAndAbi/modules/ && forge flatten src/Contest.sol > ../react-app-revamp/contracts/bytecodeAndAbi/Contest.sol/flattenedContest.sol && forge flatten src/modules/RewardsModule.sol > ../react-app-revamp/contracts/bytecodeAndAbi/modules/RewardsModule.sol/flattenedRewardsModule.sol"
+    "forgebuildandcopy": "forge build && copyfiles -u 1 out/Contest.sol/*.json ../react-app-revamp/contracts/bytecodeAndAbi && copyfiles -u 1 out/RewardsModule.sol/*.json ../react-app-revamp/contracts/bytecodeAndAbi/modules/ && forge flatten src/Contest.sol | tail -n +3 > ../react-app-revamp/contracts/bytecodeAndAbi/Contest.sol/flattenedContest.sol && forge flatten src/modules/RewardsModule.sol | tail -n +3 > ../react-app-revamp/contracts/bytecodeAndAbi/modules/RewardsModule.sol/flattenedRewardsModule.sol"
   }
 }


### PR DESCRIPTION
just reverting the removal of the `tail` command, not the updates to `0.8.19` for `.sol` files. the newest foundryup just changed flatten again for some reason.