### PR TITLE
chore: set up renovate scheduling

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,11 @@
     "dependencyDashboardApproval": true
   },
   "ignoreDeps": ["react-native"],
+  "schedule": [
+    "after 11pm every weekday",
+    "before 6am every weekday",
+    "every weekend"
+  ],
   "packageRules": [
     {
       "packagePatterns": ["*"],


### PR DESCRIPTION
have renovate run 11pm-6am UTC so that it doesn't interfere with development flow.