### PR TITLE
bugfix: fix close button style on entry page on desktop

### DIFF
--- a/packages/react-app-revamp/components/_pages/DialogModalProposal/components/Header/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalProposal/components/Header/index.tsx
@@ -40,18 +40,20 @@ const DialogModalProposalHeader: FC<DialogModalProposalHeaderProps> = ({
   return (
     <div className="flex flex-col gap-4 w-full">
       {allowDelete && <SubmissionDeleteButton onClick={() => setIsDeleteProposalModalOpen(true)} />}
-      {proposalData.proposal.votes > 0 && (
-        <div className="flex gap-2 items-center">
-          <p className="text-[20px] font-bold text-neutral-11">
-            {formatNumberAbbreviated(proposalData.proposal.votes)} vote
-            {proposalData.proposal.votes > 1 ? "s" : ""}
-          </p>
-          <span className="text-neutral-9">•</span>
-          <p className="text-[20px] font-bold text-neutral-9">
-            {ordinalize(proposalData.proposal.rank).label} place {proposalData.proposal.isTied ? "(tied)" : ""}
-          </p>
-        </div>
-      )}
+      <div className={`flex gap-2 items-center ${proposalData.proposal.votes > 0 ? "h-auto" : "h-6"}`}>
+        {proposalData.proposal.votes > 0 ? (
+          <>
+            <p className="text-[20px] font-bold text-neutral-11">
+              {formatNumberAbbreviated(proposalData.proposal.votes)} vote
+              {proposalData.proposal.votes > 1 ? "s" : ""}
+            </p>
+            <span className="text-neutral-9">•</span>
+            <p className="text-[20px] font-bold text-neutral-9">
+              {ordinalize(proposalData.proposal.rank).label} place {proposalData.proposal.isTied ? "(tied)" : ""}
+            </p>
+          </>
+        ) : null}
+      </div>
       <div className="flex justify-between w-full items-center">
         <UserProfileDisplay ethereumAddress={proposalData.proposal.authorEthereumAddress} shortenOnFallback={true} />
         <div className="flex items-center gap-2">


### PR DESCRIPTION
I have noticed that if there are no votes in the entry page header (empty space) close button on the right side goes down and messes up with the navigation actions. 

This is because we aren't preserving space to align with the close button when entry has no votes.
![image](https://github.com/user-attachments/assets/b08ed83d-9aea-4401-bdf8-710206c617af)
