### PR TITLE
chore: delete breaking husky line

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,4 +1,3 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
 
 yarn install


### PR DESCRIPTION
was getting the below so just removing the offending line, the yarn install on `git checkout`/`git switch` still works.

<img width="643" alt="Screenshot 2024-07-24 at 12 07 18 PM" src="https://github.com/user-attachments/assets/da79d281-1ea0-4603-9a5b-153288fc69f8">
