### PR TITLE
bugfix: set max submissions per contest const to be 10,000

### DIFF
--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestParams/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestParams/index.tsx
@@ -11,8 +11,6 @@ import ContestParamsVisibility from "./components/ContestVisibility";
 import ContestParamsDownvote from "./components/Downvote";
 import ContestParamsSubmissionsPerContest from "./components/SubmissionsPerContest";
 import ContestParamsSubmissionsPerPlayer from "./components/SubmissionsPerPlayer";
-import { ChevronUpIcon } from "@heroicons/react/24/outline";
-import ContestParamsMetadata from "./components/Metadata";
 
 export const VOTING_STEP = 6;
 

--- a/packages/react-app-revamp/hooks/useDeployContest/index.ts
+++ b/packages/react-app-revamp/hooks/useDeployContest/index.ts
@@ -21,7 +21,7 @@ import { useAccount } from "wagmi";
 import { ContestVisibility, MetadataField, useDeployContestStore } from "./store";
 import { SplitFeeDestinationType, SubmissionMerkle, VoteType, VotingMerkle } from "./types";
 
-export const MAX_SUBMISSIONS_LIMIT = 1000000;
+export const MAX_SUBMISSIONS_LIMIT = 10000;
 export const JK_LABS_SPLIT_DESTINATION_DEFAULT = "0xDc652C746A8F85e18Ce632d97c6118e8a52fa738";
 
 const EMPTY_ROOT = "0x0000000000000000000000000000000000000000000000000000000000000000";


### PR DESCRIPTION
Closes #2521

We have `MAX_SUBMISSIONS_LIMIT` and `DEFAULT_SUBMISSIONS` and we forgot to update `MAX_SUBMISSIONS_LIMIT` const to be 10,000. 

Reason we have those two is that previously we wanted to default some number to the user and max was different than that, let's still keep it this way in case we change numbers in the future if that sounds good!