### PR TITLE
enhancement: move entry collapse button to the right

### DIFF
--- a/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalContentInfo/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalContentInfo/index.tsx
@@ -21,20 +21,9 @@ const ProposalContentInfo: FC<ProposalContentInfoProps> = ({
   toggleContentVisibility,
 }) => {
   return (
-    <div className="flex items-center gap-3">
+    <div className="flex items-center justify-between">
       <div className="flex items-center gap-1">
-        <button
-          onClick={toggleContentVisibility}
-          className="p-1 rounded-full hover:bg-primary-2 transition-colors duration-300"
-        >
-          {isContentHidden ? (
-            <PlusIcon className="w-4 h-4 text-neutral-9" />
-          ) : (
-            <MinusIcon className="w-4 h-4 text-neutral-9" />
-          )}
-        </button>
         <UserProfileDisplay ethereumAddress={authorAddress} shortenOnFallback={true} />
-
         {rank > 0 && (
           <>
             <span className="text-neutral-9">&#8226;</span>{" "}
@@ -51,6 +40,16 @@ const ProposalContentInfo: FC<ProposalContentInfoProps> = ({
           </>
         )}
       </div>
+      <button
+        onClick={toggleContentVisibility}
+        className="p-1 rounded-full hover:bg-primary-2 transition-colors duration-300 md:mr-8"
+      >
+        {isContentHidden ? (
+          <PlusIcon className="w-4 h-4 text-neutral-11" />
+        ) : (
+          <MinusIcon className="w-4 h-4 text-neutral-11" />
+        )}
+      </button>
     </div>
   );
 };

--- a/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
@@ -196,16 +196,14 @@ const ProposalContent: FC<ProposalContentProps> = ({
 
   return (
     <div className="flex flex-col gap-4 pb-4 border-b border-primary-2 animate-reveal">
-      <div className="flex justify-between items-center">
-        <ProposalContentInfo
-          authorAddress={proposal.authorEthereumAddress}
-          rank={proposal.rank}
-          isTied={proposal.isTied}
-          isMobile={isMobile}
-          isContentHidden={isContentHidden}
-          toggleContentVisibility={toggleContentVisibility}
-        />
-      </div>
+      <ProposalContentInfo
+        authorAddress={proposal.authorEthereumAddress}
+        rank={proposal.rank}
+        isTied={proposal.isTied}
+        isMobile={isMobile}
+        isContentHidden={isContentHidden}
+        toggleContentVisibility={toggleContentVisibility}
+      />
       {!isContentHidden && (
         <div className="md:mx-8 flex flex-col gap-4">
           <div className="flex w-full">


### PR DESCRIPTION
It looks like position of the entry collapse button which was next to the entry author name was confusing to some users, so for better clarity and positioning we are moving it to the right side.