### PR TITLE
bugfix: lowercase chain name when fetching votes balance

### DIFF
--- a/packages/react-app-revamp/components/_pages/Contest/components/StickyCards/components/VotingQualifier/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/components/StickyCards/components/VotingQualifier/index.tsx
@@ -29,8 +29,9 @@ const VotingContestQualifier = () => {
   const costToVoteFormatted = formatEther(BigInt(charge?.type.costToVote ?? 0));
   const asPath = usePathname();
   const { chainName } = extractPathSegments(asPath ?? "");
-  const nativeCurrencySymbol = chains.find(chain => chain.name === chainName.toLowerCase())?.nativeCurrency.symbol;
-  const chainId = chains.find(chain => chain.name === chainName.toLowerCase())?.id;
+  const nativeCurrencySymbol = chains.find(chain => chain.name.toLowerCase() === chainName.toLowerCase())
+    ?.nativeCurrency.symbol;
+  const chainId = chains.find(chain => chain.name.toLowerCase() === chainName.toLowerCase())?.id;
 
   return (
     <div className="w-full flex flex-col gap-2 md:gap-4  md:pl-8">


### PR DESCRIPTION
I've noticed that, instead of retrieving the balance of the contest chain when the contest is open to anyone, we are retrieving the balance of the connected chain for the card that displays the users native token balance and their corresponding votes. 

The previous logic was correct and in place, however when comparing the chain names, we must `lowerCase` them.