### PR TITLE
chore: lower concurrent calls

### DIFF
--- a/packages/react-app-revamp/hooks/useComments/index.ts
+++ b/packages/react-app-revamp/hooks/useComments/index.ts
@@ -9,7 +9,7 @@ import { Abi } from "viem";
 import { useAccount } from "wagmi";
 import { Comment, CommentCore, useCommentsStore } from "./store";
 
-export const COMMENTS_PER_PAGE = 5;
+export const COMMENTS_PER_PAGE = 4;
 
 /**
  * @param address - contest address

--- a/packages/react-app-revamp/hooks/useProposal/index.ts
+++ b/packages/react-app-revamp/hooks/useProposal/index.ts
@@ -17,7 +17,7 @@ import {
   updateAndRankProposals,
 } from "./utils";
 
-export const PROPOSALS_PER_PAGE = 12;
+export const PROPOSALS_PER_PAGE = 4;
 
 export function useProposal() {
   const {

--- a/packages/react-app-revamp/hooks/useProposalVotes/index.ts
+++ b/packages/react-app-revamp/hooks/useProposalVotes/index.ts
@@ -5,7 +5,7 @@ import { readContract } from "@wagmi/core";
 import { utils } from "ethers";
 import { useEffect, useState } from "react";
 
-export const VOTES_PER_PAGE = 5;
+export const VOTES_PER_PAGE = 4;
 
 interface VoteEntry {
   address: string;

--- a/packages/react-app-revamp/hooks/useProposalVotes/index.ts
+++ b/packages/react-app-revamp/hooks/useProposalVotes/index.ts
@@ -14,7 +14,12 @@ interface VoteEntry {
 
 type VotesArray = VoteEntry[];
 
-export function useProposalVotes(contractAddress: string, proposalId: string, chainId: number, addressPerPage = 5) {
+export function useProposalVotes(
+  contractAddress: string,
+  proposalId: string,
+  chainId: number,
+  addressPerPage = VOTES_PER_PAGE,
+) {
   const { contestAbi: abi } = useContestStore(state => state);
   const [currentPage, setCurrentPage] = useState(0);
   const [totalPages, setTotalPages] = useState(0);


### PR DESCRIPTION
just lowering the number of concurrent calls we do per page for entries, comments, and voters to help minimize concurrent call surges and consequently/ideally the times we get rate-limited/run up against our Requests Per Second limit.