### PR TITLE
bugfix: add contract simulation and enhance insufficient funds error detection

### DIFF
--- a/packages/react-app-revamp/utils/error.ts
+++ b/packages/react-app-revamp/utils/error.ts
@@ -46,6 +46,11 @@ export function didUserReject(error: any): boolean {
 export function handleError(error: any): { message: string; codeFound: boolean } {
   const code = error.code as ErrorCodes;
 
+  // check for the specific insufficient funds error from simulation
+  if (error.message && error.message.includes("insufficient funds for gas * price + value")) {
+    return { message: errorMessages[ErrorCodes.INSUFFICIENT_FUNDS]!, codeFound: true };
+  }
+
   const isInsufficientFundsError =
     error instanceof EstimateGasExecutionError || (error.code === -32603 && error.data?.code === -32000);
 


### PR DESCRIPTION
Closes #2618

In this PR, we added following: 
- Implement `simulateContract` to validate transactions before execution ( for castVote ) 
- Update error handling utility to catch specific insufficient funds errors from simulation (added a new check for error messages containing "insufficient funds for gas * price + value", as these simulation errors often lack standard error codes and require message compare)