### PR TITLE
chore: ignore react-native updates for now

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   "major": {
     "dependencyDashboardApproval": true
   },
+  "ignoreDeps": ["react-native"],
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
the build keeps hanging for like 45 minutes which we just can't have with the limits of Vercel, so ignoring those updates for now.