### PR TITLE
enhancement: use light class selector for tweets

### DIFF
--- a/packages/react-app-revamp/components/_pages/Contest/components/Prompt/Proposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/components/Prompt/Proposal/index.tsx
@@ -56,11 +56,7 @@ const transform = (node: HTMLElement): ReactNode => {
         );
       } else {
         const tweetId = tweetUrlMatch[4] || tweetUrlMatch[2];
-        return (
-          <div className="not-prose">
-            <Tweet apiUrl={`/api/tweet/${tweetId}`} id={tweetId} />
-          </div>
-        );
+        return <Tweet apiUrl={`/api/tweet/${tweetId}`} id={tweetId} />;
       }
     }
   }

--- a/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalLayout/Tweet/components/CustomTweet/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalLayout/Tweet/components/CustomTweet/index.tsx
@@ -12,5 +12,9 @@ export const Tweet = ({ id, apiUrl, fallback = <TweetSkeleton />, components, on
     return <CustomTweetNotFound id={id} error={onError ? onError(error) : error} />;
   }
 
-  return <MyTweet tweet={data} components={components} />;
+  return (
+    <div className="not-prose light">
+      <MyTweet tweet={data} components={components} />
+    </div>
+  );
 };

--- a/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalLayout/Tweet/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalLayout/Tweet/index.tsx
@@ -109,9 +109,7 @@ const ProposalLayoutTweet: FC<ProposalLayoutTweetProps> = ({
           </div>
         ) : null}
       </div>
-      <div className="not-prose">
-        <Tweet id={tweetId} apiUrl={`/api/tweet/${tweetId}`} />
-      </div>
+      <Tweet id={tweetId} apiUrl={`/api/tweet/${tweetId}`} />
       <div className="mt-auto pl-2">
         <div className="flex gap-2 items-center">
           {contestStatus === ContestStatus.VotingOpen || contestStatus === ContestStatus.VotingClosed ? (

--- a/packages/react-app-revamp/components/_pages/ProposalContent/utils/markdown.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/utils/markdown.tsx
@@ -1,6 +1,6 @@
 import { twitterRegex } from "@helpers/regex";
 import { ReactNode } from "react";
-import { Tweet } from "react-tweet";
+import { Tweet } from "../components/ProposalLayout/Tweet/components/CustomTweet";
 
 export const transform = (node: HTMLElement): ReactNode => {
   const element = node.tagName.toLowerCase();
@@ -48,8 +48,4 @@ const createExternalLink = (href: string, text: string): ReactNode => (
   </a>
 );
 
-const createTweetEmbed = (tweetId: string): ReactNode => (
-  <div className="not-prose">
-    <Tweet apiUrl={`/api/tweet/${tweetId}`} id={tweetId} />
-  </div>
-);
+const createTweetEmbed = (tweetId: string): ReactNode => <Tweet apiUrl={`/api/tweet/${tweetId}`} id={tweetId} />;


### PR DESCRIPTION
We should use `light` in the className for the tweets, as suggested [here](https://react-tweet.vercel.app/#toggling-theme-manually)

I thought if not passed, that `light` is set by default but it isn't, tweets look much better now with this selector

| before | after |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/5046e2d9-91ba-4f16-82b0-ad6008434023)  | ![image](https://github.com/user-attachments/assets/274c96d4-3f84-4744-8c9d-1f5633d99da5)   |



