### PR TITLE
bugfix: fix tweet rendering issue

### DIFF
--- a/packages/react-app-revamp/components/_pages/Contest/components/Prompt/Proposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/components/Prompt/Proposal/index.tsx
@@ -29,8 +29,8 @@ interface ContestProposalProps {
 
 const transform = (node: HTMLElement): ReactNode => {
   const element = node.tagName.toLowerCase();
-  if (element === "a" || element === "p") {
-    const href = element === "a" ? node.getAttribute("href") : node.textContent;
+  if (element === "a") {
+    const href = node.getAttribute("href");
     const tweetUrlMatch = href && href.match(twitterRegex);
 
     const isInsideList =


### PR DESCRIPTION
Closes #2455 

Issue here was that when we transform the markdown, we check if the proposal is tweet, but the issue is when we check if paragraph contains the tweet. This transform check where if tweet is contained somewhere in the paragraph can introduce buggy behaviour in the markdown.

However, i think that we need to have strict rules here in order to maintain markdown clean and that is that tweet can only be in the anchor link, which makes most sense because only then it contains link to the tweet in `href`, in the future we can have an option to add tweet directly from options ( like we have for images, for heading etc .. ) 