### PR TITLE
enhancement: move resize button out of image

### DIFF
--- a/packages/react-app-revamp/components/_pages/ProposalContent/components/ImageWithFallback/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/components/ImageWithFallback/index.tsx
@@ -1,5 +1,4 @@
-import NextImage from "next/image";
-import { useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 interface ImageWithFallbackProps {
@@ -7,6 +6,8 @@ interface ImageWithFallbackProps {
   fullSrc: string;
   alt: string;
   containerWidth: number;
+  isExpanded: boolean;
+  onImageLoad: (showResizeButton: boolean) => void;
 }
 
 interface ImageData {
@@ -24,9 +25,14 @@ const preloadImage = async (src: string): Promise<ImageData> => {
   });
 };
 
-const ImageWithFallback: React.FC<ImageWithFallbackProps> = ({ mediumSrc, fullSrc, alt, containerWidth }) => {
-  const [isExpanded, setIsExpanded] = useState(false);
-  const [showResizeButton, setShowResizeButton] = useState(false);
+const ImageWithFallback: React.FC<ImageWithFallbackProps> = ({
+  mediumSrc,
+  fullSrc,
+  alt,
+  containerWidth,
+  isExpanded,
+  onImageLoad,
+}) => {
   const [useMediumImage, setUseMediumImage] = useState(true);
 
   const { data: mediumImage, isLoading: isMediumLoading } = useQuery({
@@ -50,46 +56,24 @@ const ImageWithFallback: React.FC<ImageWithFallbackProps> = ({ mediumSrc, fullSr
         const widthDifference = Math.abs(mediumImage.width - containerWidth);
         const threshold = 0.1; // 10% difference
         const significantDifference = widthDifference / containerWidth > threshold;
-        setShowResizeButton(significantDifference);
+        onImageLoad(significantDifference);
       } else {
-        setShowResizeButton(false);
+        onImageLoad(false);
       }
     }
-  }, [mediumImage, fullImage, containerWidth]);
-
-  const toggleExpand = (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsExpanded(!isExpanded);
-  };
+  }, [mediumImage, fullImage, containerWidth, onImageLoad]);
 
   const currentImage = isExpanded || !useMediumImage ? fullImage : mediumImage;
   const isLoading = isExpanded || !useMediumImage ? isFullLoading : isMediumLoading;
 
   return (
-    <div className="relative inline-block">
-      <img
-        src={isLoading ? fullSrc : currentImage?.img.src || fullSrc}
-        alt={alt}
-        className={`rounded-[16px] max-w-full ${isExpanded ? "w-full" : ""}`}
-        width={currentImage?.width}
-        height={currentImage?.height}
-      />
-      {showResizeButton && (
-        <div className="absolute top-0 right-0 p-1">
-          <button
-            onClick={toggleExpand}
-            className="bg-primary-2 opacity-75 p-2 rounded-full hover:opacity-100 transition-opacity z-10"
-          >
-            {isExpanded ? (
-              <NextImage src="/contest/minimize.svg" width={14} height={14} alt="minimize" />
-            ) : (
-              <NextImage src="/contest/maximize.svg" width={14} height={14} alt="maximize" />
-            )}
-          </button>
-        </div>
-      )}
-    </div>
+    <img
+      src={isLoading ? fullSrc : currentImage?.img.src || fullSrc}
+      alt={alt}
+      className={`rounded-[16px] max-w-full ${isExpanded ? "w-full" : ""}`}
+      width={currentImage?.width}
+      height={currentImage?.height}
+    />
   );
 };
 


### PR DESCRIPTION
This PR moves the resize button for proposal images from within the image component to the proposal header area. This change addresses few UX issues and improves overall user interaction.

1. **Improved click accuracy**: Previously, the resize button was part of the image area, which is also a link to the proposal. This created a conflict where users might accidentally trigger the link when trying to resize the image. Moving the button out of the image eliminates this issue ( user still couldn't open it by clicking a resize button, it is just that behaviour is a bit messy ) 

2. **Reduced accidental interactions**: Even with `preventDefault()`, clicking the resize button within the image area could cause the loading bar to appear, giving a false impression of navigation. The new placement prevents this confusing behaviour.

We have also removed it for mobile, since image won't be ever resized to those small dimensions so it doesn't make sense for the resize button to appear there. 