### PR TITLE
chore: add s3 response checksum validation

### DIFF
--- a/packages/react-app-revamp/config/s3/index.ts
+++ b/packages/react-app-revamp/config/s3/index.ts
@@ -7,5 +7,6 @@ export const s3 = new S3Client({
     accessKeyId: process.env.NEXT_PUBLIC_R2_ACCESS_KEY_ID as string,
     secretAccessKey: process.env.NEXT_PUBLIC_R2_SECRET_ACCESS_KEY as string,
   },
-  requestChecksumCalculation: 'WHEN_REQUIRED',
+  requestChecksumCalculation: "WHEN_REQUIRED",
+  responseChecksumValidation: "WHEN_REQUIRED",
 });


### PR DESCRIPTION
Based on the latest comment from cloudfare forum https://community.cloudflare.com/t/aws-sdk-client-s3-v3-729-0-breaks-uploadpart-and-putobject-r2-s3-api-compatibility/758637/13, looks like `responseChecksumValidation` config param is also needed in the s3 config. 