### PR TITLE
bugfix: enrich tweet not found component

### DIFF
--- a/packages/react-app-revamp/components/_pages/Contest/components/Prompt/Proposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/components/Prompt/Proposal/index.tsx
@@ -1,4 +1,5 @@
 import { Proposal } from "@components/_pages/ProposalContent";
+import { Tweet } from "@components/_pages/ProposalContent/components/ProposalLayout/Tweet/components/CustomTweet";
 import { extractPathSegments } from "@helpers/extractPath";
 import { twitterRegex } from "@helpers/regex";
 import {
@@ -16,7 +17,6 @@ import { UrlMatcher } from "interweave-autolink";
 import { ProposalState } from "lib/proposal";
 import { usePathname } from "next/navigation";
 import { FC, ReactNode } from "react";
-import { Tweet } from "react-tweet";
 
 interface ContestProposalProps {
   proposal: Proposal;

--- a/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalLayout/Tweet/components/CustomTweet/custom-not-found.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalLayout/Tweet/components/CustomTweet/custom-not-found.tsx
@@ -24,7 +24,9 @@ const CustomTweetNotFound: FC<CustomTweetNotFoundProps> = ({ error, onError, id 
       <div className="flex flex-col items-center justify-center p-4 gap-4 min-w-full text-neutral-9">
         <div className="flex flex-col text-center items-center justify-center gap-2">
           <p className="text-[16px] font-bold text-neutral-9">sorry, we couldn't load this tweet</p>
-          <p className="text-[14px] text-neutral-9">the tweet may have been deleted or is temporarily unavailable</p>
+          <p className="text-[14px] text-neutral-9">
+            the tweet may have been deleted or flagged as containing sensitive content
+          </p>
         </div>
 
         {tweetUrl && (

--- a/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalLayout/Tweet/components/CustomTweet/custom-not-found.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalLayout/Tweet/components/CustomTweet/custom-not-found.tsx
@@ -21,9 +21,9 @@ const CustomTweetNotFound: FC<CustomTweetNotFoundProps> = ({ error, onError, id 
 
   return (
     <TweetContainer className="w-full md:!w-[360px] !min-w-full !text-neutral-9 !bg-true-black !m-0 !border-primary-1">
-      <div className="flex flex-col items-center justify-center p-4 gap-4 min-w-full text-neutral-9">
-        <div className="flex flex-col text-center items-center justify-center gap-2">
-          <p className="text-[16px] font-bold text-neutral-9">sorry, we couldn't load this tweet</p>
+      <div className="flex flex-col p-4 gap-4 min-w-full text-neutral-9">
+        <div className="flex flex-col gap-2">
+          <p className="text-[16px] text-neutral-9">sorry, we couldn't load this tweet</p>
           <p className="text-[14px] text-neutral-9">
             the tweet may have been deleted or flagged as containing sensitive content
           </p>
@@ -35,12 +35,9 @@ const CustomTweetNotFound: FC<CustomTweetNotFoundProps> = ({ error, onError, id 
             onClick={navigateToTweet}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-2 text-[20px] text-positive-11 opacity-80 hover:opacity-100 transition-colors"
+            className="font-bold text-[16px] text-positive-11 opacity-80 hover:opacity-100 transition-colors"
           >
-            <span className="flex items-center gap-2 border-b border-current">
-              view on x.com
-              <LinkIcon className="h-4 w-4 text-positive-11" />
-            </span>
+            view on x.com {">"}
           </a>
         )}
       </div>

--- a/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalLayout/Tweet/components/CustomTweet/custom-not-found.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalLayout/Tweet/components/CustomTweet/custom-not-found.tsx
@@ -1,16 +1,48 @@
+import { LinkIcon } from "@heroicons/react/24/outline";
 import { FC } from "react";
-import { TweetContainer, TweetNotFound } from "react-tweet";
+import { TweetContainer } from "react-tweet";
 
 interface CustomTweetNotFoundProps {
+  id?: string;
   error?: any;
   onError?: (error: any) => any;
 }
 
-const CustomTweetNotFound: FC<CustomTweetNotFoundProps> = ({ error, onError }) => {
+const CustomTweetNotFound: FC<CustomTweetNotFoundProps> = ({ error, onError, id }) => {
+  const tweetUrl = id ? `https://x.com/i/status/${id}` : null;
+
+  const navigateToTweet = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    e.nativeEvent.stopImmediatePropagation();
+    if (tweetUrl) {
+      window.open(tweetUrl, "_blank");
+    }
+  };
+
   return (
-    <div className="min-w-full text-neutral-9 text-[16px] bg-true-black m-0 border-primary-1">
-      <p>the embedded tweet was not found...</p>
-    </div>
+    <TweetContainer className="w-full md:!w-[360px] !min-w-full !text-neutral-9 !bg-true-black !m-0 !border-primary-1">
+      <div className="flex flex-col items-center justify-center p-4 gap-4 min-w-full text-neutral-9">
+        <div className="flex flex-col text-center items-center justify-center gap-2">
+          <p className="text-[16px] font-bold text-neutral-9">sorry, we couldn't load this tweet</p>
+          <p className="text-[14px] text-neutral-9">the tweet may have been deleted or is temporarily unavailable</p>
+        </div>
+
+        {tweetUrl && (
+          <a
+            href={tweetUrl}
+            onClick={navigateToTweet}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-2 text-[20px] text-positive-11 opacity-80 hover:opacity-100 transition-colors"
+          >
+            <span className="flex items-center gap-2 border-b border-current">
+              view on x.com
+              <LinkIcon className="h-4 w-4 text-positive-11" />
+            </span>
+          </a>
+        )}
+      </div>
+    </TweetContainer>
   );
 };
 

--- a/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalLayout/Tweet/components/CustomTweet/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalLayout/Tweet/components/CustomTweet/index.tsx
@@ -9,7 +9,7 @@ export const Tweet = ({ id, apiUrl, fallback = <TweetSkeleton />, components, on
 
   if (isLoading) return <div id="tweet-skeleton">{fallback}</div>;
   if (error || !data) {
-    return <CustomTweetNotFound error={onError ? onError(error) : error} />;
+    return <CustomTweetNotFound id={id} error={onError ? onError(error) : error} />;
   }
 
   return <MyTweet tweet={data} components={components} />;


### PR DESCRIPTION
Closes #3311 

We got a response from[ this ticket ](https://github.com/vercel/react-tweet/issues/188) and it looks like this specific tweet is flagged as NSFW, therefore users who aren't logged in, can't see the tweet. 

You can try opening a [tweet ](https://x.com/mmyselfvvanilla/status/1887932387738157104)in incognito mode and it won't be able to render, i found an error as well in the network tab 
![image](https://github.com/user-attachments/assets/52b21d2b-ecd8-4655-b9b4-a75904f1c1ee)

I propose that in cases like this, we enrich our component and instead of saying "embedded tweet not found.." we give more info and also a CTA for user to open a tweet in a new window. Since API returns just 404 we do not know if either tweet is deleted or flagged as NSFW, therefore we have to give some generic message. 

![image](https://github.com/user-attachments/assets/fcfe9fad-a438-4656-804b-ac284ef680cf)

Let me know what you think of this approach @divine-economy 
