### PR TITLE
bugfix: fix vote charge settings

### DIFF
--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestMonetization/components/Charge/components/Vote/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestMonetization/components/Charge/components/Vote/index.tsx
@@ -29,8 +29,10 @@ const ContestParamsChargeVote: FC<ContestParamsChargeVoteProps> = ({
   useEffect(() => {
     if (isAnyoneCanVote) {
       setSelected(VoteType.PerVote);
+      onVoteTypeChange?.(VoteType.PerVote);
     } else {
       setSelected(VoteType.PerTransaction);
+      onVoteTypeChange?.(VoteType.PerTransaction);
     }
   }, [isAnyoneCanVote]);
 


### PR DESCRIPTION
I have noticed that if you select a template which has `PerVote` charge settings enabled (anyone can play), and if you move backwards in that template and actually select a entry contest type which means `PerTransaction` charge settings will be enabled for voting, while in UI it does reflect that change, we still set `PerVote` when we deploy a contest.