### PR TITLE
bugfix: tweets not rendering when they are paragraph element

### DIFF
--- a/packages/react-app-revamp/components/_pages/Contest/components/Prompt/Proposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/components/Prompt/Proposal/index.tsx
@@ -29,9 +29,8 @@ interface ContestProposalProps {
 
 const transform = (node: HTMLElement): ReactNode => {
   const element = node.tagName.toLowerCase();
-
-  if (element === "a") {
-    const href = node.getAttribute("href");
+  if (element === "a" || element === "p") {
+    const href = element === "a" ? node.getAttribute("href") : node.textContent;
     const tweetUrlMatch = href && href.match(twitterRegex);
 
     const isInsideList =

--- a/packages/react-app-revamp/helpers/isContentTweet.ts
+++ b/packages/react-app-revamp/helpers/isContentTweet.ts
@@ -11,9 +11,10 @@ export const isContentTweet = (htmlContent: string): Tweet => {
   let foundTweet = false;
   let tweetId = "";
 
-  $("a").each(function () {
-    const href = $(this).attr("href");
-    const tweetUrlMatch = href && href.match(twitterRegex);
+  $("a, p").each(function () {
+    const element = this.tagName.toLowerCase();
+    const content = element === "a" ? $(this).attr("href") : $(this).text();
+    const tweetUrlMatch = content && content.match(twitterRegex);
 
     const isInsideList = $(this).parents("li,ul,ol").length > 0;
 


### PR DESCRIPTION
Closes #2297 

Sometimes tweets come as `p` paragraph element rather than as `a` anchor element, not sure if this is due to user pasting incorrectly or our markdown editor making a mistake.

However, we should check if the paragraph contains full link for the tweet and render it in that case.