### PR TITLE
chore: rm background color on quoted tweet

### DIFF
--- a/packages/react-app-revamp/styles/globals.css
+++ b/packages/react-app-revamp/styles/globals.css
@@ -268,7 +268,7 @@ li {
 }
 
 [class^="react-tweet-theme"] {
-  background-color: #000000 !important;
+  background-color: #e5e5e5 !important;
   border: 1px solid #242424 !important;
   border-radius: 16px !important;
 }
@@ -277,8 +277,6 @@ li {
   min-width: 100% !important;
   max-width: 100% !important;
   overflow: hidden !important;
-  background-color: #000000 !important;
-  border: 1px solid #242424 !important;
   border-radius: 16px !important;
 }
 


### PR DESCRIPTION
I have noticed that on [this contest](https://jokerace.io/contest/base/0x164a82dd414dfa53e5c8efe1e18db8cf7fd66d5b) dark background color is applied to the quoted tweet, while `light` class should override it, we should still remove it from the `global.css`