### PR TITLE
chore: fix vote calculation precision with Math.floor

### DIFF
--- a/packages/react-app-revamp/hooks/useUser/index.ts
+++ b/packages/react-app-revamp/hooks/useUser/index.ts
@@ -286,7 +286,8 @@ export function useUser() {
       }
 
       const userVotesRaw = (userBalanceResult.value - totalGasCost) / costToVoteResult;
-      const userVotesFormatted = Number(parseEther(userVotesRaw.toString())) / 1e18;
+
+      const userVotesFormatted = Math.floor(Number(parseEther(userVotesRaw.toString())) / 1e18);
 
       // check for valid number
       if (isNaN(userVotesFormatted)) {


### PR DESCRIPTION
I noticed that when pay-per-vote is enabled on contests, `userVotesFormatted` sometimes ends up not being a whole number (in my case 4016.9999999999995). This PR adds `Math.floor` to ensure we always get a clean integer value.