### PR TITLE
chore: update sei rpc to mainnet

### DIFF
--- a/packages/react-app-revamp/config/wagmi/custom-chains/sei.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/sei.ts
@@ -11,10 +11,10 @@ export const sei: Chain = {
   },
   rpcUrls: {
     public: {
-      http: ["https://evm-rpc-arctic-1.sei-apis.com"],
+      http: ["https://evm-rpc.sei-apis.com"],
     },
     default: {
-      http: ["https://evm-rpc-arctic-1.sei-apis.com"],
+      http: ["https://evm-rpc.sei-apis.com"],
     },
   },
   blockExplorers: {


### PR DESCRIPTION
closes #1738 - we were using the rpc endpoint for the devnet instead of mainnet