### PR TITLE
bugfix: remove character length for tweets in proposal preview

### DIFF
--- a/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
@@ -192,7 +192,13 @@ const ProposalContent: FC<ProposalContentProps> = ({
               prefetch
             >
               {isProposalTweet ? (
-                <div className="dark not-prose">
+                <div className="dark interweave-container inline-block w-full">
+                  <Interweave
+                    className="prose prose-invert"
+                    content={proposal.content}
+                    transform={transform}
+                    tagName="div"
+                  />
                   <Tweet apiUrl={`/api/tweet/${proposal.tweet.id}`} id={proposal.tweet.id} />
                 </div>
               ) : (

--- a/packages/react-app-revamp/helpers/isContentTweet.ts
+++ b/packages/react-app-revamp/helpers/isContentTweet.ts
@@ -11,20 +11,18 @@ export const isContentTweet = (htmlContent: string): Tweet => {
   let foundTweet = false;
   let tweetId = "";
 
-  if ($.text().length <= 200) {
-    $("a").each(function () {
-      const href = $(this).attr("href");
-      const tweetUrlMatch = href && href.match(twitterRegex);
+  $("a").each(function () {
+    const href = $(this).attr("href");
+    const tweetUrlMatch = href && href.match(twitterRegex);
 
-      const isInsideList = $(this).parents("li,ul,ol").length > 0;
+    const isInsideList = $(this).parents("li,ul,ol").length > 0;
 
-      if (!isInsideList && tweetUrlMatch) {
-        foundTweet = true;
-        tweetId = tweetUrlMatch[4] || tweetUrlMatch[2];
-        return false;
-      }
-    });
-  }
+    if (!isInsideList && tweetUrlMatch) {
+      foundTweet = true;
+      tweetId = tweetUrlMatch[4] || tweetUrlMatch[2];
+      return false;
+    }
+  });
 
   return { isTweet: foundTweet, id: tweetId };
 };


### PR DESCRIPTION
I have noticed that for [this](https://www.jokerace.io/contest/base/0xbf6b7c06e23a07b857d47d67fcae0dcd739d1a03) contest, some of the proposals do not render tweets ( check the first place proposal ) in the proposal preview. 

This is because of the limitations we had in the previous model for the proposal preview, since we no longer need those limitations, by removing it, we are always rendering the tweets if the proposal contains one.