### PR TITLE
enhancement: improve voting slider on mobile

### DIFF
--- a/packages/react-app-revamp/components/UI/Slider/index.tsx
+++ b/packages/react-app-revamp/components/UI/Slider/index.tsx
@@ -1,6 +1,7 @@
 import Slider from "rc-slider";
 import "rc-slider/assets/index.css";
 import { FC, useEffect, useState } from "react";
+import { useMediaQuery } from "react-responsive";
 import { Tooltip } from "react-tooltip";
 
 interface StepSliderProps {
@@ -23,6 +24,7 @@ const StepSlider: FC<StepSliderProps> = ({
   onKeyDown,
 }) => {
   const [value, setValue] = useState(defaultValue);
+  const isMobile = useMediaQuery({ query: "(max-width: 768px)" });
 
   useEffect(() => {
     setValue(val);
@@ -33,44 +35,44 @@ const StepSlider: FC<StepSliderProps> = ({
     onChange?.(value);
   };
 
-  const trackStyle = {
-    backgroundColor: "#BB65FF",
-    height: 8,
-  };
-
-  const handleStyle = {
-    borderColor: "#D9D9D9",
-    height: 16,
-    width: 16,
-    backgroundColor: "#D9D9D9",
-    opacity: "1",
-  };
-
-  const railStyle = {
-    backgroundColor: "#6A6A6A",
-    height: 8,
-  };
-
-  const dotStyle = {
-    borderColor: "#D9D9D9",
-    height: 10,
-    width: 10,
-    backgroundColor: "#D9D9D9",
+  const styles = {
+    track: {
+      backgroundColor: "#BB65FF",
+      height: 8,
+    },
+    handle: {
+      borderColor: "#D9D9D9",
+      height: isMobile ? 32 : 16,
+      width: isMobile ? 32 : 16,
+      backgroundColor: "#D9D9D9",
+      opacity: 1,
+      cursor: "pointer",
+      marginTop: isMobile ? -12 : -4,
+    },
+    rail: {
+      backgroundColor: "#6A6A6A",
+      height: 8,
+    },
+    dot: {
+      borderColor: "#D9D9D9",
+      height: 10,
+      width: 10,
+      backgroundColor: "#D9D9D9",
+    },
   };
 
   return (
-    <div onKeyDown={onKeyDown} tabIndex={0}>
+    <div onKeyDown={onKeyDown} tabIndex={0} className="p-4 md:p-0">
       <Slider
         className="w-60"
         min={min}
         max={max}
         value={value}
-        dotStyle={dotStyle}
         step={step}
-        trackStyle={trackStyle}
-        handleStyle={handleStyle}
-        railStyle={railStyle}
         onChange={handleSliderChange}
+        allowCross={false}
+        pushable={true}
+        styles={styles}
         handleRender={renderProps => {
           return (
             <div {...renderProps.props} data-tooltip-id="voting-slider">

--- a/packages/react-app-revamp/components/Voting/index.tsx
+++ b/packages/react-app-revamp/components/Voting/index.tsx
@@ -173,7 +173,7 @@ const VotingWidget: FC<VotingWidgetProps> = ({
                 max={amountOfVotes}
                 onKeyDown={handleKeyDownInput}
                 onInput={handleInput}
-                className="w-full text-center text-[32px] bg-transparent outline-none placeholder-neutral-9"
+                className="w-full text-center text-[32px] bg-transparent outline-none placeholder-neutral-9 focus:placeholder-transparent md:focus:placeholder-neutral-9"
               />
               <span className="absolute right-4 text-neutral-9 text-[16px] font-bold">
                 vote{amount !== 1 ? "s" : ""}

--- a/packages/react-app-revamp/components/Voting/index.tsx
+++ b/packages/react-app-revamp/components/Voting/index.tsx
@@ -158,7 +158,7 @@ const VotingWidget: FC<VotingWidgetProps> = ({
               {charge ? <ChargeInfo charge={charge} /> : null}
             </div>
             <div
-              className={`relative flex w-full md:w-80 h-16 items-center px-4 text-[16px] bg-transparent font-bold ${
+              className={`relative flex w-full md:w-80 h-16 items-center px-8 text-[16px] bg-transparent font-bold ${
                 isInvalid ? "text-negative-11" : "text-neutral-11"
               } border-2 ${isFocused && !isInvalid ? "border-neutral-11" : isInvalid ? "border-negative-11" : "border-neutral-10"} rounded-[40px] transition-colors duration-300`}
             >
@@ -173,7 +173,7 @@ const VotingWidget: FC<VotingWidgetProps> = ({
                 max={amountOfVotes}
                 onKeyDown={handleKeyDownInput}
                 onInput={handleInput}
-                className="w-full text-center text-[32px] bg-transparent outline-none placeholder-neutral-9 focus:placeholder-transparent md:focus:placeholder-neutral-9"
+                className="w-full text-[32px] bg-transparent outline-none placeholder-neutral-10"
               />
               <span className="absolute right-4 text-neutral-9 text-[16px] font-bold">
                 vote{amount !== 1 ? "s" : ""}


### PR DESCRIPTION
Closes #2232 

Let me explain why some of these issues aren't possible on desktop and mobile.

1. the purple cursor doesn't automatically blink in the voting field unless you tap it ( on mobile )

The issue with this one, is that you can't auto focus input on mobile due to various mobile restrictions with web app (both apple and android), the problematic part is that when input is focused on mobile, keyboard is open and therefore window dimensions are resized. Therefore, on load, you can't auto focus an input because mobile explorers have to calculate those dimensions in the background, and it can be done only manually (by clicking on the input), i have done lot of research on this area but in case i missed something or you find in some web app on mobile this behaviour, please let me know! 

2. when it starts blinking, it blinks in the center in the middle of the sample text (0.00) rather than to the right to encourage people to type ( desktop & mobile )

The issue with this one is that we are centering the text of the input in the middle (we account space for the label on right too) and we can't adjust the position of the cursor in the input since cursor is by default blinking at where the text will start. We could maybe try a workaround for this by not using input and classic div, but in my opinion that is an overkill because we should use elements which are designed for what they should do (in this case number input)

3. on brave at least, i couldn't use the slider at all, i could only type ( on mobile )

We fixed this now by increasing a slider dot size a little bit and added a padding around the area where the slider is on mobile, so slider should work now across all browsers on mobile. The slider was positioned on the edge to the left and right, so touching it also touched native mobile events in the browser (sliding left or right would take you to the previous or next page).