### PR TITLE
bugfix: unable to toggle contest visibility in profile

### DIFF
--- a/packages/react-app-revamp/components/_pages/ListContests/Contest/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListContests/Contest/index.tsx
@@ -281,6 +281,7 @@ const Contest: FC<ContestProps> = ({ contest, loading, rewards, allowToHide, rew
 
   const handleToggleContestView = async (e: React.MouseEvent<HTMLImageElement, MouseEvent>) => {
     e.preventDefault();
+    e.nativeEvent.stopImmediatePropagation();
 
     const newState = !isHidden;
     setIsHidden(newState);


### PR DESCRIPTION
Closes #2848 

I tested it by switching between hidden and false, so the issue wasn't with the functioning; rather, it was with appearance.

The progress bar is only in charge of page switching within our application; it is not in charge of action states. In cases where there are nested clicks within link components, like this one, where the link has a toggle feature for the contest itself, we have to stop propagation to prevent the progress bar from showing. In this case, the user thought that the progress bar itself was a toggle indicator, which was an issue on our side for displaying it.