### PR TITLE
chore: update forge params due to their update

### DIFF
--- a/.github/workflows/forge_tests.yml
+++ b/.github/workflows/forge_tests.yml
@@ -23,8 +23,6 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
 
       - name: Run Forge build
         run: |

--- a/packages/forge/foundry.toml
+++ b/packages/forge/foundry.toml
@@ -3,5 +3,6 @@ src = "src"
 out = "out"
 libs = ["lib"]
 solc-version = "0.8.19"  # most rollups don't support past this - https://twitter.com/pashovkrum/status/1690298101448208384?s=46
+optimizer = true
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/packages/forge/foundry.toml
+++ b/packages/forge/foundry.toml
@@ -6,4 +6,4 @@ solc-version = "0.8.19"  # most rollups don't support past this - https://twitte
 optimizer = true
 optimizer_runs = 200
 
-# See more config options https://github.com/foundry-rs/foundry/tree/master/config
+# See more config options at https://book.getfoundry.sh/config/?highlight=foundry.toml#configuring-with-foundrytoml

--- a/packages/forge/foundry.toml
+++ b/packages/forge/foundry.toml
@@ -4,5 +4,6 @@ out = "out"
 libs = ["lib"]
 solc-version = "0.8.19"  # most rollups don't support past this - https://twitter.com/pashovkrum/status/1690298101448208384?s=46
 optimizer = true
+optimizer_runs = 200
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config


### PR DESCRIPTION
the issue is that nightly now contains breaking changes and [this run](https://github.com/jk-labs-inc/jokerace/actions/runs/12712471199/job/35449556840) was the first one that ran a new nightly which has the optimizer off by default, making the `forge build --sizes` test fail. ([this](https://github.com/jk-labs-inc/jokerace/actions/runs/12704521645/job/35414029550) is the link to the successful run mentioned in the below screenshots for reference)

steps taken in this PR:
- remove the nightly parameter in the installation of foundry to default to the stable build of foundry so that we don't randomly get breaking changes to this workflow
- explicitly set `optimizer` to `true` and `optimizer_runs` to 200 (documentation [here](https://book.getfoundry.sh/reference/config/solidity-compiler#optimizer)) in `foundry.toml` so that we aren't relying on foundry defaults for such an important configuration parameters
- update doc link

<img width="686" alt="Screenshot 2025-01-10 at 3 19 17 PM" src="https://github.com/user-attachments/assets/2e6cd337-f956-4e75-a0ab-a62dcc0367a8" />
<img width="691" alt="Screenshot 2025-01-10 at 3 19 34 PM" src="https://github.com/user-attachments/assets/bceab0de-a1b7-47ea-ab1a-081c71614a75" />
