### PR TITLE
bugfix: fix alchemy url for nft holders

### DIFF
--- a/packages/react-app-revamp/lib/permissioning/index.ts
+++ b/packages/react-app-revamp/lib/permissioning/index.ts
@@ -22,6 +22,19 @@ interface TokenHolder {
 const NFTS_HARD_LIMIT = 400000;
 const ERC20_HARD_LIMIT = 1000000;
 
+const chainToAlchemySubdomain = {
+  mainnet: "eth-mainnet",
+  polygon: "polygon-mainnet",
+  arbitrumone: "arb-mainnet",
+  optimism: "opt-mainnet",
+  base: "base-mainnet",
+};
+
+const getAlchemyBaseUrl = (chain: string) => {
+  const subdomain = chainToAlchemySubdomain[chain as keyof typeof chainToAlchemySubdomain] || "eth-mainnet";
+  return `https://${subdomain}.g.alchemy.com/v2/${alchemyApiKey}`;
+};
+
 export async function fetchNftHolders(
   type: "voting" | "submission",
   contractAddress: string,
@@ -31,12 +44,7 @@ export async function fetchNftHolders(
   votesPerUnit: number = 100,
   voteCalculationMethod: string = "token",
 ): Promise<Record<string, number> | Error> {
-  let baseAlchemyAppUrl = chains.filter((chain: { name: string }) => chain.name == chainName.toLowerCase())[0].rpcUrls
-    .default.http[0];
-
-  baseAlchemyAppUrl = baseAlchemyAppUrl.replace(/(v2\/).*/, "$1");
-
-  const alchemyAppUrl = `${baseAlchemyAppUrl}${alchemyApiKey}/getOwnersForCollection`;
+  const alchemyAppUrl = `${getAlchemyBaseUrl(chainName.toLowerCase())}/getOwnersForCollection`;
 
   let allOwnersData: any[] = [];
   let nextPageKey: string | undefined;


### PR DESCRIPTION
Closes #2755 
Closes #2746
Closes #2743

We were using a quicknode url instead of alchemy for fetching NFT holders data, so in this PR, we are correctly assigning a alchemy url per chain.