### PR TITLE
chore: add minor and patch automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,12 @@
   "labels": ["renovate"],
   "major": {
     "dependencyDashboardApproval": true
-  }
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
https://docs.renovatebot.com/key-concepts/automerge/#automerge-non-major-updates

if the checks clear on patch and minor updates I think we're usually in the clear to merge so might as well automerge - we're going to have to manually patch into `main` either way so will always have a point where we check before it gets to prod.