### PR TITLE
bugfix: catch correctly deleted entries

### DIFF
--- a/packages/react-app-revamp/components/_pages/Contest/components/Prompt/Proposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/components/Prompt/Proposal/index.tsx
@@ -13,6 +13,7 @@ import { useContestStore } from "@hooks/useContest/store";
 import { ContestStatus } from "@hooks/useContestStatus/store";
 import { Interweave } from "interweave";
 import { UrlMatcher } from "interweave-autolink";
+import { ProposalState } from "lib/proposal";
 import moment from "moment";
 import { usePathname } from "next/navigation";
 import { FC, ReactNode } from "react";
@@ -74,12 +75,17 @@ const ContestProposal: FC<ContestProposalProps> = ({ proposal, proposalId, conte
 
   return (
     <div className="flex flex-col gap-4">
-      <Interweave
-        className="prose prose-invert overflow-hidden interweave-container"
-        content={proposal.content}
-        matchers={[new UrlMatcher("url")]}
-        transform={transform}
-      />
+      {proposal.content === ProposalState.Deleted ? (
+        <p className="text-[16px] text-neutral-11">{ProposalState.Deleted}</p>
+      ) : (
+        <Interweave
+          className="prose prose-invert overflow-hidden interweave-container"
+          content={proposal.content}
+          matchers={[new UrlMatcher("url")]}
+          transform={transform}
+        />
+      )}
+
       {displaySocials && proposalId ? (
         <div className="hidden md:flex gap-2">
           <a

--- a/packages/react-app-revamp/lib/proposal/index.ts
+++ b/packages/react-app-revamp/lib/proposal/index.ts
@@ -18,6 +18,10 @@ export interface ProposalData {
   votedAddresses: string[] | null;
 }
 
+export enum ProposalState {
+  Deleted = "This entry has been deleted by the creator.",
+}
+
 export const COMMENTS_VERSION = "4.13";
 
 const extractVotes = (forVotesValue: bigint, againstVotesValue: bigint) => {
@@ -78,7 +82,7 @@ const fetchProposalInfo = async (abi: any, address: string, chainId: number, sub
   const againstVotesBigInt = results[1].result[1] as bigint;
   const votes = extractVotes(forVotesBigInt, againstVotesBigInt);
   const isDeleted = results[2].result;
-  const content = isDeleted ? "This proposal has been deleted by the creator" : data.description;
+  const content = isDeleted ? ProposalState.Deleted : data.description;
   const { fieldsMetadata } = data;
   const metadataFields: RawMetadataFields = {
     addressArray: fieldsMetadata.addressArray,


### PR DESCRIPTION
Closes #2808

We had previously a check if the entry is deleted, however, it looks like this one is a tweet, therefore it didn't catch it based on content.