### PR TITLE
feat: add timestamp in subscribe fn

### DIFF
--- a/packages/react-app-revamp/hooks/useEmailSignup/index.tsx
+++ b/packages/react-app-revamp/hooks/useEmailSignup/index.tsx
@@ -1,6 +1,7 @@
 import { toastError, toastLoading, toastSuccess } from "@components/UI/Toast";
 import { supabase } from "@config/supabase";
 import { isSupabaseConfigured } from "@helpers/database";
+import moment from "moment";
 import { useState } from "react";
 
 const useEmailSignup = () => {
@@ -15,7 +16,13 @@ const useEmailSignup = () => {
       setLoading(true);
       showToasts && toastLoading("Subscribing...");
       try {
-        const { error } = await supabase.from("email_signups").insert([{ email_address, user_address }]);
+        const { error } = await supabase.from("email_signups").insert([
+          {
+            email_address,
+            user_address,
+            date: moment().format("YYYY-MM-DD HH:mm:ss"),
+          },
+        ]);
         setLoading(false);
         if (error) {
           showToasts && toastError("There was an error while subscribing. Please try again later.", error.message);

--- a/packages/react-app-revamp/supabase_schemas/email_signups.sql
+++ b/packages/react-app-revamp/supabase_schemas/email_signups.sql
@@ -3,6 +3,7 @@ create table
     id uuid not null default gen_random_uuid (),
     email_address character varying not null,
     user_address character varying null,
+    date timestamp with time zone null,
     constraint email_signups_pkey primary key (id),
     constraint email_signups_email_address_key unique (email_address)
   ) tablespace pg_default;


### PR DESCRIPTION
Closes #2946 

We are storing it as a `timestampz` type in the supabase, which means that we include timezone in it. 

TODO:

- [x] add `date` column with `timestampz` type in `email_signups` table in supabase prod