### PR TITLE
bugfix: fix metadata for contest link

### DIFF
--- a/packages/react-app-revamp/app/contest/[chain]/[address]/page.tsx
+++ b/packages/react-app-revamp/app/contest/[chain]/[address]/page.tsx
@@ -1,3 +1,4 @@
+import { parsePrompt } from "@components/_pages/Contest/components/Prompt/utils";
 import { chains, serverConfig } from "@config/wagmi/server";
 import getContestContractVersion from "@helpers/getContestContractVersion";
 import { readContracts } from "@wagmi/core";
@@ -65,10 +66,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   try {
     const contestDetails = await getContestDetails(address, chain);
-    const prompt = contestDetails[1].result as string;
-    const contestDescriptionRaw = prompt.split("|")[2] || "";
-
     const contestTitle = contestDetails[0].result as string;
+    const prompt = contestDetails[1].result as string;
+    const contestPrompt = parsePrompt(prompt);
+
+    const contestDescriptionRaw =
+      contestPrompt.contestSummary + contestPrompt.contestEvaluate + contestPrompt.contestContactDetails;
+
     const contestDescription = parse(contestDescriptionRaw).textContent;
 
     return {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/30a594db-bd09-450b-a21b-64475ea0463a)

After our recent addition to the contest prompt ( image URL ) i have noticed that the metadata for contest link is broken, title of the contest is there but description is missing ( this is only for the contests that were created after image URL addition ) 

This is because we changed the way we create this string during the deployment after we added image URL, i was thinking of how can we make these additions to the prompt easier for us in the codebase and now we use `URLSearchParams` now as it is easier to add / remove on top of the prompt string and later to extract from it. 

This PR should fix the issue with the metadata when sharing a link, i'll watch closely once this is shipped!  

