### PR TITLE
bugfix: fix collapsed description container height to prevent extra scrolling

### DIFF
--- a/packages/react-app-revamp/components/_pages/Contest/components/Prompt/components/Page/components/Layout/V3/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/components/Prompt/components/Page/components/Layout/V3/index.tsx
@@ -60,7 +60,13 @@ const ContestPromptPageV3Layout: FC<ContestPromptPageV3LayoutProps> = ({ prompt,
       </div>
 
       <div className="flex flex-col gap-2 md:gap-4 w-80 xs:w-[460px] sm:w-[560px]">
-        <div className="relative">
+        <div
+          className="relative"
+          style={{
+            overflow: "hidden",
+            height: !isExpanded && shouldShowReadMore ? `${Math.min(lineCount, maxVisibleLines) * 1.6}em` : "auto",
+          }}
+        >
           <div ref={elementRef} className="prose prose-invert flex flex-col invisible absolute w-full">
             {renderSection(contestSummary, false)}
             {renderSection(contestEvaluate, true)}
@@ -79,6 +85,7 @@ const ContestPromptPageV3Layout: FC<ContestPromptPageV3LayoutProps> = ({ prompt,
                     maskImage: "linear-gradient(to bottom, black 45%, transparent 100%)",
                     WebkitMaskImage: "linear-gradient(to bottom, black 45%, transparent 100%)",
                     maxHeight: `${Math.min(lineCount, maxVisibleLines) * 1.6}em`,
+                    height: `${Math.min(lineCount, maxVisibleLines) * 1.6}em`,
                   }
                 : {}),
             }}
@@ -90,7 +97,7 @@ const ContestPromptPageV3Layout: FC<ContestPromptPageV3LayoutProps> = ({ prompt,
         </div>
 
         {shouldShowReadMore && !isExpanded && (
-          <div className="w-full flex -mt-12 items-center justify-center z-10">
+          <div className="w-full flex items-center justify-center z-10 -mt-12">
             <button
               onClick={() => setIsExpanded(true)}
               className="text-[12px] md:text-[16px] font-bold flex z-50 w-[120px] md:w-40 h-10 rounded-lg items-center justify-center bg-primary-1 gap-1 text-positive-11 hover:bg-positive-11 hover:text-primary-1 transition-all duration-300 ease-in-out"

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestConfirm/components/Description/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestConfirm/components/Description/index.tsx
@@ -62,7 +62,13 @@ const CreateContestConfirmDescription: FC<CreateContestConfirmDescriptionProps> 
         <div className="text-[12px] uppercase font-bold text-neutral-9">Description</div>
         <div className="flex flex-col gap-4">
           {imageUrl ? <ContestImage imageUrl={imageUrl} /> : null}
-          <div className="relative">
+          <div
+            className="relative"
+            style={{
+              overflow: "hidden",
+              height: !isExpanded && shouldShowReadMore ? `${Math.min(lineCount, maxVisibleLines) * 1.6}em` : "auto",
+            }}
+          >
             <div ref={elementRef} className="prose prose-invert flex flex-col invisible absolute w-full">
               {renderSection(prompt.summarize, false)}
               {renderSection(prompt.evaluateVoters, true)}
@@ -70,13 +76,14 @@ const CreateContestConfirmDescription: FC<CreateContestConfirmDescriptionProps> 
             </div>
 
             <div
-              className={`prose prose-invert flex flex-col text-neutral-11 transition-color duration-300 ${!isExpanded && shouldShowReadMore ? "overflow-hidden" : ""}`}
+              className={`prose prose-invert flex flex-col text-neutral-11 transition-color duration-300`}
               style={{
                 ...(!isExpanded && shouldShowReadMore
                   ? {
                       maskImage: "linear-gradient(to bottom, black 45%, transparent 100%)",
                       WebkitMaskImage: "linear-gradient(to bottom, black 45%, transparent 100%)",
                       maxHeight: `${Math.min(lineCount, maxVisibleLines) * 1.6}em`,
+                      height: `${Math.min(lineCount, maxVisibleLines) * 1.6}em`,
                     }
                   : {}),
               }}


### PR DESCRIPTION
I have noticed that for [this contest](https://www.jokerace.io/contest/polygon/0x69a42939b1db1455e7150b79794d0b392f2b26f9) scrollbar appears with the height of the actual contest description when it is expanded (but it isn't) and footer isn't fixed to the bottom.

Issue here was, when contest description is way too long, main container takes that height instead of keeping the height of non-expanded contest description, hence why scrollbar appears and why footer isn't fixed.

EDIT: I think this was a known issue before, someone noticed that for some contests footer isn't fixed, so it was this issue.

EDIT 2: Oh i think this was also the issue with some contests not loading entries at specific point on the site (you had to load way more in order for them to load, i added hotfix back then, but it was this issue after all)