### PR TITLE
feat: send funds button on user profile

### DIFF
--- a/packages/react-app-revamp/components/SendFunds/index.tsx
+++ b/packages/react-app-revamp/components/SendFunds/index.tsx
@@ -1,5 +1,5 @@
 import { erc20ChainDropdownOptions } from "@components/_pages/Create/components/RequirementsSettings/config";
-import TokenSearchModal, { TokenSearchModalType } from "@components/TokenSearchModal";
+import TokenSearchModalERC20MultiStep from "@components/TokenSearchModal/MultiStep";
 import { toastError } from "@components/UI/Toast";
 import { chains, config } from "@config/wagmi";
 import { useSendToken } from "@hooks/useSendToken";
@@ -41,19 +41,19 @@ const SendFunds: FC<SendFundsProps> = ({ isOpen, onClose, recipientAddress }) =>
     ];
   }, [chainId]);
 
-  const handleSelectToken = async (token: FilteredToken) => {
+  const handleSubmitTransfer = async (data: { token: FilteredToken; recipient: string; amount: string }) => {
     if (!recipientAddress) {
       toastError("recipient address is required");
       return;
     }
 
-    if (!token.balance || token.balance === 0) {
+    if (!data.token.balance || data.token.balance === 0) {
       toastError("insufficient token balance");
       return;
     }
 
     try {
-      await sendToken(token, chainId, recipientAddress, token.balance.toString());
+      await sendToken(data.token, chainId, data.recipient, data.amount);
     } catch (error) {
       console.error("Failed to send token:", error);
     }
@@ -68,13 +68,12 @@ const SendFunds: FC<SendFundsProps> = ({ isOpen, onClose, recipientAddress }) =>
   };
 
   return (
-    <TokenSearchModal
-      type={TokenSearchModalType.ERC20}
+    <TokenSearchModalERC20MultiStep
       chains={arrangedChainOptions}
       isOpen={isOpen}
       onClose={onClose}
-      onSelectToken={handleSelectToken}
       onSelectChain={handleSelectChain}
+      onSubmitTransfer={handleSubmitTransfer}
     />
   );
 };

--- a/packages/react-app-revamp/components/SendFunds/index.tsx
+++ b/packages/react-app-revamp/components/SendFunds/index.tsx
@@ -1,0 +1,83 @@
+import { erc20ChainDropdownOptions } from "@components/_pages/Create/components/RequirementsSettings/config";
+import TokenSearchModal, { TokenSearchModalType } from "@components/TokenSearchModal";
+import { FC, useState, useMemo } from "react";
+import { useAccount } from "wagmi";
+import { FilteredToken } from "@hooks/useTokenList";
+import { toast } from "react-toastify";
+import { useSendToken } from "@hooks/useSendToken";
+import { chains, config } from "@config/wagmi";
+import { switchChain } from "@wagmi/core";
+import { toastError } from "@components/UI/Toast";
+
+interface SendFundsProps {
+  isOpen: boolean;
+  onClose: () => void;
+  recipientAddress?: string;
+}
+
+const SendFunds: FC<SendFundsProps> = ({ isOpen, onClose, recipientAddress }) => {
+  const { chainId: currentChainId } = useAccount();
+  const [chainId, setChainId] = useState<number>(currentChainId ?? 1);
+  const { sendToken } = useSendToken({
+    onSuccess: () => {
+      onClose();
+    },
+  });
+
+  const arrangedChainOptions = useMemo(() => {
+    if (!chainId) return erc20ChainDropdownOptions;
+
+    const currentChain = chains.find(c => c.id === chainId)?.name.toLowerCase();
+    if (!currentChain) return erc20ChainDropdownOptions;
+
+    const currentChainOption = erc20ChainDropdownOptions.find(
+      option => option.value.toLowerCase() === currentChain.toLowerCase(),
+    );
+
+    if (!currentChainOption) return erc20ChainDropdownOptions;
+
+    return [
+      currentChainOption,
+      ...erc20ChainDropdownOptions.filter(option => option.value.toLowerCase() !== currentChain.toLowerCase()),
+    ];
+  }, [chainId]);
+
+  const handleSelectToken = async (token: FilteredToken) => {
+    if (!recipientAddress) {
+      toastError("recipient address is required");
+      return;
+    }
+
+    if (!token.balance || token.balance === 0) {
+      toast.error("insufficient token balance");
+      return;
+    }
+
+    try {
+      await sendToken(token, chainId, recipientAddress, token.balance.toString());
+    } catch (error) {
+      console.error("Failed to send token:", error);
+    }
+  };
+
+  const handleSelectChain = async (chain: string) => {
+    const chainId = chains.find(c => c.name.toLowerCase() === chain.toLowerCase())?.id;
+    if (chainId) {
+      await switchChain(config, { chainId });
+      setChainId(chainId);
+    }
+  };
+
+  return (
+    <TokenSearchModal
+      type={TokenSearchModalType.ERC20}
+      chains={arrangedChainOptions}
+      isOpen={isOpen}
+      onClose={onClose}
+      onSelectToken={handleSelectToken}
+      onSelectChain={handleSelectChain}
+    />
+  );
+};
+
+export default SendFunds;

--- a/packages/react-app-revamp/components/SendFunds/index.tsx
+++ b/packages/react-app-revamp/components/SendFunds/index.tsx
@@ -1,13 +1,12 @@
 import { erc20ChainDropdownOptions } from "@components/_pages/Create/components/RequirementsSettings/config";
 import TokenSearchModal, { TokenSearchModalType } from "@components/TokenSearchModal";
-import { FC, useState, useMemo } from "react";
-import { useAccount } from "wagmi";
-import { FilteredToken } from "@hooks/useTokenList";
-import { toast } from "react-toastify";
-import { useSendToken } from "@hooks/useSendToken";
-import { chains, config } from "@config/wagmi";
-import { switchChain } from "@wagmi/core";
 import { toastError } from "@components/UI/Toast";
+import { chains, config } from "@config/wagmi";
+import { useSendToken } from "@hooks/useSendToken";
+import { FilteredToken } from "@hooks/useTokenList";
+import { switchChain } from "@wagmi/core";
+import { FC, useMemo, useState } from "react";
+import { useAccount } from "wagmi";
 
 interface SendFundsProps {
   isOpen: boolean;
@@ -49,7 +48,7 @@ const SendFunds: FC<SendFundsProps> = ({ isOpen, onClose, recipientAddress }) =>
     }
 
     if (!token.balance || token.balance === 0) {
-      toast.error("insufficient token balance");
+      toastError("insufficient token balance");
       return;
     }
 

--- a/packages/react-app-revamp/components/TokenSearchModal/ERC20/index.tsx
+++ b/packages/react-app-revamp/components/TokenSearchModal/ERC20/index.tsx
@@ -2,10 +2,11 @@ import { chains } from "@config/wagmi";
 import { InformationCircleIcon } from "@heroicons/react/24/outline";
 import { FilteredToken, TOKENLISTOOOR_SUPPORTED_CHAIN_IDS } from "@hooks/useTokenList";
 import { FC, useState } from "react";
-import TokenSearchModalChainDropdown, { Option } from "../components/ChainDropdown";
+import TokenSearchModalChainDropdown from "../components/ChainDropdown";
 import TokenSearchModalSearchInput from "../components/SearchInput";
 import TokenSearchList from "../components/TokenList";
 import TokenSearchModalUserTokens from "../components/UserTokens";
+import { Option } from "../types";
 
 interface TokenSearchModalERC20Props {
   chains: Option[];

--- a/packages/react-app-revamp/components/TokenSearchModal/MultiStep/components/Form/index.tsx
+++ b/packages/react-app-revamp/components/TokenSearchModal/MultiStep/components/Form/index.tsx
@@ -1,0 +1,151 @@
+import { FilteredToken } from "@hooks/useTokenList";
+import { FC, useState } from "react";
+import CreateTextInput from "components/_pages/Create/components/TextInput";
+import CreateGradientTitle from "@components/_pages/Create/components/GradientTitle";
+import ButtonV3, { ButtonSize } from "@components/UI/ButtonV3";
+import { formatBalance } from "@helpers/formatBalance";
+import { addressRegex } from "@helpers/regex";
+
+interface TokenSearchModalERC20MultiStepFormProps {
+  token: FilteredToken;
+  onBack: () => void;
+  onSubmit: (recipient: string, amount: string) => void;
+}
+
+const TokenSearchModalERC20MultiStepForm: FC<TokenSearchModalERC20MultiStepFormProps> = ({
+  token,
+  onSubmit,
+  onBack,
+}) => {
+  const [recipient, setRecipient] = useState("");
+  const [amount, setAmount] = useState("");
+  const [errors, setErrors] = useState<{ recipient?: string; amount?: string }>({});
+
+  const handleSubmit = () => {
+    const newErrors: { recipient?: string; amount?: string } = {};
+
+    if (!recipient) {
+      newErrors.recipient = "recipient address is required";
+    } else if (!addressRegex.test(recipient)) {
+      newErrors.recipient = "invalid ethereum address";
+    }
+
+    if (!amount) {
+      newErrors.amount = "amount is required";
+    } else {
+      const amountValue = parseFloat(amount);
+      if (isNaN(amountValue) || amountValue <= 0) {
+        newErrors.amount = "amount must be a positive number";
+      } else if (token.balance && amountValue > parseFloat(token.balance.toString())) {
+        newErrors.amount = "amount exceeds available balance";
+      }
+    }
+
+    setErrors(newErrors);
+
+    if (Object.keys(newErrors).length === 0) {
+      onSubmit(recipient, amount);
+    }
+  };
+
+  const handleRecipientChange = (value: string) => {
+    setRecipient(value);
+    if (errors.recipient) {
+      if (addressRegex.test(value)) {
+        setErrors(prev => ({ ...prev, recipient: undefined }));
+      }
+    }
+  };
+
+  const handleAmountChange = (value: string) => {
+    if (value === "" || /^[0-9]*\.?[0-9]*$/.test(value)) {
+      setAmount(value);
+      if (errors.amount) {
+        const amountValue = parseFloat(value);
+        if (
+          !isNaN(amountValue) &&
+          amountValue > 0 &&
+          (!token.balance || amountValue <= parseFloat(token.balance.toString()))
+        ) {
+          setErrors(prev => ({ ...prev, amount: undefined }));
+        }
+      }
+    }
+  };
+
+  const handleMaxAmount = () => {
+    const maxAmount = token.balance ? token.balance.toString() : "0";
+    setAmount(maxAmount);
+    if (errors.amount) {
+      setErrors(prev => ({ ...prev, amount: undefined }));
+    }
+  };
+
+  const isAmountExceedingBalance = () => {
+    if (!amount || !token.balance) return false;
+    return parseFloat(amount) > parseFloat(token.balance.toString());
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-2">
+          <CreateGradientTitle>recipient address</CreateGradientTitle>
+          <CreateTextInput
+            className="md:w-full"
+            value={recipient}
+            onChange={handleRecipientChange}
+            placeholder="0x..."
+          />
+          {errors.recipient && <p className="text-[14px] font-bold text-negative-11">{errors.recipient}</p>}
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <CreateGradientTitle>amount</CreateGradientTitle>
+          <div className="relative">
+            <CreateTextInput value={amount} onChange={handleAmountChange} placeholder="0.0" className="md:w-full" />
+            <div className="absolute right-6 top-1/2 transform -translate-y-1/2 flex items-center gap-2">
+              <span className="text-[14px] uppercase text-neutral-9">{token.symbol}</span>
+              <button
+                onClick={handleMaxAmount}
+                className="uppercase text-[14px] text-positive-11 hover:text-positive-9 transition-colors duration-300 ease-in-out"
+                type="button"
+              >
+                max
+              </button>
+            </div>
+          </div>
+          {errors.amount && <p className="text-[14px] font-bold text-negative-11">{errors.amount}</p>}
+          {isAmountExceedingBalance() && !errors.amount && (
+            <p className="text-[14px] font-bold text-negative-11">amount exceeds available balance</p>
+          )}
+          <div className="flex justify-end">
+            <span className="text-[14px] text-neutral-9">
+              Available: {formatBalance(token.balance?.toString() ?? "0")}{" "}
+              <span className="uppercase">{token.symbol}</span>
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col items-center gap-2">
+        <ButtonV3
+          colorClass="bg-gradient-create"
+          size={ButtonSize.FULL}
+          textColorClass="text-true-black rounded-[40px]"
+          onClick={handleSubmit}
+        >
+          submit
+        </ButtonV3>
+        <div className="flex items-center gap-[5px] -ml-[15px] cursor-pointer group" onClick={onBack}>
+          <div className="transition-transform duration-200 group-hover:-translate-x-1">
+            <img src="/create-flow/back.svg" alt="back" width={15} height={15} className="mt-[1px]" />
+          </div>
+          <p className="text-[16px]">back</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TokenSearchModalERC20MultiStepForm;

--- a/packages/react-app-revamp/components/TokenSearchModal/MultiStep/components/Form/index.tsx
+++ b/packages/react-app-revamp/components/TokenSearchModal/MultiStep/components/Form/index.tsx
@@ -135,7 +135,7 @@ const TokenSearchModalERC20MultiStepForm: FC<TokenSearchModalERC20MultiStepFormP
           textColorClass="text-true-black rounded-[40px]"
           onClick={handleSubmit}
         >
-          submit
+          send funds
         </ButtonV3>
         <div className="flex items-center gap-[5px] -ml-[15px] cursor-pointer group" onClick={onBack}>
           <div className="transition-transform duration-200 group-hover:-translate-x-1">

--- a/packages/react-app-revamp/components/TokenSearchModal/MultiStep/index.tsx
+++ b/packages/react-app-revamp/components/TokenSearchModal/MultiStep/index.tsx
@@ -1,0 +1,98 @@
+import DialogModalV4 from "@components/UI/DialogModalV4";
+import { FilteredToken } from "@hooks/useTokenList";
+import { FC, useState } from "react";
+import TokenSearchModalERC20 from "../ERC20";
+import { Option } from "../types";
+import TokenSearchModalERC20MultiStepForm from "./components/Form";
+
+interface TokenSearchModalERC20MultiStepProps {
+  chains: Option[];
+  isOpen: boolean;
+  setIsOpen?: (isOpen: boolean) => void;
+  onClose?: () => void;
+  onSelectChain?: (chain: string) => void;
+  onSubmitTransfer?: (data: { token: FilteredToken; recipient: string; amount: string }) => void;
+}
+
+enum STEPS {
+  SELECT_TOKEN = 1,
+  TRANSFER_DETAILS = 2,
+}
+
+const TokenSearchModalERC20MultiStep: FC<TokenSearchModalERC20MultiStepProps> = ({
+  isOpen,
+  setIsOpen,
+  chains,
+  onClose,
+  onSelectChain,
+  onSubmitTransfer,
+}) => {
+  const [currentStep, setCurrentStep] = useState(STEPS.SELECT_TOKEN);
+  const [selectedToken, setSelectedToken] = useState<FilteredToken | null>(null);
+
+  const handleClose = () => {
+    setIsOpen?.(false);
+    onClose?.();
+    setCurrentStep(STEPS.SELECT_TOKEN);
+    setSelectedToken(null);
+  };
+
+  const handleTokenSelect = (token: FilteredToken) => {
+    setSelectedToken(token);
+    setCurrentStep(STEPS.TRANSFER_DETAILS);
+  };
+
+  const handleBack = () => {
+    setCurrentStep(STEPS.SELECT_TOKEN);
+  };
+
+  const handleSubmitTransfer = (recipient: string, amount: string) => {
+    if (selectedToken && onSubmitTransfer) {
+      onSubmitTransfer({
+        token: selectedToken,
+        recipient,
+        amount,
+      });
+      handleClose();
+    }
+  };
+
+  return (
+    <DialogModalV4 isOpen={isOpen} onClose={handleClose} width="w-full" lgWidth="lg:max-w-[552px]">
+      <div className="flex flex-col gap-8 py-6 px-4">
+        <div className="flex justify-between items-center">
+          <p className="text-[24px] text-neutral-11 font-bold">
+            {currentStep === STEPS.SELECT_TOKEN ? (
+              "select a token"
+            ) : (
+              <>
+                send <span className="uppercase">{selectedToken?.symbol}</span>
+              </>
+            )}
+          </p>
+          <img
+            src="/modal/modal_close.svg"
+            alt="close"
+            width={25}
+            height={22}
+            className="cursor-pointer"
+            onClick={handleClose}
+          />
+        </div>
+        <div className="bg-primary-5 h-[2px]" />
+
+        {currentStep === STEPS.SELECT_TOKEN ? (
+          <TokenSearchModalERC20 chains={chains} onSelectToken={handleTokenSelect} onSelectChain={onSelectChain} />
+        ) : (
+          <TokenSearchModalERC20MultiStepForm
+            token={selectedToken!}
+            onBack={handleBack}
+            onSubmit={handleSubmitTransfer}
+          />
+        )}
+      </div>
+    </DialogModalV4>
+  );
+};
+
+export default TokenSearchModalERC20MultiStep;

--- a/packages/react-app-revamp/components/TokenSearchModal/NFT/index.tsx
+++ b/packages/react-app-revamp/components/TokenSearchModal/NFT/index.tsx
@@ -1,9 +1,10 @@
 import { chains as wagmiChains } from "@config/wagmi";
 import { NFTMetadata } from "@hooks/useSearchNfts";
 import { FC, useState } from "react";
-import TokenSearchModalChainDropdown, { Option } from "../components/ChainDropdown";
+import TokenSearchModalChainDropdown from "../components/ChainDropdown";
 import NftsSearchList from "../components/NftList";
 import TokenSearchModalSearchInput from "../components/SearchInput";
+import { Option } from "../types";
 
 interface TokenSearchModalNftProps {
   chains: Option[];

--- a/packages/react-app-revamp/components/TokenSearchModal/components/ChainDropdown/index.tsx
+++ b/packages/react-app-revamp/components/TokenSearchModal/components/ChainDropdown/index.tsx
@@ -2,11 +2,7 @@ import { chainsImages } from "@config/wagmi";
 import { Menu, MenuButton, MenuItem, MenuItems, Transition } from "@headlessui/react";
 import { ChevronDownIcon } from "@heroicons/react/24/outline";
 import { FC, Fragment, useState } from "react";
-
-export interface Option {
-  value: string;
-  label: string;
-}
+import { Option } from "../../types";
 
 interface ChainDropdownProps {
   options: Option[];

--- a/packages/react-app-revamp/components/TokenSearchModal/components/SearchInput/index.tsx
+++ b/packages/react-app-revamp/components/TokenSearchModal/components/SearchInput/index.tsx
@@ -24,7 +24,7 @@ const TokenSearchModalSearchInput: FC<TokenSearchModalSearchInputProps> = ({ cha
 
   return (
     <div
-      className={`flex items-center h-12 rounded-[15px] bg-primary-5 text-[16px] pl-8 pr-4 transition-all duration-300 ease-in-out`}
+      className={`flex items-center h-12 rounded-[15px] bg-primary-5 text-[16px] pl-4 pr-4 transition-all duration-300 ease-in-out`}
     >
       <span className="text-neutral-11">
         <MagnifyingGlassIcon
@@ -36,7 +36,7 @@ const TokenSearchModalSearchInput: FC<TokenSearchModalSearchInputProps> = ({ cha
       <input
         className="text-[20px] bg-transparent text-neutral-11 ml-3 outline-none placeholder-neutral-14 w-full"
         type="text"
-        placeholder={isChainSupportedBySearch ? "search name or paste address" : "paste token address"}
+        placeholder={isChainSupportedBySearch ? "search token name or paste address" : "paste token address"}
         value={searchValue}
         onChange={handleChange}
       />

--- a/packages/react-app-revamp/components/TokenSearchModal/components/TokenList/components/Token/index.tsx
+++ b/packages/react-app-revamp/components/TokenSearchModal/components/TokenList/components/Token/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @next/next/no-img-element */
 import { formatNumber } from "@helpers/formatNumber";
 import { FilteredToken } from "@hooks/useTokenList";
-import { FC, useState } from "react";
+import { FC, useEffect, useState } from "react";
 
 interface TokenSearchListTokenProps {
   token: FilteredToken;
@@ -12,6 +12,10 @@ interface TokenSearchListTokenProps {
 const TokenSearchListToken: FC<TokenSearchListTokenProps> = ({ token, isChainDropdownOpen, onSelectToken }) => {
   const [isHovered, setIsHovered] = useState(false);
   const [imgSrc, setImgSrc] = useState(token.logoURI);
+
+  useEffect(() => {
+    setImgSrc(token.logoURI);
+  }, [token.logoURI]);
 
   const truncateTokenName = (name: string, maxLength: number = 20): string => {
     if (name.length > maxLength) {

--- a/packages/react-app-revamp/components/TokenSearchModal/components/UserTokens/index.tsx
+++ b/packages/react-app-revamp/components/TokenSearchModal/components/UserTokens/index.tsx
@@ -42,8 +42,6 @@ const TokenSearchModalUserTokens: FC<TokenSearchModalUserTokensProps> = ({
 
   if (!tokens) return null;
 
-  console.log("tokens", tokens);
-
   return (
     <div className="h-72 animate-reveal">
       <SimpleBar style={{ maxHeight: "100%", height: "100%" }} autoHide={false}>

--- a/packages/react-app-revamp/components/TokenSearchModal/components/UserTokens/index.tsx
+++ b/packages/react-app-revamp/components/TokenSearchModal/components/UserTokens/index.tsx
@@ -42,6 +42,8 @@ const TokenSearchModalUserTokens: FC<TokenSearchModalUserTokensProps> = ({
 
   if (!tokens) return null;
 
+  console.log("tokens", tokens);
+
   return (
     <div className="h-72 animate-reveal">
       <SimpleBar style={{ maxHeight: "100%", height: "100%" }} autoHide={false}>

--- a/packages/react-app-revamp/components/TokenSearchModal/index.tsx
+++ b/packages/react-app-revamp/components/TokenSearchModal/index.tsx
@@ -2,7 +2,7 @@ import DialogModalV4 from "@components/UI/DialogModalV4";
 import { NFTMetadata } from "@hooks/useSearchNfts";
 import { FilteredToken } from "@hooks/useTokenList";
 import { FC, useCallback } from "react";
-import { Option } from "./components/ChainDropdown";
+import { Option } from "./types";
 import TokenSearchModalERC20 from "./ERC20";
 import TokenSearchModalNft from "./NFT";
 

--- a/packages/react-app-revamp/components/TokenSearchModal/types.ts
+++ b/packages/react-app-revamp/components/TokenSearchModal/types.ts
@@ -1,0 +1,4 @@
+export interface Option {
+  value: string;
+  label: string;
+}

--- a/packages/react-app-revamp/components/UI/DialogModalV4/index.tsx
+++ b/packages/react-app-revamp/components/UI/DialogModalV4/index.tsx
@@ -19,13 +19,13 @@ const DialogModalV4: FC<DialogModalV4Props> = ({
   const isInPwaMode = window.matchMedia("(display-mode: standalone)").matches;
 
   return (
-    <Dialog open={isOpen} onClose={onClose} className="relative z-10">
+    <Dialog open={isOpen} onClose={onClose} className="relative z-50">
       <DialogBackdrop
         transition
         className="fixed inset-0 bg-neutral-8 bg-opacity-40 transition-opacity data-[closed]:opacity-0 data-[enter]:duration-300 data-[leave]:duration-200 data-[enter]:ease-out data-[leave]:ease-in"
       />
 
-      <div className="fixed inset-0 z-10 w-screen overflow-y-auto">
+      <div className="fixed inset-0 z-50 w-screen overflow-y-auto">
         <div className="flex min-h-full items-end justify-center text-center lg:items-center p-0">
           <DialogPanel
             transition

--- a/packages/react-app-revamp/components/UI/MobileWalletPortal/index.tsx
+++ b/packages/react-app-revamp/components/UI/MobileWalletPortal/index.tsx
@@ -5,10 +5,11 @@ import {
   ROUTE_VIEW_USER_VOTING,
 } from "@config/routes";
 import { ChevronRightIcon, PowerIcon } from "@heroicons/react/24/outline";
-import React, { useCallback, useRef } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import ReactDOM from "react-dom";
 import CustomLink from "../Link";
 import UserProfileDisplay from "../UserProfileDisplay";
+import SendFunds from "@components/SendFunds";
 
 interface MobileProfilePortalProps {
   isOpen: boolean;
@@ -38,6 +39,7 @@ const navLinks = [
 
 export const MobileProfilePortal: React.FC<MobileProfilePortalProps> = ({ isOpen, onClose, address, onDisconnect }) => {
   const backdropRef = useRef<HTMLDivElement>(null);
+  const [isSendFundsModalOpen, setIsSendFundsModalOpen] = useState(false);
 
   const handleBackdropClick = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
@@ -63,7 +65,14 @@ export const MobileProfilePortal: React.FC<MobileProfilePortalProps> = ({ isOpen
       >
         <div className="flex flex-col gap-8">
           <div className="flex flex-col gap-6 px-8 pt-8">
-            <UserProfileDisplay size="medium" ethereumAddress={address} shortenOnFallback includeSocials />
+            <UserProfileDisplay
+              size="medium"
+              ethereumAddress={address}
+              shortenOnFallback
+              includeSocials
+              includeSendFunds
+              onSendFundsClick={() => setIsSendFundsModalOpen(true)}
+            />
             <div className="flex flex-col gap-2 border-t border-primary-2 px-4 pt-6">
               {navLinks.map(link => (
                 <CustomLink
@@ -82,6 +91,13 @@ export const MobileProfilePortal: React.FC<MobileProfilePortalProps> = ({ isOpen
           </div>
         </div>
       </div>
+      {isSendFundsModalOpen && (
+        <SendFunds
+          isOpen={isSendFundsModalOpen}
+          onClose={() => setIsSendFundsModalOpen(false)}
+          recipientAddress={address}
+        />
+      )}
     </div>,
     document.body,
   );

--- a/packages/react-app-revamp/components/UI/UserProfileDisplay/componentts/SendFundsButton/index.tsx
+++ b/packages/react-app-revamp/components/UI/UserProfileDisplay/componentts/SendFundsButton/index.tsx
@@ -1,0 +1,20 @@
+import ButtonV3 from "@components/UI/ButtonV3";
+import { FC } from "react";
+
+interface SendFundsButtonProps {
+  onSendFundsClick?: () => void;
+}
+
+const SendFundsButton: FC<SendFundsButtonProps> = ({ onSendFundsClick }) => {
+  return (
+    <ButtonV3
+      onClick={onSendFundsClick}
+      colorClass="bg-true-black hover:bg-neutral-11 hover:text-true-black transition-all duration-300"
+      textColorClass="text-neutral-11 border border-neutral-11 rounded-[40px] text-[16px] font-bold"
+    >
+      send funds &gt;
+    </ButtonV3>
+  );
+};
+
+export default SendFundsButton;

--- a/packages/react-app-revamp/components/UI/UserProfileDisplay/index.tsx
+++ b/packages/react-app-revamp/components/UI/UserProfileDisplay/index.tsx
@@ -6,8 +6,8 @@ import useProfileData from "@hooks/useProfileData";
 import { useMemo, useState } from "react";
 import { useAccount } from "wagmi";
 import { Avatar } from "../Avatar";
-import ButtonV3 from "../ButtonV3";
 import CustomLink from "../Link";
+import SendFundsButton from "./componentts/SendFundsButton";
 
 interface UserProfileDisplayProps {
   ethereumAddress: string;
@@ -148,13 +148,7 @@ const UserProfileDisplay = ({
             isConnected &&
             isChainSupportedForSendFunds &&
             userConnectedAddress === ethereumAddress ? (
-              <ButtonV3
-                onClick={onSendFundsClick}
-                colorClass="bg-gradient-create"
-                textColorClass="text-true-black rounded-[40px] text-[16px] font-bold"
-              >
-                send funds &gt;
-              </ButtonV3>
+              <SendFundsButton onSendFundsClick={onSendFundsClick} />
             ) : null}
           </div>
         </div>

--- a/packages/react-app-revamp/components/UI/UserProfileDisplay/index.tsx
+++ b/packages/react-app-revamp/components/UI/UserProfileDisplay/index.tsx
@@ -3,7 +3,6 @@ import { erc20ChainDropdownOptions } from "@components/_pages/Create/components/
 import { ROUTE_VIEW_USER } from "@config/routes";
 import { CheckCircleIcon } from "@heroicons/react/24/outline";
 import useProfileData from "@hooks/useProfileData";
-import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { useMemo, useState } from "react";
 import { useAccount } from "wagmi";
 import { Avatar } from "../Avatar";
@@ -53,7 +52,6 @@ const UserProfileDisplay = ({
   onSendFundsClick,
 }: UserProfileDisplayProps) => {
   const { chain, isConnected, address: userConnectedAddress } = useAccount();
-  const { openConnectModal } = useConnectModal();
   const { profileName, profileAvatar, socials, isLoading } = useProfileData(
     ethereumAddress,
     shortenOnFallback,
@@ -146,24 +144,17 @@ const UserProfileDisplay = ({
                 ) : null}
               </div>
             ) : null}
-            {includeSendFunds ? (
-              isConnected && isChainSupportedForSendFunds && userConnectedAddress === ethereumAddress ? (
-                <ButtonV3
-                  onClick={onSendFundsClick}
-                  colorClass="bg-gradient-create"
-                  textColorClass="text-true-black rounded-[40px] text-[16px] font-bold"
-                >
-                  send funds &gt;
-                </ButtonV3>
-              ) : (
-                <ButtonV3
-                  onClick={openConnectModal}
-                  colorClass="bg-gradient-create"
-                  textColorClass="text-true-black rounded-[40px] text-[16px] font-bold"
-                >
-                  send funds &gt;
-                </ButtonV3>
-              )
+            {includeSendFunds &&
+            isConnected &&
+            isChainSupportedForSendFunds &&
+            userConnectedAddress === ethereumAddress ? (
+              <ButtonV3
+                onClick={onSendFundsClick}
+                colorClass="bg-gradient-create"
+                textColorClass="text-true-black rounded-[40px] text-[16px] font-bold"
+              >
+                send funds &gt;
+              </ButtonV3>
             ) : null}
           </div>
         </div>

--- a/packages/react-app-revamp/components/UI/UserProfileDisplay/index.tsx
+++ b/packages/react-app-revamp/components/UI/UserProfileDisplay/index.tsx
@@ -1,13 +1,14 @@
 /* eslint-disable @next/next/no-img-element */
+import { erc20ChainDropdownOptions } from "@components/_pages/Create/components/RequirementsSettings/config";
 import { ROUTE_VIEW_USER } from "@config/routes";
 import { CheckCircleIcon } from "@heroicons/react/24/outline";
 import useProfileData from "@hooks/useProfileData";
+import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { useMemo, useState } from "react";
-import { Avatar } from "../Avatar";
-import CustomLink from "../Link";
-import ButtonV3, { ButtonSize } from "../ButtonV3";
 import { useAccount } from "wagmi";
-import { erc20ChainDropdownOptions } from "@components/_pages/Create/components/RequirementsSettings/config";
+import { Avatar } from "../Avatar";
+import ButtonV3 from "../ButtonV3";
+import CustomLink from "../Link";
 
 interface UserProfileDisplayProps {
   ethereumAddress: string;
@@ -51,7 +52,8 @@ const UserProfileDisplay = ({
   includeSendFunds,
   onSendFundsClick,
 }: UserProfileDisplayProps) => {
-  const { chain } = useAccount();
+  const { chain, isConnected, address: userConnectedAddress } = useAccount();
+  const { openConnectModal } = useConnectModal();
   const { profileName, profileAvatar, socials, isLoading } = useProfileData(
     ethereumAddress,
     shortenOnFallback,
@@ -144,14 +146,24 @@ const UserProfileDisplay = ({
                 ) : null}
               </div>
             ) : null}
-            {includeSendFunds && isChainSupportedForSendFunds ? (
-              <ButtonV3
-                onClick={onSendFundsClick}
-                colorClass="bg-gradient-create"
-                textColorClass="text-true-black rounded-[40px] text-[16px] font-bold"
-              >
-                send funds &gt;
-              </ButtonV3>
+            {includeSendFunds ? (
+              isConnected && isChainSupportedForSendFunds && userConnectedAddress !== ethereumAddress ? (
+                <ButtonV3
+                  onClick={onSendFundsClick}
+                  colorClass="bg-gradient-create"
+                  textColorClass="text-true-black rounded-[40px] text-[16px] font-bold"
+                >
+                  send funds &gt;
+                </ButtonV3>
+              ) : (
+                <ButtonV3
+                  onClick={openConnectModal}
+                  colorClass="bg-gradient-create"
+                  textColorClass="text-true-black rounded-[40px] text-[16px] font-bold"
+                >
+                  send funds &gt;
+                </ButtonV3>
+              )
             ) : null}
           </div>
         </div>

--- a/packages/react-app-revamp/components/UI/UserProfileDisplay/index.tsx
+++ b/packages/react-app-revamp/components/UI/UserProfileDisplay/index.tsx
@@ -147,7 +147,7 @@ const UserProfileDisplay = ({
               </div>
             ) : null}
             {includeSendFunds ? (
-              isConnected && isChainSupportedForSendFunds && userConnectedAddress !== ethereumAddress ? (
+              isConnected && isChainSupportedForSendFunds && userConnectedAddress === ethereumAddress ? (
                 <ButtonV3
                   onClick={onSendFundsClick}
                   colorClass="bg-gradient-create"

--- a/packages/react-app-revamp/components/UI/UserProfileDisplay/index.tsx
+++ b/packages/react-app-revamp/components/UI/UserProfileDisplay/index.tsx
@@ -2,9 +2,12 @@
 import { ROUTE_VIEW_USER } from "@config/routes";
 import { CheckCircleIcon } from "@heroicons/react/24/outline";
 import useProfileData from "@hooks/useProfileData";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Avatar } from "../Avatar";
 import CustomLink from "../Link";
+import ButtonV3, { ButtonSize } from "../ButtonV3";
+import { useAccount } from "wagmi";
+import { erc20ChainDropdownOptions } from "@components/_pages/Create/components/RequirementsSettings/config";
 
 interface UserProfileDisplayProps {
   ethereumAddress: string;
@@ -14,6 +17,8 @@ interface UserProfileDisplayProps {
   textualVersion?: boolean;
   avatarVersion?: boolean;
   includeSocials?: boolean;
+  includeSendFunds?: boolean;
+  onSendFundsClick?: () => void;
 }
 
 export const SIZES = {
@@ -43,7 +48,10 @@ const UserProfileDisplay = ({
   textColor,
   shortenOnFallback,
   size = "small",
+  includeSendFunds,
+  onSendFundsClick,
 }: UserProfileDisplayProps) => {
+  const { chain } = useAccount();
   const { profileName, profileAvatar, socials, isLoading } = useProfileData(
     ethereumAddress,
     shortenOnFallback,
@@ -51,6 +59,10 @@ const UserProfileDisplay = ({
   );
   const { avatarSizeClass, textSizeClass } = SIZES[size];
   const [isAddressCopied, setIsAddressCopied] = useState(false);
+
+  const isChainSupportedForSendFunds = useMemo(() => {
+    return erc20ChainDropdownOptions.some(option => option.value.toLowerCase() === chain?.name.toLowerCase());
+  }, [chain]);
 
   if (textualVersion) {
     return (
@@ -87,7 +99,7 @@ const UserProfileDisplay = ({
     <div
       className={`flex ${
         size === "large" ? "gap-6" : size === "medium" ? "gap-4" : "gap-2"
-      } items-center ${textSizeClass} ${textColor || "text-neutral-11"} font-bold`}
+      } items-center ${textColor || "text-neutral-11"} font-bold`}
     >
       <div className={`flex items-center ${avatarSizeClass} bg-neutral-5 rounded-full overflow-hidden`}>
         <img style={{ width: "100%", height: "100%", objectFit: "cover" }} src={profileAvatar} alt="avatar" />
@@ -114,23 +126,34 @@ const UserProfileDisplay = ({
             )}
           </div>
 
-          {includeSocials ? (
-            <div className="flex gap-2 items-center">
-              <a href={socials?.etherscan} target="_blank">
-                <div className="w-6 h-6 flex justify-center items-center overflow-hidden rounded-full">
-                  <img className="object-cover" src="/etherscan.svg" alt="Etherscan" />
-                </div>
-              </a>
-
-              {socials?.cluster ? (
-                <a href={socials.cluster} target="_blank">
+          <div className="flex items-center gap-4">
+            {includeSocials ? (
+              <div className="flex gap-2 items-center">
+                <a href={socials?.etherscan} target="_blank">
                   <div className="w-6 h-6 flex justify-center items-center overflow-hidden rounded-full">
-                    <img className="object-cover" src="/socials/cluster.png" alt="Cluster" />
+                    <img className="object-cover" src="/etherscan.svg" alt="Etherscan" />
                   </div>
                 </a>
-              ) : null}
-            </div>
-          ) : null}
+
+                {socials?.cluster ? (
+                  <a href={socials.cluster} target="_blank">
+                    <div className="w-6 h-6 flex justify-center items-center overflow-hidden rounded-full">
+                      <img className="object-cover" src="/socials/cluster.png" alt="Cluster" />
+                    </div>
+                  </a>
+                ) : null}
+              </div>
+            ) : null}
+            {includeSendFunds && isChainSupportedForSendFunds ? (
+              <ButtonV3
+                onClick={onSendFundsClick}
+                colorClass="bg-gradient-create"
+                textColorClass="text-true-black rounded-[40px] text-[16px] font-bold"
+              >
+                send funds &gt;
+              </ButtonV3>
+            ) : null}
+          </div>
         </div>
       )}
     </div>

--- a/packages/react-app-revamp/components/_pages/Contest/components/StickyCards/components/VotingQualifier/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/components/StickyCards/components/VotingQualifier/index.tsx
@@ -76,7 +76,7 @@ const VotingContestQualifier = () => {
         )
       ) : (
         <button
-          className="w-32 md:w-48 h-8 text-[16px] font-bold bg-true-black text-positive-11 md:text-neutral-11 rounded-[40px] border border-positive-11 md:border-neutral-11 hover:bg-neutral-11 hover:text-true-black transition-all duration-300"
+          className="w-32 md:w-48 h-8 text-[16px] font-bold bg-true-black text-neutral-11 rounded-[40px] border border-neutral-11 hover:bg-neutral-11 hover:text-true-black transition-all duration-300"
           onClick={openConnectModal}
         >
           connect wallet

--- a/packages/react-app-revamp/components/_pages/Create/components/TextInput/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/components/TextInput/index.tsx
@@ -40,7 +40,7 @@ const CreateTextInput: FC<CreateTextInputProps> = ({
 
   return (
     <div
-      className={`w-full md:w-[656px] bg-true-black rounded-[16px] border-true-black md:shadow-file-upload md:p-2 relative`}
+      className={`w-full md:w-[656px] bg-true-black rounded-[16px] border-true-black md:shadow-file-upload md:p-2 relative ${className}`}
     >
       <input
         ref={inputRef}

--- a/packages/react-app-revamp/hooks/useFetchUserTokens/index.ts
+++ b/packages/react-app-revamp/hooks/useFetchUserTokens/index.ts
@@ -1,6 +1,9 @@
 import { FilteredToken } from "@hooks/useTokenList";
 import { useQuery } from "@tanstack/react-query";
 import { formatUnits } from "ethers/lib/utils";
+import { useBalance } from "wagmi";
+import { chains, chainsImages } from "@config/wagmi";
+import React from "react";
 
 const ZERO_BALANCE = "0x0000000000000000000000000000000000000000000000000000000000000000";
 const NEAR_ZERO_BALANCE = "0x0000000000000000000000000000000000000000000000000000000000000001"; // etherscan and rabby show these values as 0, so to not confuse the user, we will exclude them.
@@ -20,11 +23,22 @@ const getAlchemyBaseUrl = (chain: string) => {
   return `https://${subdomain}.g.alchemy.com/v2/${alchemyApiKey}`;
 };
 
+const findChainByName = (chainName: string) => {
+  return chains.find(chain => chain.name.toLowerCase() === chainName.toLowerCase());
+};
+
 export const useFetchUserTokens = (userAddress: string, chainName: string) => {
+  const chain = findChainByName(chainName);
+
+  const { data: nativeBalance, isLoading: isLoadingNativeBalance } = useBalance({
+    address: userAddress as `0x${string}`,
+    chainId: chain?.id,
+  });
+
   const {
-    data: tokens,
+    data: erc20Tokens,
     error,
-    isLoading,
+    isLoading: isLoadingErc20,
     refetch,
   } = useQuery<FilteredToken[], Error>({
     queryKey: ["user-erc20-balance", chainName, userAddress],
@@ -89,6 +103,7 @@ export const useFetchUserTokens = (userAddress: string, chainName: string) => {
         return {
           address: token.contractAddress,
           name: metadata.result.name,
+          decimals: metadata.result.decimals,
           symbol: metadata.result.symbol,
           logoURI: metadata.result.logo ? metadata.result.logo : "/contest/mona-lisa-moustache.png",
           balance: formattedTokenBalance,
@@ -100,6 +115,32 @@ export const useFetchUserTokens = (userAddress: string, chainName: string) => {
     },
     enabled: !!userAddress && !!chainName && !!process.env.NEXT_PUBLIC_ALCHEMY_KEY,
   });
+
+  const tokens = React.useMemo(() => {
+    const allTokens: FilteredToken[] = [...(erc20Tokens || [])];
+
+    if (nativeBalance && nativeBalance?.value.toString() !== "0" && chain) {
+      const isEth = chain.nativeCurrency.symbol.toUpperCase() === "ETH";
+      const normalizedChainName = chainName.toLowerCase();
+
+      const nativeToken: FilteredToken = {
+        address: "0x0000000000000000000000000000000000000000",
+        name: chain.nativeCurrency.symbol,
+        symbol: chain.nativeCurrency.symbol,
+        decimals: chain.nativeCurrency.decimals,
+        logoURI: isEth ? "/mainnet.svg" : chainsImages[normalizedChainName] || "/contest/mona-lisa-moustache.png",
+        balance: parseFloat(nativeBalance.formatted),
+      };
+
+      console.log("nativeToken", nativeToken);
+
+      allTokens.unshift(nativeToken);
+    }
+
+    return allTokens;
+  }, [erc20Tokens, nativeBalance, chain, chainName]);
+
+  const isLoading = isLoadingErc20 || isLoadingNativeBalance;
 
   return { tokens, error, isLoading, refetchUserBalances: refetch };
 };

--- a/packages/react-app-revamp/hooks/useFetchUserTokens/index.ts
+++ b/packages/react-app-revamp/hooks/useFetchUserTokens/index.ts
@@ -132,8 +132,6 @@ export const useFetchUserTokens = (userAddress: string, chainName: string) => {
         balance: parseFloat(nativeBalance.formatted),
       };
 
-      console.log("nativeToken", nativeToken);
-
       allTokens.unshift(nativeToken);
     }
 

--- a/packages/react-app-revamp/hooks/useSendToken/index.ts
+++ b/packages/react-app-revamp/hooks/useSendToken/index.ts
@@ -2,13 +2,7 @@ import { toastError, toastLoading, toastSuccess } from "@components/UI/Toast";
 import { config } from "@config/wagmi";
 import { useError } from "@hooks/useError";
 import { FilteredToken } from "@hooks/useTokenList";
-import {
-  estimateGas,
-  estimateMaxPriorityFeePerGas,
-  sendTransaction,
-  simulateContract,
-  writeContract,
-} from "@wagmi/core";
+import { estimateMaxPriorityFeePerGas, sendTransaction, simulateContract, writeContract } from "@wagmi/core";
 import { erc20Abi, parseUnits } from "viem";
 
 interface UseSendTokenOptions {
@@ -76,6 +70,7 @@ export function useSendToken(options?: UseSendTokenOptions) {
 
           toastLoading("sending transfer transaction...");
           const hash = await sendTransaction(config, {
+            chainId,
             to: recipientAddress as `0x${string}`,
             value: adjustedAmount,
           });

--- a/packages/react-app-revamp/hooks/useSendToken/index.ts
+++ b/packages/react-app-revamp/hooks/useSendToken/index.ts
@@ -2,7 +2,7 @@ import { toastError, toastLoading, toastSuccess } from "@components/UI/Toast";
 import { config } from "@config/wagmi";
 import { useError } from "@hooks/useError";
 import { FilteredToken } from "@hooks/useTokenList";
-import { estimateMaxPriorityFeePerGas, sendTransaction, simulateContract, writeContract } from "@wagmi/core";
+import { sendTransaction, simulateContract, writeContract } from "@wagmi/core";
 import { erc20Abi, parseUnits } from "viem";
 
 interface UseSendTokenOptions {
@@ -52,27 +52,14 @@ export function useSendToken(options?: UseSendTokenOptions) {
 
     try {
       if (token.address === "0x0000000000000000000000000000000000000000") {
-        const parsedAmount = parseUnits(amount, 18);
+        const parsedAmount = parseUnits(amount, token.decimals);
 
         try {
-          const maxPriorityFeePerGas = await estimateMaxPriorityFeePerGas(config, {
-            chainId,
-          });
-
-          const gasBuffer = maxPriorityFeePerGas * 100000n;
-
-          const adjustedAmount = parsedAmount > gasBuffer ? parsedAmount - gasBuffer : 0n;
-
-          if (adjustedAmount <= 0n) {
-            toastError("amount too small to cover gas fees");
-            return;
-          }
-
           toastLoading("sending transfer transaction...");
           const hash = await sendTransaction(config, {
             chainId,
             to: recipientAddress as `0x${string}`,
-            value: adjustedAmount,
+            value: parsedAmount,
           });
 
           toastSuccess("transaction sent successfully!");

--- a/packages/react-app-revamp/hooks/useSendToken/index.ts
+++ b/packages/react-app-revamp/hooks/useSendToken/index.ts
@@ -1,0 +1,114 @@
+import { toastError, toastLoading, toastSuccess } from "@components/UI/Toast";
+import { config } from "@config/wagmi";
+import { useError } from "@hooks/useError";
+import { FilteredToken } from "@hooks/useTokenList";
+import {
+  estimateGas,
+  estimateMaxPriorityFeePerGas,
+  sendTransaction,
+  simulateContract,
+  writeContract,
+} from "@wagmi/core";
+import { erc20Abi, parseUnits } from "viem";
+
+interface UseSendTokenOptions {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+}
+
+export function useSendToken(options?: UseSendTokenOptions) {
+  const { handleError } = useError();
+
+  const transferERC20Token = async (
+    chainId: number,
+    to: `0x${string}`,
+    amount: bigint,
+    contractAddress: `0x${string}`,
+  ) => {
+    try {
+      const { request } = await simulateContract(config, {
+        abi: erc20Abi,
+        chainId,
+        address: contractAddress,
+        functionName: "transfer",
+        args: [to, amount],
+      });
+
+      toastLoading("sending transfer transaction...");
+      const hash = await writeContract(config, request);
+
+      toastSuccess("transfer transaction sent successfully!");
+      options?.onSuccess?.();
+      return hash;
+    } catch (error) {
+      handleError(error as Error, "transfer transaction failed");
+    }
+  };
+
+  const sendToken = async (token: FilteredToken, chainId: number, recipientAddress: string, amount: string) => {
+    if (!recipientAddress) {
+      toastError("recipient address is required");
+      return;
+    }
+
+    if (!amount || isNaN(Number(amount)) || Number(amount) <= 0) {
+      toastError("please enter a valid amount");
+      return;
+    }
+
+    try {
+      if (token.address === "0x0000000000000000000000000000000000000000") {
+        const parsedAmount = parseUnits(amount, 18);
+
+        try {
+          toastLoading("preparing native token transaction...");
+
+          const maxPriorityFeePerGas = await estimateMaxPriorityFeePerGas(config, {
+            chainId,
+          });
+
+          const gasBuffer = maxPriorityFeePerGas * 100000n;
+
+          const adjustedAmount = parsedAmount > gasBuffer ? parsedAmount - gasBuffer : 0n;
+
+          if (adjustedAmount <= 0n) {
+            toastError("amount too small to cover gas fees");
+            return;
+          }
+
+          toastLoading("sending native token transaction...");
+          const hash = await sendTransaction(config, {
+            to: recipientAddress as `0x${string}`,
+            value: adjustedAmount,
+          });
+
+          toastSuccess("transaction sent successfully!");
+          options?.onSuccess?.();
+          return hash;
+        } catch (error) {
+          const err = error as Error;
+          toastError(err.message || "transaction failed");
+          options?.onError?.(err);
+          throw error;
+        }
+      } else {
+        toastLoading("preparing token transfer...");
+
+        const parsedAmount = parseUnits(amount, token.decimals);
+
+        return await transferERC20Token(
+          chainId,
+          recipientAddress as `0x${string}`,
+          parsedAmount,
+          token.address as `0x${string}`,
+        );
+      }
+    } catch (e) {
+      handleError(e as Error, "transaction failed");
+    }
+  };
+
+  return {
+    sendToken,
+  };
+}

--- a/packages/react-app-revamp/hooks/useSendToken/index.ts
+++ b/packages/react-app-revamp/hooks/useSendToken/index.ts
@@ -61,8 +61,6 @@ export function useSendToken(options?: UseSendTokenOptions) {
         const parsedAmount = parseUnits(amount, 18);
 
         try {
-          toastLoading("preparing native token transaction...");
-
           const maxPriorityFeePerGas = await estimateMaxPriorityFeePerGas(config, {
             chainId,
           });
@@ -76,7 +74,7 @@ export function useSendToken(options?: UseSendTokenOptions) {
             return;
           }
 
-          toastLoading("sending native token transaction...");
+          toastLoading("sending transfer transaction...");
           const hash = await sendTransaction(config, {
             to: recipientAddress as `0x${string}`,
             value: adjustedAmount,
@@ -92,8 +90,6 @@ export function useSendToken(options?: UseSendTokenOptions) {
           throw error;
         }
       } else {
-        toastLoading("preparing token transfer...");
-
         const parsedAmount = parseUnits(amount, token.decimals);
 
         return await transferERC20Token(

--- a/packages/react-app-revamp/layouts/LayoutUser/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutUser/index.tsx
@@ -14,6 +14,7 @@ import { ReactNode, useEffect, useRef, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
 import { useMediaQuery } from "react-responsive";
+import { useAccount } from "wagmi";
 
 interface LayoutUserProps {
   address: string;
@@ -46,6 +47,7 @@ function isActiveLink(pathname: string, hrefTemplate: string, address: string) {
 }
 
 const LayoutUser = (props: LayoutUserProps) => {
+  const { address: userAddress, isConnected } = useAccount();
   const { children, address } = props;
   const pathname = usePathname();
   const [indicatorStyle, setIndicatorStyle] = useState({ left: "0px", width: "0px" });
@@ -81,7 +83,7 @@ const LayoutUser = (props: LayoutUserProps) => {
               shortenOnFallback
               size={isMobile ? "medium" : "large"}
               includeSocials
-              includeSendFunds
+              includeSendFunds={isConnected && userAddress !== address}
               onSendFundsClick={() => {
                 setIsSendFundsModalOpen(true);
               }}

--- a/packages/react-app-revamp/layouts/LayoutUser/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutUser/index.tsx
@@ -14,7 +14,6 @@ import { ReactNode, useEffect, useRef, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
 import { useMediaQuery } from "react-responsive";
-import { useAccount } from "wagmi";
 
 interface LayoutUserProps {
   address: string;
@@ -47,7 +46,6 @@ function isActiveLink(pathname: string, hrefTemplate: string, address: string) {
 }
 
 const LayoutUser = (props: LayoutUserProps) => {
-  const { address: userAddress, isConnected } = useAccount();
   const { children, address } = props;
   const pathname = usePathname();
   const [indicatorStyle, setIndicatorStyle] = useState({ left: "0px", width: "0px" });

--- a/packages/react-app-revamp/layouts/LayoutUser/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutUser/index.tsx
@@ -83,7 +83,7 @@ const LayoutUser = (props: LayoutUserProps) => {
               shortenOnFallback
               size={isMobile ? "medium" : "large"}
               includeSocials
-              includeSendFunds={isConnected && userAddress !== address}
+              includeSendFunds
               onSendFundsClick={() => {
                 setIsSendFundsModalOpen(true);
               }}

--- a/packages/react-app-revamp/layouts/LayoutUser/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutUser/index.tsx
@@ -1,4 +1,5 @@
 "use client";
+import SendFunds from "@components/SendFunds";
 import Button from "@components/UI/Button";
 import CustomLink from "@components/UI/Link";
 import UserProfileDisplay from "@components/UI/UserProfileDisplay";
@@ -50,6 +51,7 @@ const LayoutUser = (props: LayoutUserProps) => {
   const [indicatorStyle, setIndicatorStyle] = useState({ left: "0px", width: "0px" });
   const tabRefs = useRef<(HTMLDivElement | null)[]>([]);
   const isMobile = useMediaQuery({ maxWidth: "768px" });
+  const [isSendFundsModalOpen, setIsSendFundsModalOpen] = useState(false);
 
   useEffect(() => {
     const activeTabIndex = navLinks.findIndex(link => isActiveLink(pathname ?? "", link.href, address));
@@ -79,6 +81,10 @@ const LayoutUser = (props: LayoutUserProps) => {
               shortenOnFallback
               size={isMobile ? "medium" : "large"}
               includeSocials
+              includeSendFunds
+              onSendFundsClick={() => {
+                setIsSendFundsModalOpen(true);
+              }}
             />
           )}
 
@@ -108,6 +114,11 @@ const LayoutUser = (props: LayoutUserProps) => {
             </div>
           </div>
         </div>
+        <SendFunds
+          isOpen={isSendFundsModalOpen}
+          onClose={() => setIsSendFundsModalOpen(false)}
+          recipientAddress={address}
+        />
       </SkeletonTheme>
 
       <ErrorBoundary


### PR DESCRIPTION
Closes #3525

Let's make this serve as an MVP, current flow is:

1. When user visits their profile, send funds button appear.
2. When clicked on send funds button, token search modal would open (i'm including native token as first in the list of user's tokens since i guess most of the time they will send native token)
3. When clicked on token from the modal, they are brought to the second step of the form, where they can specify recipient address and amount they wish to send. Once submit is clicked, tx is initialized.

For now, sending only to these chains is supported, because we can only fetch for tokens on these chains

```
export const erc20ChainDropdownOptions: Option[] = [
  {
    value: "mainnet",
    label: "ethereum",
  },
  {
    value: "arbitrumone",
    label: "arbitrum",
  },
  {
    value: "avalanche",
    label: "avalanche",
  },
  {
    value: "base",
    label: "base",
  },
  {
    value: "celo",
    label: "celo",
  },
  {
    value: "mantle",
    label: "mantle",
  },
  {
    value: "optimism",
    label: "optimism",
  },
  {
    value: "polygon",
    label: "polygon",
  },
];
```

Let's iterate on this and in next version, we can include all chains. where user can either send a native token or explicitly specify a token address of the erc20 token that they are about to send. 