### PR TITLE
enhancement: add different language for anyone can vote in voting widget

### DIFF
--- a/packages/react-app-revamp/components/Voting/index.tsx
+++ b/packages/react-app-revamp/components/Voting/index.tsx
@@ -17,17 +17,10 @@ interface VotingWidgetProps {
   proposalId: string;
   amountOfVotes: number;
   downvoteAllowed?: boolean;
-  isWidgetInModal?: boolean;
   onVote?: (amount: number, isUpvote: boolean) => void;
 }
 
-const VotingWidget: FC<VotingWidgetProps> = ({
-  proposalId,
-  amountOfVotes,
-  downvoteAllowed,
-  isWidgetInModal,
-  onVote,
-}) => {
+const VotingWidget: FC<VotingWidgetProps> = ({ proposalId, amountOfVotes, downvoteAllowed, onVote }) => {
   const { charge } = useContestStore(state => state);
   const asPath = usePathname();
   const { chainId: accountChainId } = useAccount();
@@ -127,87 +120,79 @@ const VotingWidget: FC<VotingWidgetProps> = ({
   if (isContestCanceled) return null;
 
   return (
-    <div className="flex flex-col gap-4 md:w-80">
-      <hr className={`${isWidgetInModal ? "hidden" : "block"} md:block border border-neutral-9`} />
-      <div className="flex flex-col gap-8">
-        <p className="text-neutral-11 font-bold text-[20px]">add votes</p>
-        <div className="flex flex-col -mt-[16px] md:-mt-0 gap-4">
-          {downvoteAllowed ? (
-            <div className="flex w-full border border-neutral-10 rounded-[25px] overflow-hidden text-[16px] text-center">
-              <div
-                className={`w-full px-4 py-1 cursor-pointer ${
-                  isUpvote ? "bg-neutral-11 text-true-black font-bold" : "bg-true-black text-neutral-10"
-                }`}
-                onClick={() => handleClick(true)}
-              >
-                upvote
-              </div>
-              <div
-                className={`w-full px-4 py-1 cursor-pointer ${
-                  !isUpvote ? "bg-neutral-11 text-true-black font-bold" : "bg-true-black text-neutral-10"
-                }`}
-                onClick={() => handleClick(false)}
-              >
-                downvote
-              </div>
-            </div>
-          ) : null}
-          <div className="flex flex-col gap-6">
-            <div className="flex flex-col gap-2">
-              <MyVotes amountOfVotes={amountOfVotes} charge={charge} chainId={chainId} />
-              {charge ? <ChargeInfo charge={charge} /> : null}
+    <div className="flex flex-col gap-8">
+      <div className="flex flex-col gap-4">
+        {downvoteAllowed ? (
+          <div className="flex w-full border border-neutral-10 rounded-[25px] overflow-hidden text-[16px] text-center">
+            <div
+              className={`w-full px-4 py-1 cursor-pointer ${
+                isUpvote ? "bg-neutral-11 text-true-black font-bold" : "bg-true-black text-neutral-10"
+              }`}
+              onClick={() => handleClick(true)}
+            >
+              upvote
             </div>
             <div
-              className={`relative flex w-full md:w-80 h-16 items-center px-8 text-[16px] bg-transparent font-bold ${
-                isInvalid ? "text-negative-11" : "text-neutral-11"
-              } border-2 ${isFocused && !isInvalid ? "border-neutral-11" : isInvalid ? "border-negative-11" : "border-neutral-10"} rounded-[40px] transition-colors duration-300`}
+              className={`w-full px-4 py-1 cursor-pointer ${
+                !isUpvote ? "bg-neutral-11 text-true-black font-bold" : "bg-true-black text-neutral-10"
+              }`}
+              onClick={() => handleClick(false)}
             >
-              <input
-                ref={inputRef}
-                type="number"
-                value={amount || ""}
-                onChange={e => handleChange(e.target.value)}
-                onFocus={() => setIsFocused(true)}
-                onBlur={() => setIsFocused(false)}
-                placeholder="0.00"
-                max={amountOfVotes}
-                onKeyDown={handleKeyDownInput}
-                onInput={handleInput}
-                className="w-full text-[32px] bg-transparent outline-none placeholder-primary-5"
-              />
-              <span className="absolute right-4 text-neutral-9 text-[16px] font-bold">
-                vote{amount !== 1 ? "s" : ""}
-              </span>
-            </div>
-            <div className="flex flex-col gap-4">
-              <StepSlider val={sliderValue} onChange={handleSliderChange} onKeyDown={handleKeyDownSlider} />
-              {charge ? <TotalCharge charge={charge} amountOfVotes={amount} /> : null}
+              downvote
             </div>
           </div>
-        </div>
-        <div className="flex flex-col">
-          {isCorrectNetwork ? (
-            <ButtonV3
-              type={ButtonType.TX_ACTION}
-              isDisabled={voteDisabled}
-              colorClass="px-[20px] bg-gradient-purple rounded-[40px] w-full"
-              size={ButtonSize.FULL}
-              onClick={() => onVote?.(amount, isUpvote)}
-            >
-              <span className="w-full text-center">add votes to entry</span>
-            </ButtonV3>
-          ) : (
-            <ButtonV3
-              type={ButtonType.TX_ACTION}
-              colorClass="flex items-center justify-center bg-gradient-vote rounded-[40px] w-full"
-              size={ButtonSize.FULL}
-              onClick={onSwitchNetwork}
-            >
-              switch network
-            </ButtonV3>
-          )}
+        ) : null}
+        <div className="flex flex-col gap-6">
+          <div className="flex flex-col gap-2">
+            <MyVotes amountOfVotes={amountOfVotes} charge={charge} chainId={chainId} />
+            {charge ? <ChargeInfo charge={charge} /> : null}
+          </div>
+          <div
+            className={`relative flex w-full md:w-80 h-16 items-center px-8 text-[16px] bg-transparent font-bold ${
+              isInvalid ? "text-negative-11" : "text-neutral-11"
+            } border-2 ${isFocused && !isInvalid ? "border-neutral-11" : isInvalid ? "border-negative-11" : "border-neutral-10"} rounded-[40px] transition-colors duration-300`}
+          >
+            <input
+              ref={inputRef}
+              type="number"
+              value={amount || ""}
+              onChange={e => handleChange(e.target.value)}
+              onFocus={() => setIsFocused(true)}
+              onBlur={() => setIsFocused(false)}
+              placeholder="0.00"
+              max={amountOfVotes}
+              onKeyDown={handleKeyDownInput}
+              onInput={handleInput}
+              className="w-full text-[32px] bg-transparent outline-none placeholder-primary-5"
+            />
+            <span className="absolute right-4 text-neutral-9 text-[16px] font-bold">vote{amount !== 1 ? "s" : ""}</span>
+          </div>
+          <div className="flex flex-col gap-4">
+            <StepSlider val={sliderValue} onChange={handleSliderChange} onKeyDown={handleKeyDownSlider} />
+            {charge ? <TotalCharge charge={charge} amountOfVotes={amount} /> : null}
+          </div>
         </div>
       </div>
+      {isCorrectNetwork ? (
+        <ButtonV3
+          type={ButtonType.TX_ACTION}
+          isDisabled={voteDisabled}
+          colorClass="px-[20px] bg-gradient-purple rounded-[40px] w-full"
+          size={ButtonSize.FULL}
+          onClick={() => onVote?.(amount, isUpvote)}
+        >
+          <span className="w-full text-center">add votes to entry</span>
+        </ButtonV3>
+      ) : (
+        <ButtonV3
+          type={ButtonType.TX_ACTION}
+          colorClass="flex items-center justify-center bg-gradient-vote rounded-[40px] w-full"
+          size={ButtonSize.FULL}
+          onClick={onSwitchNetwork}
+        >
+          switch network
+        </ButtonV3>
+      )}
     </div>
   );
 };

--- a/packages/react-app-revamp/components/_pages/Contest/components/StickyCards/components/VotingQualifier/components/VotingQualifierMessage/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/components/StickyCards/components/VotingQualifier/components/VotingQualifierMessage/index.tsx
@@ -64,6 +64,7 @@ const VotingQualifierMessage: FC<VotingQualifierMessageProps> = ({
   const outOfVotes = currentUserTotalVotesAmount > 0 && !canVote;
   const zeroVotesOnAnyoneCanVote = currentUserTotalVotesAmount === 0 && anyoneCanVote;
   const chainName = chains.find(chain => chain.id === chainId)?.name;
+  const chainCurrencySymbol = chains.find(chain => chain.id === chainId)?.nativeCurrency?.symbol;
   const { data: userBalance, isLoading: isUserBalanceLoading } = useBalance({
     address: userAddress as `0x${string}`,
     chainId,
@@ -114,7 +115,11 @@ const VotingQualifierMessage: FC<VotingQualifierMessageProps> = ({
   }
 
   if (zeroVotesOnAnyoneCanVote) {
-    return <p className="text-[16px] text-negative-11 font-bold leading-loose">add eth to {chainName} to get votes </p>;
+    return (
+      <p className="text-[16px] text-negative-11 font-bold leading-loose">
+        add {chainCurrencySymbol} to {chainName} to get votes{" "}
+      </p>
+    );
   }
 
   if (outOfVotes) return <p className="text-[16px] md:text-[24px] text-neutral-9 font-bold">you're out of votes :(</p>;

--- a/packages/react-app-revamp/components/_pages/DialogModalVoteForProposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalVoteForProposal/index.tsx
@@ -89,13 +89,18 @@ export const DialogModalVoteForProposal: FC<DialogModalVoteForProposalProps> = (
               </>
             )}
           </div>
-          <VotingWidget
-            proposalId={proposal.id}
-            amountOfVotes={currentUserAvailableVotesAmount}
-            downvoteAllowed={downvotingAllowed}
-            onVote={onSubmitCastVotes}
-            isWidgetInModal
-          />
+          <div className="flex flex-col gap-4 md:gap-8 md:w-80">
+            <div className="flex flex-col gap-4">
+              <hr className="hidden md:block border border-neutral-9" />
+              <p className="text-neutral-11 font-bold text-[20px]">add votes</p>
+            </div>
+            <VotingWidget
+              proposalId={proposal.id}
+              amountOfVotes={currentUserAvailableVotesAmount}
+              downvoteAllowed={downvotingAllowed}
+              onVote={onSubmitCastVotes}
+            />
+          </div>
         </div>
       </div>
     </DialogModalV4>

--- a/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
@@ -73,7 +73,6 @@ const ProposalContent: FC<ProposalContentProps> = ({
   const { currentUserAvailableVotesAmount } = useUserStore(state => state);
   const { votesOpen } = useContestStore(state => state);
   const canVote = currentUserAvailableVotesAmount > 0;
-  const isProposalTweet = proposal.tweet.isTweet;
   const contestStatus = useContestStatusStore(state => state.contestStatus);
   const { contestState } = useContestStateStore(state => state);
   const isContestCanceled = contestState === ContestStateEnum.Canceled;

--- a/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
@@ -22,6 +22,9 @@ import { Tweet } from "react-tweet";
 import { useAccount } from "wagmi";
 import DialogModalVoteForProposal from "../DialogModalVoteForProposal";
 import ProposalContentInfo from "./components/ProposalContentInfo";
+import { VoteType } from "@hooks/useDeployContest/types";
+import { chains } from "@config/wagmi";
+import { toastInfo } from "@components/UI/Toast";
 
 export interface Proposal {
   id: string;
@@ -69,9 +72,11 @@ const ProposalContent: FC<ProposalContentProps> = ({
   const isMobile = useMediaQuery({ maxWidth: 768 });
   const asPath = usePathname();
   const { chainName, address: contestAddress } = extractPathSegments(asPath ?? "");
+  const chainCurrencySymbol = chains.find(chain => chain.name.toLowerCase() === chainName.toLowerCase())?.nativeCurrency
+    ?.symbol;
   const [isVotingModalOpen, setIsVotingModalOpen] = useState(false);
   const { currentUserAvailableVotesAmount } = useUserStore(state => state);
-  const { votesOpen } = useContestStore(state => state);
+  const { votesOpen, charge } = useContestStore(state => state);
   const canVote = currentUserAvailableVotesAmount > 0;
   const contestStatus = useContestStatusStore(state => state.contestStatus);
   const { contestState } = useContestStateStore(state => state);
@@ -100,7 +105,7 @@ const ProposalContent: FC<ProposalContentProps> = ({
     }
 
     if (contestStatus === ContestStatus.VotingClosed) {
-      alert("Voting is closed for this contest.");
+      toastInfo("Voting is closed for this contest.");
       return;
     }
 
@@ -110,7 +115,11 @@ const ProposalContent: FC<ProposalContentProps> = ({
     }
 
     if (!canVote) {
-      alert("You need to have votes to vote for a proposal.");
+      if (charge?.voteType === VoteType.PerVote) {
+        toastInfo(`add ${chainCurrencySymbol} to ${chainName} to get votes`);
+        return;
+      }
+      toastInfo("You need to be allowlisted to vote for this contest.");
       return;
     }
 


### PR DESCRIPTION
Closes #2485

I have noticed that there is a confusion between users when they do not have enough balance for anyone-can-vote contests in the entry page as currently we show them a message which tells them that they do not qualify, while this isn't a bug we need to have a clearer message.

We forgot to accommodate this language for anyone-can-vote contests, so i just added a simple message that we already have on the contest page, such as `add {chainCurrency} to {chain} to get votes` if user does not have enough balance to vote on the entry page.