### PR TITLE
chore: bump down submission limit

### DIFF
--- a/packages/react-app-revamp/hooks/useDeployContest/store.tsx
+++ b/packages/react-app-revamp/hooks/useDeployContest/store.tsx
@@ -18,7 +18,7 @@ import {
 
 type ReactStyleStateSetter<T> = T | ((prev: T) => T);
 
-const DEFAULT_SUBMISSIONS = 1000000;
+const DEFAULT_SUBMISSIONS = 10000;
 
 type ContestDeployError = {
   step: number;


### PR DESCRIPTION
to hedge the risk that rpc memory limits prevent the calls that we need to make like in this case of [this contest](https://www.jokerace.io/contest/movementtestnet/0x6c24646b1ece34d514135bfef7106b951e09180f), we're going to bring the submission limit down from 1mm to 10k (contests really don't make sense having more than 10k submissions anyways.