### PR TITLE
chore: allow major update PRs to be made without approval

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,9 +4,6 @@
     "config:recommended"
   ],
   "labels": ["renovate"],
-  "major": {
-    "dependencyDashboardApproval": true
-  },
   "ignoreDeps": ["react-native"],
   "schedule": [
     "after 11pm every weekday",


### PR DESCRIPTION
draft until we have the current backlog solidly cleared so we don't get hit with a huge flood of PRs all at once.

we still won't allow major update PRs to auto-merge, but we will allow them to be created for visibility.