### PR TITLE
chore: enhance didUserReject function to catch more user rejection scenarios

### DIFF
--- a/packages/react-app-revamp/utils/error.ts
+++ b/packages/react-app-revamp/utils/error.ts
@@ -40,7 +40,14 @@ function handleContractFunctionExecutionError(error: any): { message: string; co
 
 export function didUserReject(error: any): boolean {
   const errorCode = error?.code ?? error?.cause?.code;
-  return errorCode === 4001 || errorCode === "ACTION_REJECTED";
+  const errorMessage = error?.message ?? error?.cause?.message ?? "";
+
+  return (
+    errorCode === 4001 ||
+    errorCode === "ACTION_REJECTED" ||
+    errorMessage.toLowerCase().includes("user rejected") ||
+    errorMessage.toLowerCase().includes("user denied")
+  );
 }
 
 export function handleError(error: any): { message: string; codeFound: boolean } {


### PR DESCRIPTION
I have noticed that if you reject a transaction, error is thrown via toast, while it doesn't effect anything, we shouldn't treat this as an error. 

This is also due to lack of standard error codes so we should add checks for "user rejected" and "user denied" phrases in `didUserReject` fn