### PR TITLE
enhancement: add show / hide toggle for submissions

### DIFF
--- a/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalContentInfo/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalContentInfo/index.tsx
@@ -1,5 +1,6 @@
 import UserProfileDisplay from "@components/UI/UserProfileDisplay";
 import ordinalize from "@helpers/ordinalize";
+import { MinusIcon, PlusIcon } from "@heroicons/react/outline";
 import { FC } from "react";
 
 interface ProposalContentInfoProps {
@@ -7,12 +8,31 @@ interface ProposalContentInfoProps {
   rank: number;
   isTied: boolean;
   isMobile: boolean;
+  isContentHidden: boolean;
+  toggleContentVisibility: () => void;
 }
 
-const ProposalContentInfo: FC<ProposalContentInfoProps> = ({ authorAddress, rank, isTied, isMobile }) => {
+const ProposalContentInfo: FC<ProposalContentInfoProps> = ({
+  authorAddress,
+  rank,
+  isTied,
+  isMobile,
+  isContentHidden,
+  toggleContentVisibility,
+}) => {
   return (
     <div className="flex items-center gap-3">
       <div className="flex items-center gap-1">
+        <button
+          onClick={toggleContentVisibility}
+          className="p-1 rounded-full hover:bg-primary-2 transition-colors duration-300"
+        >
+          {isContentHidden ? (
+            <PlusIcon className="w-4 h-4 text-neutral-9" />
+          ) : (
+            <MinusIcon className="w-4 h-4 text-neutral-9" />
+          )}
+        </button>
         <UserProfileDisplay ethereumAddress={authorAddress} shortenOnFallback={true} />
 
         {rank > 0 && (

--- a/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
@@ -127,7 +127,7 @@ const ProposalContent: FC<ProposalContentProps> = ({
       />
 
       {!isContentHidden ? (
-        <div className="animate-reveal md:mx-8 flex flex-col gap-4">
+        <div className="md:mx-8 flex flex-col gap-4">
           <Link
             className="p-4 rounded-[8px] bg-primary-1 border border-transparent hover:border-neutral-9 transition-colors duration-300 ease-in-out overflow-hidden"
             href={`/contest/${chainName}/${contestAddress}/submission/${proposal.id}`}

--- a/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
@@ -1,4 +1,4 @@
-import MarkdownImage from "@components/UI/Markdown/components/MarkdownImage";
+/* eslint-disable @next/next/no-img-element */
 import { extractPathSegments } from "@helpers/extractPath";
 import { formatNumberAbbreviated } from "@helpers/formatNumber";
 import { Tweet as TweetType } from "@helpers/isContentTweet";
@@ -40,48 +40,12 @@ interface ProposalContentProps {
   toggleProposalSelection?: (proposalId: string) => void;
 }
 
-const MAX_CHARS = 400;
-
-function smartTruncate(text: string, maxLength: number): string {
-  if (text.length <= maxLength) return text;
-
-  // Find the last space within the maxLength
-  let lastSpace = text.lastIndexOf(" ", maxLength);
-
-  // If no space found, look for punctuation marks
-  if (lastSpace === -1) {
-    const punctuationMarks = [".", "!", "?", ",", ";", ":", ")"];
-    for (let mark of punctuationMarks) {
-      let index = text.lastIndexOf(mark, maxLength);
-      if (index > lastSpace) lastSpace = index;
-    }
-  }
-
-  // If still no good breakpoint, use maxLength
-  if (lastSpace === -1 || lastSpace < maxLength * 0.8) {
-    lastSpace = maxLength;
-  }
-
-  // Trim any trailing spaces
-  while (lastSpace > 0 && text[lastSpace - 1] === " ") {
-    lastSpace--;
-  }
-
-  return text.substring(0, lastSpace) + "...";
-}
-
 const transform = (node: HTMLElement, children: Node[]): ReactNode => {
   const element = node.tagName.toLowerCase();
 
   if (element === "img") {
-    return <MarkdownImage imageSize="compact" src={node.getAttribute("src") ?? ""} />;
+    return <img src={node.getAttribute("src") ?? ""} alt={"image"} className="rounded-[16px]" />;
   }
-
-  // if (element === "div") {
-  //   return <div className="flex gap-5 flex-col md:flex-row items-start md:items-center markdown">{children}</div>;
-  // } else if (element === "img") {
-  //   return <MarkdownImage imageSize="compact" src={node.getAttribute("src") ?? ""} />;
-  // }
 };
 
 const ProposalContent: FC<ProposalContentProps> = ({
@@ -101,7 +65,7 @@ const ProposalContent: FC<ProposalContentProps> = ({
   const isProposalTweet = proposal.tweet.isTweet;
   const contestStatus = useContestStatusStore(state => state.contestStatus);
   const setPickProposal = useCastVotesStore(state => state.setPickedProposal);
-
+  const [isContentHidden, setIsContentHidden] = useState(false);
   const formattedVotingOpen = moment(votesOpen);
   const commentLink = {
     pathname: `/contest/${chainName}/${contestAddress}/submission/${proposal.id}`,
@@ -118,11 +82,13 @@ const ProposalContent: FC<ProposalContentProps> = ({
     const textContent = cheerio.text();
     const textLength = isMobile ? 100 : 200;
 
-    const truncatedText = textContent.length > textLength ? textContent.substring(0, textLength) + "..." : textContent;
-
-    truncatedContent = `<div><p>${truncatedText}</p><img src="${firstImageSrc}"/></div>`;
+    if (textContent.length > textLength) {
+      truncatedContent = proposal.content;
+    } else {
+      truncatedContent = `<div><p>${textContent}</p><img src="${firstImageSrc}"/></div>`;
+    }
   } else {
-    truncatedContent = smartTruncate(proposal.content, MAX_CHARS);
+    truncatedContent = proposal.content;
   }
 
   const handleVotingModalOpen = () => {
@@ -145,6 +111,10 @@ const ProposalContent: FC<ProposalContentProps> = ({
     setIsVotingModalOpen(true);
   };
 
+  const toggleContentVisibility = () => {
+    setIsContentHidden(!isContentHidden);
+  };
+
   return (
     <div className="flex flex-col gap-4 pb-4 border-b border-primary-2 animate-reveal">
       <ProposalContentInfo
@@ -152,68 +122,79 @@ const ProposalContent: FC<ProposalContentProps> = ({
         rank={proposal.rank}
         isTied={proposal.isTied}
         isMobile={isMobile}
+        isContentHidden={isContentHidden}
+        toggleContentVisibility={toggleContentVisibility}
       />
-      <div className="md:mx-8 flex flex-col gap-4">
-        <Link
-          className="p-4 rounded-[8px] bg-primary-1 border border-transparent hover:border-neutral-9 transition-colors duration-300 ease-in-out overflow-hidden"
-          href={`/contest/${chainName}/${contestAddress}/submission/${proposal.id}`}
-          shallow
-          scroll={false}
-          prefetch
-        >
-          {isProposalTweet ? (
-            <div className="dark not-prose">
-              <Tweet apiUrl={`/api/tweet/${proposal.tweet.id}`} id={proposal.tweet.id} />
-            </div>
-          ) : (
-            <Interweave className="prose prose-invert" content={proposal.content} />
-          )}
-        </Link>
-        <div className="flex items-center justify-between">
-          <div className="flex gap-2 items-center">
-            {contestStatus === ContestStatus.VotingOpen || contestStatus === ContestStatus.VotingClosed ? (
-              <button
-                onClick={handleVotingModalOpen}
-                className="min-w-36 flex-shrink-0 h-10 p-2 flex items-center justify-between gap-2 bg-primary-1 rounded-[16px] cursor-pointer border border-transparent hover:border-positive-11 transition-colors duration-300 ease-in-out"
-              >
-                <Image src="/contest/upvote.svg" width={21.56} height={20.44} alt="upvote" className="flex-shrink-0" />
-                <p className="text-[16px] text-positive-11 font-bold flex-grow text-center">
-                  {formatNumberAbbreviated(proposal.votes)} vote{proposal.votes !== 1 ? "s" : ""}
-                </p>
-              </button>
-            ) : (
-              <p className="text-neutral-10 text-[16px] font-bold">
-                voting opens {formattedVotingOpen.format("MMMM Do, h:mm a")}
-              </p>
-            )}
 
-            <Link
-              href={commentLink}
-              className="min-w-16 flex-shrink-0 h-10 p-2 flex items-center justify-between gap-2 bg-primary-1 rounded-[16px] cursor-pointer border border-transparent hover:border-neutral-9 transition-colors duration-300 ease-in-out"
-              shallow
-              scroll={false}
-            >
-              <ChatAltIcon className="w-6 h-6 text-neutral-9 flex-shrink-0" />
-              <p className="text-[16px] text-neutral-9 font-bold flex-grow text-center">{proposal.commentsCount}</p>
-            </Link>
-          </div>
-          {allowDelete && (
-            <div className="h-8 w-8 relative cursor-pointer" onClick={() => toggleProposalSelection?.(proposal.id)}>
-              <CheckIcon
-                className={`absolute top-0 left-0 transform transition-all ease-in-out duration-300 
+      {!isContentHidden ? (
+        <div className="animate-reveal md:mx-8 flex flex-col gap-4">
+          <Link
+            className="p-4 rounded-[8px] bg-primary-1 border border-transparent hover:border-neutral-9 transition-colors duration-300 ease-in-out overflow-hidden"
+            href={`/contest/${chainName}/${contestAddress}/submission/${proposal.id}`}
+            shallow
+            scroll={false}
+            prefetch
+          >
+            {isProposalTweet ? (
+              <div className="dark not-prose">
+                <Tweet apiUrl={`/api/tweet/${proposal.tweet.id}`} id={proposal.tweet.id} />
+              </div>
+            ) : (
+              <Interweave className="prose prose-invert" content={truncatedContent} transform={transform} />
+            )}
+          </Link>
+          <div className="flex items-center justify-between">
+            <div className="flex gap-2 items-center">
+              {contestStatus === ContestStatus.VotingOpen || contestStatus === ContestStatus.VotingClosed ? (
+                <button
+                  onClick={handleVotingModalOpen}
+                  className="min-w-36 flex-shrink-0 h-10 p-2 flex items-center justify-between gap-2 bg-primary-1 rounded-[16px] cursor-pointer border border-transparent hover:border-positive-11 transition-colors duration-300 ease-in-out"
+                >
+                  <Image
+                    src="/contest/upvote.svg"
+                    width={21.56}
+                    height={20.44}
+                    alt="upvote"
+                    className="flex-shrink-0"
+                  />
+                  <p className="text-[16px] text-positive-11 font-bold flex-grow text-center">
+                    {formatNumberAbbreviated(proposal.votes)} vote{proposal.votes !== 1 ? "s" : ""}
+                  </p>
+                </button>
+              ) : (
+                <p className="text-neutral-10 text-[16px] font-bold">
+                  voting opens {formattedVotingOpen.format("MMMM Do, h:mm a")}
+                </p>
+              )}
+
+              <Link
+                href={commentLink}
+                className="min-w-16 flex-shrink-0 h-10 p-2 flex items-center justify-between gap-2 bg-primary-1 rounded-[16px] cursor-pointer border border-transparent hover:border-neutral-9 transition-colors duration-300 ease-in-out"
+                shallow
+                scroll={false}
+              >
+                <ChatAltIcon className="w-6 h-6 text-neutral-9 flex-shrink-0" />
+                <p className="text-[16px] text-neutral-9 font-bold flex-grow text-center">{proposal.commentsCount}</p>
+              </Link>
+            </div>
+            {allowDelete && (
+              <div className="h-8 w-8 relative cursor-pointer" onClick={() => toggleProposalSelection?.(proposal.id)}>
+                <CheckIcon
+                  className={`absolute top-0 left-0 transform transition-all ease-in-out duration-300 
         ${selectedProposalIds.includes(proposal.id) ? "opacity-100" : "opacity-0"}
         h-8 w-8 text-primary-10 bg-white bg-true-black border border-neutral-11 hover:text-primary-9 
         shadow-md hover:shadow-lg rounded-md`}
-              />
-              <TrashIcon
-                className={`absolute top-0 left-0 transition-opacity duration-300 
+                />
+                <TrashIcon
+                  className={`absolute top-0 left-0 transition-opacity duration-300 
         ${selectedProposalIds.includes(proposal.id) ? "opacity-0" : "opacity-100"}
         h-8 w-8 text-negative-11 bg-true-black hover:text-negative-10`}
-              />
-            </div>
-          )}
+                />
+              </div>
+            )}
+          </div>
         </div>
-      </div>
+      ) : null}
 
       <DialogModalVoteForProposal isOpen={isVotingModalOpen} setIsOpen={setIsVotingModalOpen} proposal={proposal} />
     </div>


### PR DESCRIPTION
Here is a screenshot of the enhancement because, for some reason, the tool i'm using won't let me compile .gif files smaller than 10MB. 

We have included a toggle so that users can choose whether to view or hide submissions.

![image](https://github.com/jk-labs-inc/jokerace/assets/18723426/ba8cf113-74d4-4f6f-b054-36f2c0e37a44)


EDIT: 

We have implemented a feature to save user preferences for hidden proposals in local storage. The data structure stores an array of proposal ids for each contest id. This allows users to have different hidden proposals for different contests.

Key points:
1. User preferences persist through page reloads.
2. Preferences reset when the user closes the tab or window.
