### PR TITLE
wording: update submission language for contests

### DIFF
--- a/packages/react-app-revamp/components/_pages/ListContests/Contest/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListContests/Contest/index.tsx
@@ -128,7 +128,7 @@ const Contest: FC<ContestProps> = ({ contest, loading, rewards, allowToHide, rew
         setSubmissionTimeLeft({ value: daysLeft, type: "days" });
       }
     } else {
-      setSubmissionStatus("entering closed");
+      setSubmissionStatus("entries closed");
     }
 
     if (now.isBefore(moment(contest.vote_start_at))) {
@@ -505,7 +505,7 @@ const Contest: FC<ContestProps> = ({ contest, loading, rewards, allowToHide, rew
                         {moment(contest.start_at).format("MMM D")} - {moment(contest.vote_start_at).format("MMM D")}
                       </>
                     ) : (
-                      "entering closed"
+                      "entries closed"
                     )}
                   </li>
                   <li>

--- a/packages/react-app-revamp/hooks/useContestInfo/index.tsx
+++ b/packages/react-app-revamp/hooks/useContestInfo/index.tsx
@@ -53,7 +53,7 @@ const useContestInfo = ({
 
   useEffect(() => {
     const newSubmissionClass = (() => {
-      if (submissionStatus === "entering closed") {
+      if (submissionStatus === "entries closed") {
         return "text-neutral-9";
       }
 
@@ -100,7 +100,7 @@ const useContestInfo = ({
     const newSubmissionMessage = (() => {
       if (loading) return;
 
-      if (submissionStatus === "entering closed") {
+      if (submissionStatus === "entries closed") {
         return null;
       }
 


### PR DESCRIPTION
In this PR we replaced all instances with `entering closed` with `entries closed`