### PR TITLE
bugfix: fix scroll threshold for entries

### DIFF
--- a/packages/react-app-revamp/components/_pages/ListProposals/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListProposals/index.tsx
@@ -16,9 +16,11 @@ import { useAccount } from "wagmi";
 import { verifyEntryPreviewPrompt } from "../DialogModalSendProposal/utils";
 import ListProposalsContainer from "./container";
 import ListProposalsSkeleton from "./skeleton";
+import { useMediaQuery } from "react-responsive";
 
 export const ListProposals = () => {
   const { address, chainId: userChainId } = useAccount();
+  const isMobile = useMediaQuery({ query: "(max-width: 768px)" });
   const asPath = usePathname();
   const { address: contestAddress, chainName: contestChainName } = extractPathSegments(asPath);
   const contestChainId = chains.filter(
@@ -118,6 +120,7 @@ export const ListProposals = () => {
           count={skeletonRemainingLoaderCount}
         />
       }
+      scrollThreshold={isMobile ? 0.4 : 0.5}
     >
       <ListProposalsContainer enabledPreview={enabledPreview}>
         {listProposalsData.map((proposal, index) => {

--- a/packages/react-app-revamp/components/_pages/ListProposals/skeleton.tsx
+++ b/packages/react-app-revamp/components/_pages/ListProposals/skeleton.tsx
@@ -27,10 +27,21 @@ const ListProposalsSkeleton: FC<ListProposalsSkeletonProps> = ({ enabledPreview,
         </ProposalSkeleton>
       );
     case EntryPreview.IMAGE:
+    case EntryPreview.IMAGE_AND_TITLE:
     case EntryPreview.TWEET:
       return (
         <ProposalSkeleton highlightColor={highlightColor}>
-          <Skeleton borderRadius={16} count={count} className="flex flex-col w-full h-52 animate-appear rounded-2xl" />
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {Array(count || 1)
+              .fill(0)
+              .map((_, index) => (
+                <Skeleton
+                  key={index}
+                  borderRadius={16}
+                  className="flex flex-col w-full h-52 animate-appear rounded-2xl"
+                />
+              ))}
+          </div>
         </ProposalSkeleton>
       );
     default:


### PR DESCRIPTION
Closes #3465 

This is just a quick fix for the bug above. We should get rid of the `react-infinite-scroll-component` package as it is not maintained anymore and has lot of bugs, explained more in the dev channel.