### PR TITLE
bugfix: rm contest status check in user qualifications

### DIFF
--- a/packages/react-app-revamp/hooks/useContest/index.ts
+++ b/packages/react-app-revamp/hooks/useContest/index.ts
@@ -6,7 +6,7 @@ import getContestContractVersion from "@helpers/getContestContractVersion";
 import getRewardsModuleContractVersion from "@helpers/getRewardsModuleContractVersion";
 import { MAX_MS_TIMEOUT } from "@helpers/timeout";
 import { ContestStateEnum, useContestStateStore } from "@hooks/useContestState/store";
-import { ContestStatus, useContestStatusStore } from "@hooks/useContestStatus/store";
+import { JK_LABS_SPLIT_DESTINATION_DEFAULT } from "@hooks/useDeployContest";
 import { SplitFeeDestinationType, VoteType } from "@hooks/useDeployContest/types";
 import { useError } from "@hooks/useError";
 import useProposal from "@hooks/useProposal";
@@ -23,7 +23,6 @@ import { Abi } from "viem";
 import { ErrorType, useContestStore } from "./store";
 import { getV1Contracts } from "./v1/contracts";
 import { getContracts } from "./v3v4/contracts";
-import { JK_LABS_SPLIT_DESTINATION_DEFAULT } from "@hooks/useDeployContest";
 
 interface ContractConfigResult {
   contractConfig: {
@@ -81,7 +80,6 @@ export function useContest() {
   const { setContestMaxNumberSubmissionsPerUser } = useUserStore(state => state);
   const { checkIfCurrentUserQualifyToVote, checkIfCurrentUserQualifyToSubmit } = useUser();
   const { fetchProposalsIdsList } = useProposal();
-  const { contestStatus } = useContestStatusStore(state => state);
   const { setContestState } = useContestStateStore(state => state);
   const { error: errorMessage, handleError } = useError();
   const alchemyRpc = chains
@@ -375,8 +373,6 @@ export function useContest() {
    * Fetch merkle tree data from DB and re-create the tree
    */
   async function processUserQualifications(contractConfig: ContractConfig, version: string) {
-    if (contestStatus === ContestStatus.VotingClosed) return;
-
     await Promise.all([
       checkIfCurrentUserQualifyToSubmit(contractConfig, version),
       checkIfCurrentUserQualifyToVote(contractConfig, version),


### PR DESCRIPTION
I have noticed some weird behaviour in our app when you switch between contest that has ended and submission / voting was allowlisted and contest in which you are allowed to play.

One example is, i was looking at climate contest ( submission was allowlisted there and i wasn't allowlisted ) and i switched to landing page and opened applympics contest. It said that i wasn't allowlisted to enter while it is anyone-can-enter contest.

After some digging, i found out that `contestStatus` isn't refreshed in the `hooks\useContest\index.ts` as it is being called after that, and in there we had a check that if `contestStatus = voting closed`, do not process user qualifications. While this check could be useful to not call those qualifications if contest has ended, by simply removing it now it won't affect the contest page anyways, and we can jump later to refactor that piece of code. 