### PR TITLE
bugfix: revert "fix(deps): update dependency @tanstack/react-query to…

### DIFF
--- a/packages/react-app-revamp/package.json
+++ b/packages/react-app-revamp/package.json
@@ -23,7 +23,7 @@
     "@supabase/supabase-js": "2.45.4",
     "@tailwindcss/line-clamp": "0.4.4",
     "@tailwindcss/typography": "0.5.15",
-    "@tanstack/react-query": "5.59.0",
+    "@tanstack/react-query": "5.56.2",
     "@tiptap/core": "2.4.0",
     "@tiptap/extension-image": "2.4.0",
     "@tiptap/extension-link": "2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7149,17 +7149,17 @@
     lodash.merge "^4.6.2"
     postcss-selector-parser "6.0.10"
 
-"@tanstack/query-core@5.59.0":
-  version "5.59.0"
-  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.59.0.tgz#d8323f1c6eb0e573ab0aa85a7b7690d0c263818a"
-  integrity sha512-WGD8uIhX6/deH/tkZqPNcRyAhDUqs729bWKoByYHSogcshXfFbppOdTER5+qY7mFvu8KEFJwT0nxr8RfPTVh0Q==
+"@tanstack/query-core@5.56.2":
+  version "5.56.2"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.56.2.tgz#2def2fb0290cd2836bbb08afb0c175595bb8109b"
+  integrity sha512-gor0RI3/R5rVV3gXfddh1MM+hgl0Z4G7tj6Xxpq6p2I03NGPaJ8dITY9Gz05zYYb/EJq9vPas/T4wn9EaDPd4Q==
 
-"@tanstack/react-query@5.59.0":
-  version "5.59.0"
-  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.59.0.tgz#5dcc21cfb85ecad6dcb1bf2a616d2820c0b49754"
-  integrity sha512-YDXp3OORbYR+8HNQx+lf4F73NoiCmCcSvZvgxE29OifmQFk0sBlO26NWLHpcNERo92tVk3w+JQ53/vkcRUY1hA==
+"@tanstack/react-query@5.56.2":
+  version "5.56.2"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.56.2.tgz#3a0241b9d010910905382f5e99160997b8795f91"
+  integrity sha512-SR0GzHVo6yzhN72pnRhkEFRAHMsUo5ZPzAxfTMvUxFIDVS6W9LYUp6nXW3fcHVdg0ZJl8opSH85jqahvm6DSVg==
   dependencies:
-    "@tanstack/query-core" "5.59.0"
+    "@tanstack/query-core" "5.56.2"
 
 "@tanstack/react-virtual@^3.8.1":
   version "3.8.1"


### PR DESCRIPTION
… v5.59.0"

This reverts commit c8cf0855c986d22fdb9a7862ad717e2e2b599401.

Reverting because it resulted in this same error before and after the env var update:
![image](https://github.com/user-attachments/assets/bcac7c46-a8b3-456c-b89e-ced8ee9507c1)
![image](https://github.com/user-attachments/assets/8c7214d0-fc30-40be-800a-8597574b7c17)
