### PR TITLE
feat: add multigets

### DIFF
--- a/packages/forge/src/governance/Governor.sol
+++ b/packages/forge/src/governance/Governor.sol
@@ -291,6 +291,18 @@ abstract contract Governor is GovernorSorting, GovernorMerkleVotes {
     }
 
     /**
+     * @dev Retrieve the data of an array of proposalIds.
+     */
+    function getProposals(uint256[] memory inputProposalIds) public view returns (ProposalCore[] memory) {
+        ProposalCore[] memory proposalCoresArray = new ProposalCore[](inputProposalIds.length);
+        for (uint256 i = 0; i < inputProposalIds.length; i++) {
+            proposalCoresArray[i] = proposals[inputProposalIds[i]];
+        }
+
+        return proposalCoresArray;
+    }
+
+    /**
      * @dev Set the contest name.
      */
     function setName(string memory newName) public returns (string memory) {

--- a/packages/forge/src/governance/extensions/GovernorCountingSimple.sol
+++ b/packages/forge/src/governance/extensions/GovernorCountingSimple.sol
@@ -66,6 +66,19 @@ abstract contract GovernorCountingSimple is Governor {
     }
 
     /**
+     * @dev Retrieve the array of VoteCounts objects for an array of userAddresses for a given proposal.
+     */
+    function getProposalAddressesVotes(uint256 proposalId, address[] memory userAddresses) public view returns (VoteCounts[] memory) {
+        VoteCounts[] memory voteCountsArray = new VoteCounts[](userAddresses.length);
+        for (uint256 i = 0; i < userAddresses.length; i++) {
+            voteCountsArray[i] = proposalVotesStructs[proposalId].addressVoteCounts[userAddresses[i]];
+        }
+
+        return voteCountsArray;
+    }
+
+
+    /**
      * @dev Accessor to which addresses have cast a vote for a given proposal.
      */
     function proposalAddressesHaveVoted(uint256 proposalId) public view returns (address[] memory) {
@@ -81,7 +94,7 @@ abstract contract GovernorCountingSimple is Governor {
     }
 
     /**
-     * @dev Accessor to the internal vote counts for a given proposal.
+     * @dev Get the array of proposalIds and the array of their respective VoteCounts objects.
      */
     function allProposalTotalVotes()
         public

--- a/packages/forge/src/governance/extensions/GovernorEngagement.sol
+++ b/packages/forge/src/governance/extensions/GovernorEngagement.sol
@@ -62,6 +62,19 @@ abstract contract GovernorEngagement is Governor {
     }
 
     /**
+     * @dev Retrieve the data of an array of commentIds.
+     */
+    function getComments(uint256[] memory inputCommentIds) public view returns (CommentCore[] memory) {
+        CommentCore[] memory commentCoresArray = new CommentCore[](inputCommentIds.length);
+        for (uint256 i = 0; i < inputCommentIds.length; i++) {
+            commentCoresArray[i] = comments[inputCommentIds[i]];
+        }
+
+        return commentCoresArray;
+    }
+
+
+    /**
      * @dev Return the array of commentIds on a given proposalId.
      */
     function getProposalComments(uint256 proposalId) public view returns (uint256[] memory) {


### PR DESCRIPTION
making this PR for posterity/to save this solution in case the contract size tradeoff ever makes sense since I don't think it does right now (this would bring us significantly closer to the limit for the benefit of that only 1 RPC call would be needed to get entries, comments, and votes - so would be useful to help bring down concurrent RPC calls primarily, but also helps w total RPC calls generally too just relatively not as much)