### PR TITLE
bugfix: add overflow hidden to entry container in leaderboards

### DIFF
--- a/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalLayout/Leaderboard/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalLayout/Leaderboard/index.tsx
@@ -11,6 +11,7 @@ import ProposalContentProfile from "../../Profile";
 import ProposalLayoutLeaderboardMobile from "./components/Mobile";
 import ProposalLayoutLeaderboardRankOrPlaceholder from "./components/RankOrPlaceholder";
 import { toastInfo } from "@components/UI/Toast";
+import { UrlMatcher } from "interweave-autolink";
 
 interface ProposalLayoutLeaderboardProps {
   proposal: Proposal;
@@ -140,6 +141,7 @@ const ProposalLayoutLeaderboard: FC<ProposalLayoutLeaderboardProps> = ({
                     content={proposal.content}
                     transform={transform}
                     tagName="div"
+                    matchers={[new UrlMatcher("url")]}
                   />
                 </div>
                 <div className="flex gap-2 items-center">

--- a/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalLayout/Leaderboard/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalLayout/Leaderboard/index.tsx
@@ -136,7 +136,7 @@ const ProposalLayoutLeaderboard: FC<ProposalLayoutLeaderboardProps> = ({
               <>
                 <div className="animate-reveal">
                   <Interweave
-                    className="prose prose-invert inline-block w-full  [&_*]:text-neutral-9 max-w-[560px]"
+                    className="prose prose-invert inline-block w-full overflow-hidden [&_*]:text-neutral-9 max-w-[560px]"
                     content={proposal.content}
                     transform={transform}
                     tagName="div"


### PR DESCRIPTION
Interweave, our library for rendering markdown does not break link into the next row, so we have to use `overflow-hidden` in order to prevent link from going outside of the container.

![image](https://github.com/user-attachments/assets/8ffe6472-82e5-418c-b589-c54fae372123)
