### PR TITLE
bugfix: prevent duplicate analytics entries by sequential executions

### DIFF
--- a/packages/react-app-revamp/hooks/useCastVotes/index.ts
+++ b/packages/react-app-revamp/hooks/useCastVotes/index.ts
@@ -248,7 +248,12 @@ export function useCastVotes() {
   }
 
   async function performAnalytics(params: CombinedAnalyticsParams) {
-    await Promise.all([addUserActionAnalytics(params), updateRewardAnalyticsIfNeeded(params)]);
+    try {
+      await addUserActionAnalytics(params);
+      await updateRewardAnalyticsIfNeeded(params);
+    } catch (error) {
+      console.error("Error in performAnalytics:", error);
+    }
   }
 
   return {

--- a/packages/react-app-revamp/hooks/useSubmitProposal/index.ts
+++ b/packages/react-app-revamp/hooks/useSubmitProposal/index.ts
@@ -237,8 +237,12 @@ export function useSubmitProposal() {
   }
 
   async function performAnalytics(params: CombinedAnalyticsParams) {
-    await addUserActionAnalytics(params);
-    await updateRewardAnalyticsIfNeeded(params);
+    try {
+      await addUserActionAnalytics(params);
+      await updateRewardAnalyticsIfNeeded(params);
+    } catch (error) {
+      console.error("Error in performAnalytics:", error);
+    }
   }
 
   return {

--- a/packages/react-app-revamp/hooks/useSubmitProposal/index.ts
+++ b/packages/react-app-revamp/hooks/useSubmitProposal/index.ts
@@ -237,7 +237,8 @@ export function useSubmitProposal() {
   }
 
   async function performAnalytics(params: CombinedAnalyticsParams) {
-    await Promise.all([addUserActionAnalytics(params), updateRewardAnalyticsIfNeeded(params)]);
+    await addUserActionAnalytics(params);
+    await updateRewardAnalyticsIfNeeded(params);
   }
 
   return {


### PR DESCRIPTION
Closes #3166

After i did some research, it could be that `Promise.all` could introduce duplicate behaviour here, so we replaced `Promise.all` with sequential await calls in order to try and prevent it. 

Let's make sure that analytics operations complete one at a time to avoid possible race conditions and duplicate entries.