### PR TITLE
bugfix: hide earnings edit if percentage to creator is 0

### DIFF
--- a/packages/react-app-revamp/components/_pages/Contest/Parameters/components/Earnings/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/Parameters/components/Earnings/index.tsx
@@ -56,7 +56,7 @@ const ContestParametersEarnings: FC<ContestParametersEarningsProps> = ({ charge,
     <div className="flex flex-col gap-8">
       <div className="flex gap-4 items-center">
         <p className="text-[20px] font-bold text-neutral-14">earnings</p>
-        {isConnectedWalletAuthor && !isContestFinishedOrCanceled && (
+        {isConnectedWalletAuthor && charge.percentageToCreator > 0 && !isContestFinishedOrCanceled && (
           <button onClick={() => setIsEditEarningsModalOpen(true)}>
             <PencilSquareIcon className="w-6 h-6 text-neutral-9 hover:text-neutral-11 transition-colors duration-300 ease-in-out" />
           </button>
@@ -66,6 +66,7 @@ const ContestParametersEarnings: FC<ContestParametersEarningsProps> = ({ charge,
         <li className="list-disc">{percentageToCreatorMessage()}</li>
         {isCreatorSplitEnabled && <li className="list-disc">{creatorEarningsDestinationMessage()}</li>}
       </ul>
+
       <ContestParamsEarningsModal
         charge={charge}
         isOpen={isEditEarningsModalOpen}

--- a/packages/react-app-revamp/components/_pages/Contest/Rewards/components/Create/steps/ReviewPool/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/Rewards/components/Create/steps/ReviewPool/index.tsx
@@ -29,7 +29,7 @@ const CreateRewardsReviewPool = () => {
   const isUserOnCorrectChain = contestChainId === userChainId;
   const isContestFinishedOrCanceled =
     contestState === ContestStateEnum.Completed || contestState === ContestStateEnum.Canceled;
-  const enableEarningsToggle = charge && !isContestFinishedOrCanceled;
+  const enableEarningsToggle = charge && charge.percentageToCreator > 0 && !isContestFinishedOrCanceled;
 
   const handleSwitchNetwork = async () => {
     if (!contestChainId) return;


### PR DESCRIPTION
I am not sure if this action is allowed on the contract side, can we use `setCreatorSplitDestination` function if percentage to creator is 0? 

This PR will not prevent it to happen on the front ( as long percentage to creator is 0, we do not allow to edit earnings or to set it during the rewards creation ) 