### PR TITLE
chore: add try/catch for signer during contest deployment

### DIFF
--- a/packages/react-app-revamp/hooks/useDeployContest/index.ts
+++ b/packages/react-app-revamp/hooks/useDeployContest/index.ts
@@ -56,7 +56,15 @@ export function useDeployContest() {
   const { address, chain } = useAccount();
 
   async function deployContest() {
-    const signer = await getEthersSigner(config, { chainId: chain?.id });
+    let signer: any;
+
+    try {
+      signer = await getEthersSigner(config, { chainId: chain?.id });
+    } catch (error: any) {
+      handleError(error, "Please try reconnecting your wallet.");
+      return;
+    }
+
     const isSpoofingDetected = await checkForSpoofing(signer?._address);
 
     if (isSpoofingDetected) {


### PR DESCRIPTION
Closes #3538

I think the issue lays in `getEthersSigner`, where we are attempting to get `signer`, but due to stale connection, it errors out. 

Let's add try/catch in this iteration, and we can check with tavvi if she gets immediate error for this one (we would initialize error before the deployment screen appears with a message "Please try reconnecting your wallet.")