### PR TITLE
bugfix: fix undefined BigInt conversion in entry votes

### DIFF
--- a/packages/react-app-revamp/hooks/useProposal/index.ts
+++ b/packages/react-app-revamp/hooks/useProposal/index.ts
@@ -133,13 +133,18 @@ export function useProposal() {
       const currentDate = new Date();
 
       if (!useLegacyGetAllProposalsIdFn) {
+        const hasDownvotes = compareVersions(version, "5.1") < 0;
+
         const extractVotes = (index: number) => {
-          const forVotesValue = BigInt(proposalsIdsRawData[1][index].forVotes);
-          const againstVotesValue = BigInt(proposalsIdsRawData[1][index].againstVotes);
+          if (hasDownvotes) {
+            const forVotesValue = BigInt(proposalsIdsRawData[1][index].forVotes);
+            const againstVotesValue = BigInt(proposalsIdsRawData[1][index].againstVotes);
 
-          const netVotes = Number(formatEther(forVotesValue - againstVotesValue));
+            const netVotes = Number(formatEther(forVotesValue - againstVotesValue));
 
-          return netVotes;
+            return netVotes;
+          }
+          return Number(formatEther(proposalsIdsRawData[1][index]));
         };
 
         mappedProposals = proposalsIdsRawData[0].map((data: any, index: number) => {

--- a/packages/react-app-revamp/hooks/useProposal/utils.ts
+++ b/packages/react-app-revamp/hooks/useProposal/utils.ts
@@ -248,12 +248,12 @@ export async function getProposalIdsRaw(contractConfig: ContractConfig, isLegacy
           accumulator.validProposalIds.push(proposalId);
 
           if (hasDownvotes) {
-            accumulator.correspondingVotes.push(results[0].result[1][index]);
-          } else {
             accumulator.correspondingVotes.push({
               forVotes: results[0].result[1][index],
               againstVotes: BigInt(0),
             });
+          } else {
+            accumulator.correspondingVotes.push(results[0].result[1][index]);
           }
         }
         return accumulator;

--- a/packages/react-app-revamp/hooks/useProposal/utils.ts
+++ b/packages/react-app-revamp/hooks/useProposal/utils.ts
@@ -249,8 +249,8 @@ export async function getProposalIdsRaw(contractConfig: ContractConfig, isLegacy
 
           if (hasDownvotes) {
             accumulator.correspondingVotes.push({
-              forVotes: results[0].result[1][index],
-              againstVotes: BigInt(0),
+              forVotes: results[0].result[1][index].forVotes,
+              againstVotes: results[0].result[1][index].againstVotes,
             });
           } else {
             accumulator.correspondingVotes.push(results[0].result[1][index]);


### PR DESCRIPTION
There is a small bug that is currently in prod, if you go over [this contest](https://www.jokerace.io/contest/base/0xba9d6fa92b812b84f172fa77b7eeba73ed375516)  and click on any entry, ranks won't be included.

Issue is that i have i missed to update new logic in 2 places in our codebase, everything should be working correctly now! 