### PR TITLE
bugfix: add weavm testnet to wagmi server config

### DIFF
--- a/packages/react-app-revamp/config/wagmi/custom-chains/weavevmTestnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/weavevmTestnet.ts
@@ -21,4 +21,5 @@ export const weavevmTestnet: Chain = {
     etherscan: { name: "WeaveVM Block Explorer", url: "https://explorer.wvm.dev" },
     default: { name: "WeaveVM Block Explorer", url: "https://explorer.wvm.dev" },
   },
+  testnet: true,
 };

--- a/packages/react-app-revamp/config/wagmi/server.ts
+++ b/packages/react-app-revamp/config/wagmi/server.ts
@@ -100,6 +100,7 @@ import { taiko } from "./custom-chains/taiko";
 import { taikoTestnet } from "./custom-chains/taikoTestnet";
 import { unique } from "./custom-chains/unique";
 import { vitruveo } from "./custom-chains/vitruveo";
+import { weavevmTestnet } from "./custom-chains/weavevmTestnet";
 import { xLayer } from "./custom-chains/xLayer";
 import { xLayerTestnet } from "./custom-chains/xLayerTestnet";
 import { zetaTestnet } from "./custom-chains/zetaTestnet";
@@ -212,6 +213,7 @@ export const chains: readonly [Chain, ...Chain[]] = [
   movementTestnet,
   kaiaTestnet,
   fluentTestnet,
+  weavevmTestnet,
   formaTestnet,
   kakarotTestnet,
   mainnet,


### PR DESCRIPTION
I have noticed that contest on weaveVM testnet is failing to load, specifically [this](https://www.jokerace.io/contest/weavevm/0x67d6e74d68e65ba05bd2b6a150bca1a41d6950cd) one.

We missed to include it in the list of chains for the wagmi server config, with this in place, it should load correctly! 