### PR TITLE
chore: rm view transition lib

### DIFF
--- a/packages/react-app-revamp/app/contests/search.tsx
+++ b/packages/react-app-revamp/app/contests/search.tsx
@@ -7,8 +7,7 @@ import useContestSortOptions from "@hooks/useSortOptions";
 import { useQuery } from "@tanstack/react-query";
 import { getEnsAddress } from "@wagmi/core";
 import { ITEMS_PER_PAGE, getRewards, searchContests } from "lib/contests";
-import { useTransitionRouter } from "next-view-transitions";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useAccount } from "wagmi";
 
@@ -63,7 +62,7 @@ function useContests(searchCriteria: SearchCriteria, sortBy?: string) {
 }
 
 const SearchContests = () => {
-  const router = useTransitionRouter();
+  const router = useRouter();
   const query = useSearchParams();
   const [searchCriteria, setSearchCriteria] = useState<SearchCriteria>({
     searchString: "",

--- a/packages/react-app-revamp/app/layout.tsx
+++ b/packages/react-app-revamp/app/layout.tsx
@@ -16,7 +16,6 @@ import "react-toastify/dist/ReactToastify.min.css";
 import "react-tooltip/dist/react-tooltip.css";
 import "simplebar-react/dist/simplebar.min.css";
 import Providers from "./providers";
-import { ViewTransitions } from "next-view-transitions";
 
 polyfill();
 
@@ -80,19 +79,17 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   const cookie = headers().get("cookie") ?? "";
 
   return (
-    <ViewTransitions>
-      <html lang="en" className={`${lato.variable} ${sabo.variable}`}>
-        <body>
-          <div id="__next">
-            <NextTopLoader color="#BB65FF" shadow="0 0 10px #BB65FF, 0 0 5px #78FFC6" showSpinner={false} />
-            <Providers cookie={cookie}>
-              <LayoutBase>{children}</LayoutBase>
-              <DynamicPortal />
-              <GoogleAnalytics gaId={GA_TRACKING_ID} />
-            </Providers>
-          </div>
-        </body>
-      </html>
-    </ViewTransitions>
+    <html lang="en" className={`${lato.variable} ${sabo.variable}`}>
+      <body>
+        <div id="__next">
+          <NextTopLoader color="#BB65FF" shadow="0 0 10px #BB65FF, 0 0 5px #78FFC6" showSpinner={false} />
+          <Providers cookie={cookie}>
+            <LayoutBase>{children}</LayoutBase>
+            <DynamicPortal />
+            <GoogleAnalytics gaId={GA_TRACKING_ID} />
+          </Providers>
+        </div>
+      </body>
+    </html>
   );
 }

--- a/packages/react-app-revamp/app/not-found.tsx
+++ b/packages/react-app-revamp/app/not-found.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useTransitionRouter } from "next-view-transitions";
+import { useRouter } from "next/navigation";
 
 export const metadata = {
   title: "Page not found - JokeRace",
@@ -7,7 +7,7 @@ export const metadata = {
 };
 
 const NotFoundPage = () => {
-  const router = useTransitionRouter();
+  const router = useRouter();
 
   return (
     <div className="container m-auto sm:text-center animate-appear">

--- a/packages/react-app-revamp/components/Header/CreateFlowHeader/DesktopLayout/index.tsx
+++ b/packages/react-app-revamp/components/Header/CreateFlowHeader/DesktopLayout/index.tsx
@@ -3,7 +3,7 @@ import CustomLink from "@components/UI/Link";
 import UserProfileDisplay from "@components/UI/UserProfileDisplay";
 import { ROUTE_CREATE_CONTEST, ROUTE_VIEW_LIVE_CONTESTS } from "@config/routes";
 import { PageAction } from "@hooks/useCreateFlowAction/store";
-import { useTransitionRouter } from "next-view-transitions";
+import { useRouter } from "next/navigation";
 import { FC, useEffect, useState } from "react";
 
 interface CreateFlowHeaderDesktopLayoutProps {
@@ -20,7 +20,7 @@ const CreateFlowHeaderDesktopLayout: FC<CreateFlowHeaderDesktopLayoutProps> = ({
   pageAction,
 }) => {
   const [isClient, setIsClient] = useState(false);
-  const router = useTransitionRouter();
+  const router = useRouter();
 
   useEffect(() => {
     setIsClient(true);

--- a/packages/react-app-revamp/components/Sort/index.tsx
+++ b/packages/react-app-revamp/components/Sort/index.tsx
@@ -1,8 +1,7 @@
 import { ROUTE_VIEW_PAST_CONTESTS } from "@config/routes";
 import { Menu, MenuButton, MenuItem, MenuItems, Transition } from "@headlessui/react";
 import { ChevronDownIcon, XMarkIcon } from "@heroicons/react/24/outline";
-import { useTransitionRouter } from "next-view-transitions";
-import { usePathname, useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { FC, Fragment, useEffect, useState } from "react";
 
 function classNames(...classes: string[]) {
@@ -24,7 +23,7 @@ const Sort: FC<SortProps> = ({ sortOptions, onSortChange }) => {
   const [label, setLabel] = useState<string | null>(null);
   const query = useSearchParams();
   const pathname = usePathname();
-  const router = useTransitionRouter();
+  const router = useRouter();
   const sortByFromQuery = query?.get("sortBy");
 
   useEffect(() => {

--- a/packages/react-app-revamp/components/UI/Link/index.tsx
+++ b/packages/react-app-revamp/components/UI/Link/index.tsx
@@ -1,6 +1,4 @@
-import { Link } from "next-view-transitions";
-import { LinkProps } from "next/link";
-
+import Link, { LinkProps } from "next/link";
 interface CustomLinkProps extends LinkProps {
   children: React.ReactNode;
   prefetch?: boolean;

--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestDeploying/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestDeploying/index.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable react/no-unescaped-entities */
 import { toastDismiss } from "@components/UI/Toast";
 import { useDeployContestStore } from "@hooks/useDeployContest/store";
-import { useTransitionRouter } from "next-view-transitions";
+import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { create } from "zustand";
 
@@ -21,7 +21,7 @@ const WARNING_MESSAGE_THRESHOLD = 10000;
 const CreateContestDeploying = () => {
   const { isSuccess, deployContestData, votingMerkle: votingMerkleData } = useDeployContestStore(state => state);
   const votingMerkle = votingMerkleData.prefilled || votingMerkleData.csv;
-  const router = useTransitionRouter();
+  const router = useRouter();
   const { setShowRewards } = useShowRewardsStore(state => state);
 
   useEffect(() => {

--- a/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalLayout/Leaderboard/components/Mobile/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalLayout/Leaderboard/components/Mobile/index.tsx
@@ -5,7 +5,7 @@ import CustomLink from "@components/UI/Link";
 import { formatNumberAbbreviated } from "@helpers/formatNumber";
 import { ChatBubbleLeftEllipsisIcon, ChevronRightIcon } from "@heroicons/react/24/outline";
 import { ContestStatus } from "@hooks/useContestStatus/store";
-import { useTransitionRouter } from "next-view-transitions";
+import { useRouter } from "next/navigation";
 import { FC } from "react";
 import ProposalLayoutLeaderboardRankOrPlaceholder from "../RankOrPlaceholder";
 
@@ -39,7 +39,7 @@ const ProposalLayoutLeaderboardMobile: FC<ProposalLayoutLeaderboardMobileProps> 
   chainName,
   contestAddress,
 }) => {
-  const router = useTransitionRouter();
+  const router = useRouter();
   const entryTitle = proposal.metadataFields.stringArray[0];
 
   const navigateToCommentLink = (e: React.MouseEvent<HTMLButtonElement>) => {

--- a/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalLayout/Leaderboard/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalLayout/Leaderboard/index.tsx
@@ -1,19 +1,18 @@
+import { useEntryPreviewTitleToggleStore } from "@components/_pages/Contest/components/EntryPreviewTitleToggle/store";
 import { Proposal } from "@components/_pages/ProposalContent";
 import { transform } from "@components/_pages/ProposalContent/utils/markdown";
+import CustomLink from "@components/UI/Link";
+import { toastInfo } from "@components/UI/Toast";
 import { formatNumberAbbreviated } from "@helpers/formatNumber";
 import { ChatBubbleLeftEllipsisIcon, ChevronDownIcon, ChevronRightIcon, LinkIcon } from "@heroicons/react/24/outline";
 import { ContestStatus } from "@hooks/useContestStatus/store";
 import { Interweave } from "interweave";
-import { Link } from "next-view-transitions";
+import { UrlMatcher } from "interweave-autolink";
 import { FC, useEffect, useState } from "react";
 import ProposalContentDeleteButton from "../../Buttons/Delete";
 import ProposalContentProfile from "../../Profile";
 import ProposalLayoutLeaderboardMobile from "./components/Mobile";
 import ProposalLayoutLeaderboardRankOrPlaceholder from "./components/RankOrPlaceholder";
-import { toastInfo } from "@components/UI/Toast";
-import { UrlMatcher } from "interweave-autolink";
-import { useEntryPreviewTitleToggleStore } from "@components/_pages/Contest/components/EntryPreviewTitleToggle/store";
-import CustomLink from "@components/UI/Link";
 
 interface ProposalLayoutLeaderboardProps {
   proposal: Proposal;

--- a/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalLayout/Tweet/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalLayout/Tweet/index.tsx
@@ -3,7 +3,7 @@ import CustomLink from "@components/UI/Link";
 import { formatNumberAbbreviated } from "@helpers/formatNumber";
 import { ChatBubbleLeftEllipsisIcon, CheckIcon, TrashIcon } from "@heroicons/react/24/outline";
 import { ContestStatus } from "@hooks/useContestStatus/store";
-import { useTransitionRouter } from "next-view-transitions";
+import { useRouter } from "next/navigation";
 import { FC } from "react";
 import ProposalContentProfile from "../../Profile";
 import { Tweet } from "./components/CustomTweet";
@@ -50,7 +50,7 @@ const ProposalLayoutTweet: FC<ProposalLayoutTweetProps> = ({
 }) => {
   const tweetUrl = proposal.metadataFields.stringArray[0];
   const tweetId = extractTweetId(tweetUrl);
-  const router = useTransitionRouter();
+  const router = useRouter();
 
   const onVotingModalOpen = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();

--- a/packages/react-app-revamp/components/_pages/Submission/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Submission/index.tsx
@@ -4,7 +4,7 @@ import { useContestStore } from "@hooks/useContest/store";
 import useFetchProposalData from "@hooks/useFetchProposalData";
 import { useProposalStore } from "@hooks/useProposal/store";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
-import { useTransitionRouter } from "next-view-transitions";
+import { useRouter } from "next/navigation";
 import { FC, useEffect } from "react";
 import { useMediaQuery } from "react-responsive";
 import { Abi } from "viem";
@@ -28,7 +28,7 @@ const SubmissionPage: FC<SubmissionPageProps> = ({ contestInfo, proposalId }) =>
     error: isProposalError,
   } = useFetchProposalData(contestInfo.abi, contestInfo.version, contestInfo.address, contestInfo.chainId, proposalId);
   const { contestPrompt: prompt } = useContestStore(state => state);
-  const router = useTransitionRouter();
+  const router = useRouter();
   const isMobile = useMediaQuery({ maxWidth: "768px" });
   const { openConnectModal } = useConnectModal();
   const { castVotes } = useCastVotes();

--- a/packages/react-app-revamp/package.json
+++ b/packages/react-app-revamp/package.json
@@ -69,7 +69,6 @@
     "moment-timezone": "0.5.48",
     "next": "14.2.28",
     "next-pwa": "5.6.0",
-    "next-view-transitions": "^0.3.4",
     "nextjs-current-url": "1.0.3",
     "nextjs-toploader": "1.6.12",
     "node-html-parser": "6.1.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15405,11 +15405,6 @@ next-pwa@5.6.0:
     workbox-webpack-plugin "^6.5.4"
     workbox-window "^6.5.4"
 
-next-view-transitions@^0.3.4:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/next-view-transitions/-/next-view-transitions-0.3.4.tgz#442372e1d55f25d565c063032231980784e224f0"
-  integrity sha512-SSiskenQ8JkEFGzPjvFwC5LGGoqgTxM5dxexkeugxvcXFLpWI2ZUh4IsCURD3ovW+8Ue7xXlrtrpy8b7XR7IwQ==
-
 next@14.2.28:
   version "14.2.28"
   resolved "https://registry.yarnpkg.com/next/-/next-14.2.28.tgz#fdc2af93544d90a3915e544b73208c18668af6f9"
@@ -18148,16 +18143,7 @@ strict-uri-encode@^2.0.0:
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
   integrity sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -18245,7 +18231,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -18258,13 +18244,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -19893,7 +19872,7 @@ wrangler@3.60.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -19906,15 +19885,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
I'm noticing some weird delay again when closing entry page, or when leaving browser open and coming back to it and trying to navigate between pages. 

While i really like `next-view-transition` lib i think it's not necessary as of right now, when we upgrade to nextjs 15 we will have this native support that we can enable, so we will get there eventually. Keep in mind, that pages will still be instantly navigated with our `prefetch` mechanic, this will just reduce that smooth effect of navigation (by upgrading to nextjs 15 we will have this as well)