### PR TITLE
chore: group actions on branch

### DIFF
--- a/.github/workflows/forge_tests.yml
+++ b/.github/workflows/forge_tests.yml
@@ -5,6 +5,10 @@ on: push
 env:
   FOUNDRY_PROFILE: ci
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   check:
     strategy:

--- a/.github/workflows/nextjs_build.yml
+++ b/.github/workflows/nextjs_build.yml
@@ -5,7 +5,7 @@ on: push
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: "nextjs"
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs#example-using-concurrency-and-the-default-behavior

tldr: this setting makes it so that a given workflow will only be scheduled concurrently with another trigger of the same workflow on the same branch a maximum of one time and that the already running workflow will finish, any workflow triggers between the current running workflow and the latest triggered workflow will be canceled.

tldrtldr: if you push 6 times to a branch before the workflow triggered by the first push finishes, only the first and sixth triggers will run, the ones in between those will be canceled. this will save us a lot of redundant build time.