### PR TITLE
bugfix: fix arbitrum onramp

### DIFF
--- a/packages/react-app-revamp/components/Onramp/providers/coinbase/utils.ts
+++ b/packages/react-app-revamp/components/Onramp/providers/coinbase/utils.ts
@@ -8,6 +8,10 @@ export type OnrampParams = {
   fiatCurrency?: string;
 };
 
+export const COINBASE_CHAIN_MAPPING: Record<string, string> = {
+  arbitrumone: "arbitrum",
+};
+
 export const getOnrampBuyUrl = ({
   address,
   chain,
@@ -17,9 +21,11 @@ export const getOnrampBuyUrl = ({
 }: OnrampParams): string => {
   if (!projectId) return "";
 
+  const coinbaseChain = COINBASE_CHAIN_MAPPING[chain.toLowerCase()] || chain;
+
   const addresses = encodeURIComponent(
     JSON.stringify({
-      [address]: [chain],
+      [address]: [coinbaseChain],
     }),
   );
 
@@ -35,7 +41,7 @@ export const getOnrampBuyUrl = ({
 };
 
 export const COINBASE_SUPPORTED_CHAINS = [
-  "arbitrum",
+  "arbitrumone",
   "avalanche",
   "base",
   "bnb",


### PR DESCRIPTION
I have noticed that if you try to add funds and onramp with arbitrum, we currently show disabled status for that chain, while coinbase does support it.

Issue was, we are configuring `arbitrum` as `arbitrumone`, and we should map and configure it to check our internal config for `arbitrumone` and pass it as `arbitrum` to the onramp URL.