### PR TITLE
bugfix: move sort enabled check out of monetization check

### DIFF
--- a/packages/react-app-revamp/hooks/useContest/index.ts
+++ b/packages/react-app-revamp/hooks/useContest/index.ts
@@ -144,6 +144,11 @@ export function useContest() {
     if (compareVersions(version, "4.0") >= 0) {
       const costToPropose = Number(results[11].result);
 
+      if (compareVersions(version, "4.2") >= 0) {
+        const sortingEnabled = Number(results[12].result) === 1;
+        setSortingEnabled(sortingEnabled);
+      }
+
       if (costToPropose === 0) {
         setCharge(null);
       } else {
@@ -151,11 +156,6 @@ export function useContest() {
         let costToVote = 0;
         let payPerVote = 0;
         let creatorSplitDestination = "";
-
-        if (compareVersions(version, "4.2") >= 0) {
-          const sortingEnabled = Number(results[12].result) === 1;
-          setSortingEnabled(sortingEnabled);
-        }
 
         if (compareVersions(version, "4.23") >= 0) {
           if (compareVersions(version, "4.25") >= 0) {


### PR DESCRIPTION
Closes #2679

During the small refactor, we moved `sortEnabled` check in the monetization check, therefore for all chains that do not have monetization set, `sortEnabled` would be false and therefore message like above in the issue would appear. 