### PR TITLE
chore: rm deprecated dependency

### DIFF
--- a/packages/react-app-revamp/package.json
+++ b/packages/react-app-revamp/package.json
@@ -95,7 +95,6 @@
     "@types/papaparse": "5.3.14",
     "@types/react": "18.3.3",
     "@types/react-csv": "1.1.10",
-    "@types/react-datepicker": "7.0.0",
     "@types/react-dom": "18.3.0",
     "@types/react-virtualized": "9.21.30",
     "@types/react-window": "1.8.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7211,13 +7211,6 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-datepicker@7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@types/react-datepicker/-/react-datepicker-7.0.0.tgz#1d36553a92546246f1e10d862b3cfa7d295dff01"
-  integrity sha512-4tWwOUq589tozyQPBVEqGNng5DaZkomx5IVNuur868yYdgjH6RaL373/HKiVt1IDoNNXYiTGspm1F7kjrarM8Q==
-  dependencies:
-    react-datepicker "*"
-
 "@types/react-dom@18.3.0":
   version "18.3.0"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
@@ -14218,7 +14211,7 @@ react-csv@2.2.2:
   resolved "https://registry.yarnpkg.com/react-csv/-/react-csv-2.2.2.tgz#5bbf0d72a846412221a14880f294da9d6def9bfb"
   integrity sha512-RG5hOcZKZFigIGE8LxIEV/OgS1vigFQT4EkaHeKgyuCbUAu9Nbd/1RYq++bJcJJ9VOqO/n9TZRADsXNDR4VEpw==
 
-react-datepicker@*, react-datepicker@7.3.0:
+react-datepicker@7.3.0:
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-7.3.0.tgz#666664a609d4b57b095083fe29d080943fa7b3ed"
   integrity sha512-EqRKLAtLZUTztiq6a+tjSjQX9ES0Xd229JPckAtyZZ4GoY3rtvNWAzkYZnQUf6zTWT50Ki0+t+W9VRQIkSJLfg==


### PR DESCRIPTION
[`@types/react-datepicker`](https://www.npmjs.com/package/@types/react-datepicker) has been deprecated, so removing.