### PR TITLE
enhancement: refactor contests calls

### DIFF
--- a/packages/react-app-revamp/components/_pages/FeaturedContests/components/Contest.tsx
+++ b/packages/react-app-revamp/components/_pages/FeaturedContests/components/Contest.tsx
@@ -3,7 +3,7 @@ import { Avatar } from "@components/UI/Avatar";
 import CustomLink from "@components/UI/Link";
 import { ROUTE_VIEW_CONTEST_BASE_PATH } from "@config/routes";
 import useProfileData from "@hooks/useProfileData";
-import { Contest, ContestReward } from "lib/contests";
+import { Contest, ContestReward } from "lib/contests/types";
 import moment from "moment";
 import { FC, useCallback, useEffect, useState } from "react";
 import Skeleton from "react-loading-skeleton";

--- a/packages/react-app-revamp/components/_pages/FeaturedContests/index.tsx
+++ b/packages/react-app-revamp/components/_pages/FeaturedContests/index.tsx
@@ -1,17 +1,14 @@
-import { Contest, ContestReward } from "lib/contests";
 import { FC } from "react";
 import FeaturedContestCard from "./components/Contest";
 import Skeleton from "react-loading-skeleton";
 import { CONTESTS_FEATURE_COUNT } from "lib/contests/constants";
+import { Contest, ContestReward } from "lib/contests/types";
 
 interface FeaturedContestsProps {
   status: "error" | "pending" | "success";
   isContestDataFetching: boolean;
   isRewardsFetching: boolean;
-  contestData?: {
-    data: Contest[];
-    count: number | null;
-  };
+  contestData?: Contest[];
   rewardsData?: (ContestReward | null)[];
 }
 
@@ -37,6 +34,7 @@ const FeaturedContests: FC<FeaturedContestsProps> = ({
       <Skeleton width={150} height={16} baseColor="#212121" highlightColor="#100816" />
     </div>
   );
+
   return (
     <>
       {status === "error" ? (
@@ -48,17 +46,22 @@ const FeaturedContests: FC<FeaturedContestsProps> = ({
           <p className="text-[16px] text-neutral-14 font-bold uppercase">featured contests</p>
           <div className="overflow-x-auto scrollbar-hide">
             <div className="flex lg:featured-contests-grid gap-4 pb-4">
-              {isContestDataFetching
-                ? Array.from({ length: CONTESTS_FEATURE_COUNT }).map((_, index) => <SkeletonCard key={index} />)
-                : contestData?.data.map((contest, index) => (
-                    <div className="w-[320px] flex-shrink-0 lg:w-auto" key={index}>
-                      <FeaturedContestCard
-                        contestData={contest}
-                        rewardsData={rewardsData?.[index]}
-                        isRewardsFetching={isRewardsFetching}
-                      />
-                    </div>
-                  ))}
+              {/* Show loaded contests */}
+              {contestData?.map((contest, index) => (
+                <div className="w-[320px] flex-shrink-0 lg:w-auto" key={`contest-${index}`}>
+                  <FeaturedContestCard
+                    contestData={contest}
+                    rewardsData={rewardsData?.[index]}
+                    isRewardsFetching={isRewardsFetching}
+                  />
+                </div>
+              ))}
+
+              {/* Show skeletons for remaining slots */}
+              {isContestDataFetching &&
+                Array.from({
+                  length: Math.max(0, CONTESTS_FEATURE_COUNT - (contestData?.length || 0)),
+                }).map((_, index) => <SkeletonCard key={`skeleton-${index}`} />)}
             </div>
           </div>
         </div>

--- a/packages/react-app-revamp/components/_pages/Landing/components/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Landing/components/index.tsx
@@ -4,9 +4,11 @@ import { ROUTE_CREATE_CONTEST, ROUTE_VIEW_LIVE_CONTESTS } from "@config/routes";
 import { isSupabaseConfigured } from "@helpers/database";
 import { ChevronRightIcon } from "@heroicons/react/24/outline";
 import { useQuery } from "@tanstack/react-query";
-import { getFeaturedContests, getRewards } from "lib/contests";
+import { getRewards, streamFeaturedContests } from "lib/contests";
 import { CONTESTS_FEATURE_COUNT } from "lib/contests/constants";
-import { useState } from "react";
+import { Contest } from "lib/contests/types";
+import moment from "moment";
+import { useMemo, useState } from "react";
 import { useMediaQuery } from "react-responsive";
 import { TypeAnimation } from "react-type-animation";
 import LandingPageExplainer from "./Explainer";
@@ -39,32 +41,71 @@ const wordConfig = {
 
 function useFeaturedContests() {
   const [page] = useState(0);
+  const [contests, setContests] = useState<Contest[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [status, setStatus] = useState<"error" | "pending" | "success">("pending");
 
-  const {
-    status,
-    data: contestData,
-    error,
-    isFetching: isContestDataFetching,
-  } = useQuery({
-    queryKey: ["featuredContests", page],
-    queryFn: () => getFeaturedContests(page, CONTESTS_FEATURE_COUNT),
+  useQuery({
+    queryKey: ["featuredContestsStream", page],
+    queryFn: async () => {
+      setIsLoading(true);
+      setStatus("pending");
+      setContests([]);
+
+      try {
+        for await (const contest of streamFeaturedContests(page, CONTESTS_FEATURE_COUNT)) {
+          if (contest) {
+            setContests(prev => [...prev, contest]);
+            setStatus("success");
+          }
+        }
+
+        setIsLoading(false);
+        return true;
+      } catch (e) {
+        console.error("Error fetching featured contests:", e);
+        setStatus("error");
+        setIsLoading(false);
+        return false;
+      }
+    },
     refetchOnWindowFocus: false,
   });
 
+  // Get rewards for contests that have been loaded
   const { data: rewardsData, isFetching: isRewardsFetching } = useQuery({
-    queryKey: ["rewards", contestData],
-    queryFn: () => getRewards(contestData?.data ?? []),
-    enabled: !!contestData,
+    queryKey: ["rewards", contests],
+    queryFn: () => getRewards(contests),
+    enabled: contests.length > 0,
     refetchOnWindowFocus: false,
   });
+
+  // Sort contests once they're all loaded
+  const sortedContests = useMemo(() => {
+    if (contests.length === 0) return [];
+
+    return [...contests].sort((a, b) => {
+      const now = moment();
+      const aIsHappening = moment(a.created_at).isBefore(now) && moment(a.end_at).isAfter(now);
+      const bIsHappening = moment(b.created_at).isBefore(now) && moment(b.end_at).isAfter(now);
+
+      if (aIsHappening && bIsHappening) {
+        return moment(a.end_at).diff(now) - moment(b.end_at).diff(now);
+      }
+
+      if (aIsHappening) return -1;
+      if (bIsHappening) return 1;
+
+      return moment(a.created_at).diff(now) - moment(b.created_at).diff(now);
+    });
+  }, [contests]);
 
   return {
     status,
-    contestData,
+    contestData: sortedContests,
     rewardsData,
     isRewardsFetching,
-    error,
-    isContestDataFetching,
+    isContestDataFetching: isLoading,
   };
 }
 

--- a/packages/react-app-revamp/hooks/useTotalVotes/index.ts
+++ b/packages/react-app-revamp/hooks/useTotalVotes/index.ts
@@ -3,7 +3,7 @@ import { useContestStore } from "@hooks/useContest/store";
 import { useQuery } from "@tanstack/react-query";
 import { readContract } from "@wagmi/core";
 import { fetchDataFromBucket } from "lib/buckets";
-import { EMPTY_HASH } from "lib/contests";
+import { EMPTY_HASH } from "lib/contests/contracts";
 import { Recipient } from "lib/merkletree/generateMerkleTree";
 import { Abi } from "viem";
 

--- a/packages/react-app-revamp/lib/contests/constants/index.ts
+++ b/packages/react-app-revamp/lib/contests/constants/index.ts
@@ -1,1 +1,4 @@
 export const CONTESTS_FEATURE_COUNT = 8;
+
+export const FEATURED_CONTEST_COLUMNS =
+  "created_at, start_at, end_at, address, author_address, network_name, vote_start_at, featured, type, submissionMerkleRoot, votingMerkleRoot, voting_requirements, submission_requirements";

--- a/packages/react-app-revamp/lib/contests/contracts.ts
+++ b/packages/react-app-revamp/lib/contests/contracts.ts
@@ -1,0 +1,270 @@
+import { chains, config } from "@config/wagmi";
+import { formatBalance } from "@helpers/formatBalance";
+import getContestContractVersion from "@helpers/getContestContractVersion";
+import getRewardsModuleContractVersion from "@helpers/getRewardsModuleContractVersion";
+import { ContestStateEnum } from "@hooks/useContestState/store";
+import { getBalance, readContract, readContracts } from "@wagmi/core";
+import { getTokenAddresses } from "lib/rewards";
+import { Abi, erc20Abi, formatUnits } from "viem";
+import { ContestReward } from "./types";
+
+export const EMPTY_HASH = "0x0000000000000000000000000000000000000000000000000000000000000000";
+export const EMPTY_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+/**
+ * Get contract config for a given address and chainId
+ * @param address Contract address
+ * @param chainId Chain ID
+ * @returns Contract config
+ */
+async function getContractConfig(address: string, chainId: number) {
+  const { abi } = await getContestContractVersion(address, chainId);
+
+  if (abi === null) {
+    return;
+  }
+
+  const contractConfig = {
+    address: address as `0x${string}`,
+    abi: abi as any,
+    chainId: chainId,
+  };
+
+  return contractConfig;
+}
+
+/**
+ * Get contest title and state in a single batch of contract calls
+ * @param contestAddress Contract address
+ * @param networkName Network name
+ * @returns Object containing title and isCanceled status
+ */
+export async function getContestTitleAndState(
+  contestAddress: string,
+  networkName: string,
+): Promise<{ title: string | null; isCanceled: boolean }> {
+  const chainId = chains.find(c => c.name.toLowerCase() === networkName.toLowerCase())?.id;
+  if (!chainId) return { title: null, isCanceled: false };
+
+  try {
+    const contractConfig = await getContractConfig(contestAddress, chainId);
+    if (!contractConfig) {
+      return { title: null, isCanceled: false };
+    }
+
+    const results = await readContracts(config, {
+      contracts: [
+        {
+          ...contractConfig,
+          functionName: "name",
+          args: [],
+        },
+        {
+          ...contractConfig,
+          functionName: "state",
+          args: [],
+        },
+      ],
+    });
+
+    const title = results[0].result as string;
+    const state = results[1].result;
+    const isCanceled = state === ContestStateEnum.Canceled;
+
+    return { title, isCanceled };
+  } catch (error) {
+    console.error("Error fetching contest data:", error);
+    return { title: null, isCanceled: false };
+  }
+}
+
+export async function fetchNativeBalance(contestRewardModuleAddress: string, chainId: number) {
+  try {
+    const nativeBalance = await getBalance(config, {
+      address: contestRewardModuleAddress as `0x${string}`,
+      chainId: chainId,
+    });
+    return nativeBalance;
+  } catch (error) {
+    console.error("Error fetching native balance:", error);
+    return null;
+  }
+}
+
+export async function fetchFirstToken(contestRewardModuleAddress: string, chainId: number, tokenAddress: string) {
+  try {
+    const firstToken = await getBalance(config, {
+      address: contestRewardModuleAddress as `0x${string}`,
+      chainId: chainId,
+      token: tokenAddress as `0x${string}`,
+    });
+    return firstToken;
+  } catch (error) {
+    console.error("Error fetching first token balance:", error);
+    return null;
+  }
+}
+
+export async function getTokenDetails(tokenAddress: string, chainId: number) {
+  try {
+    const result = await readContracts(config, {
+      contracts: [
+        {
+          address: tokenAddress as `0x${string}`,
+          abi: erc20Abi,
+          functionName: "symbol",
+          chainId,
+        },
+        {
+          address: tokenAddress as `0x${string}`,
+          abi: erc20Abi,
+          functionName: "decimals",
+          chainId,
+        },
+      ],
+    });
+
+    return {
+      symbol: result[0].result as string,
+      decimals: result[1].result as number,
+    };
+  } catch (error) {
+    console.error("Error fetching token details:", error);
+    return { symbol: "Unknown", decimals: 18 };
+  }
+}
+
+export async function processContestRewardsData(
+  contestAddress: string,
+  contestChainName: string,
+): Promise<ContestReward | null> {
+  try {
+    const chain = chains.find(
+      c => c.name.replace(/\s+/g, "").toLowerCase() === contestChainName.replace(/\s+/g, "").toLowerCase(),
+    );
+    if (!chain) throw new Error("Chain not found");
+
+    const contractConfig = await getContractConfig(contestAddress, chain.id);
+    if (!contractConfig || !contractConfig.abi?.some((el: { name: string }) => el.name === "officialRewardsModule")) {
+      return null;
+    }
+
+    const rewardsModuleAddress = (await readContract(config, {
+      ...contractConfig,
+      functionName: "officialRewardsModule",
+      args: [],
+    })) as string;
+
+    if (rewardsModuleAddress === EMPTY_ADDRESS || rewardsModuleAddress === EMPTY_HASH) return null;
+
+    const abiRewardsModule = await getRewardsModuleContractVersion(rewardsModuleAddress, chain.id);
+    if (!abiRewardsModule) return null;
+
+    const [winners, erc20TokenAddresses] = await Promise.all([
+      readContract(config, {
+        address: rewardsModuleAddress as `0x${string}`,
+        abi: abiRewardsModule,
+        chainId: chain.id,
+        functionName: "getPayees",
+      }) as Promise<bigint[]>,
+      getTokenAddresses(rewardsModuleAddress, contestChainName),
+    ]);
+
+    if (!winners.length) return null;
+
+    const checkReleasableAndReleased = async (isNative: boolean, tokenAddress?: string) => {
+      const [releasableAmounts, releasedAmounts] = await Promise.all([
+        readContracts(config, {
+          contracts: winners.map(ranking => ({
+            address: rewardsModuleAddress as `0x${string}`,
+            abi: abiRewardsModule as Abi,
+            chainId: chain.id,
+            functionName: "releasable",
+            args: isNative ? [ranking] : [tokenAddress, ranking],
+          })),
+        }),
+        readContracts(config, {
+          contracts: winners.map(ranking => ({
+            address: rewardsModuleAddress as `0x${string}`,
+            abi: abiRewardsModule as Abi,
+            chainId: chain.id,
+            functionName: isNative ? "released" : "erc20Released",
+            args: isNative ? [ranking] : [tokenAddress, ranking],
+          })),
+        }),
+      ]);
+
+      const totalReleasable = releasableAmounts.reduce((sum, amount) => sum + BigInt(amount.result as string), 0n);
+      const totalReleased = releasedAmounts.reduce((sum, amount) => sum + BigInt(amount.result as string), 0n);
+
+      return { totalReleasable, totalReleased };
+    };
+
+    // check native token first
+    const { totalReleasable: nativeReleasable, totalReleased: nativeReleased } = await checkReleasableAndReleased(true);
+
+    if (nativeReleasable > 0n) {
+      return {
+        contestAddress,
+        chain: contestChainName,
+        token: {
+          symbol: chain.nativeCurrency.symbol,
+          value: formatBalance(formatUnits(nativeReleasable, chain.nativeCurrency.decimals).toString()),
+        },
+        winners: winners.length,
+        numberOfTokens: 1,
+        rewardsPaidOut: false,
+      };
+    }
+
+    if (nativeReleased > 0n) {
+      return {
+        contestAddress,
+        chain: contestChainName,
+        token: null,
+        winners: winners.length,
+        numberOfTokens: 1,
+        rewardsPaidOut: true,
+      };
+    }
+
+    // 0check ERC20 tokens
+    for (const tokenAddress of erc20TokenAddresses) {
+      const { totalReleasable: erc20Releasable, totalReleased: erc20Released } = await checkReleasableAndReleased(
+        false,
+        tokenAddress,
+      );
+
+      if (erc20Releasable > 0n) {
+        const tokenDetails = await getTokenDetails(tokenAddress, chain.id);
+        return {
+          contestAddress,
+          chain: contestChainName,
+          token: {
+            symbol: tokenDetails.symbol ?? "",
+            value: formatBalance(formatUnits(erc20Releasable, tokenDetails.decimals).toString()),
+          },
+          winners: winners.length,
+          numberOfTokens: erc20TokenAddresses.length,
+          rewardsPaidOut: false,
+        };
+      }
+
+      if (erc20Released > 0n) {
+        return {
+          contestAddress,
+          chain: contestChainName,
+          token: null,
+          winners: winners.length,
+          numberOfTokens: erc20TokenAddresses.length,
+          rewardsPaidOut: true,
+        };
+      }
+    }
+
+    return null;
+  } catch (error) {
+    console.error("Error:", error);
+    return null;
+  }
+}

--- a/packages/react-app-revamp/lib/contests/index.ts
+++ b/packages/react-app-revamp/lib/contests/index.ts
@@ -2,9 +2,9 @@ import { isSupabaseConfigured } from "@helpers/database";
 import getPagination from "@helpers/getPagination";
 import { SearchOptions } from "types/search";
 import { FEATURED_CONTEST_COLUMNS } from "./constants";
-import { Contest } from "./types";
+import { Contest, ContestReward } from "./types";
 import { sortContests } from "./utils/sortContests";
-import { streamProcessItems } from "./utils/streamItems";
+import { streamProcessItems, streamPromiseResults } from "./utils/streamItems";
 import { EMPTY_HASH, getContestTitleAndState, processContestRewardsData } from "./contracts";
 
 export const ITEMS_PER_PAGE = 7;

--- a/packages/react-app-revamp/lib/contests/index.ts
+++ b/packages/react-app-revamp/lib/contests/index.ts
@@ -1,146 +1,15 @@
-import { chains, config } from "@config/wagmi";
 import { isSupabaseConfigured } from "@helpers/database";
-import getContestContractVersion from "@helpers/getContestContractVersion";
 import getPagination from "@helpers/getPagination";
-import getRewardsModuleContractVersion from "@helpers/getRewardsModuleContractVersion";
-import { getBalance, readContract, readContracts } from "@wagmi/core";
-import { getTokenAddresses } from "lib/rewards";
-import moment from "moment";
 import { SearchOptions } from "types/search";
-import { Abi, erc20Abi, formatUnits } from "viem";
+import { FEATURED_CONTEST_COLUMNS } from "./constants";
+import { Contest } from "./types";
 import { sortContests } from "./utils/sortContests";
-import { formatBalance } from "@helpers/formatBalance";
-import { ContestStateEnum } from "@hooks/useContestState/store";
+import { streamProcessItems } from "./utils/streamItems";
+import { EMPTY_HASH, getContestTitleAndState, processContestRewardsData } from "./contracts";
 
 export const ITEMS_PER_PAGE = 7;
 
-export const EMPTY_HASH = "0x0000000000000000000000000000000000000000000000000000000000000000";
-export const EMPTY_ADDRESS = "0x0000000000000000000000000000000000000000";
-
-export interface ContestReward {
-  contestAddress: string;
-  chain: string;
-  token: {
-    symbol: string;
-    value: string;
-  } | null;
-  winners: number;
-  numberOfTokens: number;
-  rewardsPaidOut: boolean;
-}
-
-export interface Contest {
-  created_at: string;
-  start_at: string | null;
-  end_at: string | null;
-  address: string | null;
-  author_address: string | null;
-  network_name: string | null;
-  vote_start_at: string | null;
-  featured: boolean | null;
-  title: string | null;
-  type: string | null;
-  votingMerkleRoot: string | null;
-  submissionMerkleRoot: string | null;
-  hidden: boolean;
-  voting_requirements: Record<string, any> | null;
-  submission_requirements: Record<string, any> | null;
-  cost_to_propose: number | null;
-  percentage_to_propose: number | null;
-  cost_to_vote: number | null;
-  isCanceled: boolean;
-}
-
-export async function getContestTitle(contestAddress: string, networkName: string) {
-  const chainId = chains.find(c => c.name.toLowerCase() === networkName.toLowerCase())?.id;
-  if (!chainId) return null;
-
-  try {
-    const contractConfig = await getContractConfig(contestAddress, chainId);
-    if (!contractConfig) {
-      return null;
-    }
-
-    const title = (await readContract(config, {
-      ...contractConfig,
-      functionName: "name",
-      args: [],
-    })) as string;
-
-    return title;
-  } catch (error) {
-    console.error("Error fetching contest title:", error);
-    return null;
-  }
-}
-
-async function getContractConfig(address: string, chainId: number) {
-  const { abi } = await getContestContractVersion(address, chainId);
-
-  if (abi === null) {
-    return;
-  }
-
-  const contractConfig = {
-    address: address as `0x${string}`,
-    abi: abi as any,
-    chainId: chainId,
-  };
-
-  return contractConfig;
-}
-
-async function checkIfContestIsCanceled(contestAddress: string, networkName: string): Promise<boolean> {
-  const chainId = chains.find(c => c.name.toLowerCase() === networkName.toLowerCase())?.id;
-  if (!chainId) return false;
-
-  try {
-    const contractConfig = await getContractConfig(contestAddress, chainId);
-    if (!contractConfig) {
-      return false;
-    }
-
-    const state = await readContract(config, {
-      ...contractConfig,
-      functionName: "state",
-      args: [],
-    });
-
-    return state === ContestStateEnum.Canceled;
-  } catch (error) {
-    console.error("Error checking if contest is canceled:", error);
-    return false;
-  }
-}
-
-export const fetchNativeBalance = async (contestRewardModuleAddress: string, chainId: number) => {
-  try {
-    const nativeBalance = await getBalance(config, {
-      address: contestRewardModuleAddress as `0x${string}`,
-      chainId: chainId,
-    });
-    return nativeBalance;
-  } catch (error) {
-    console.error("Error fetching native balance:", error);
-    return null;
-  }
-};
-
-export const fetchFirstToken = async (contestRewardModuleAddress: string, chainId: number, tokenAddress: string) => {
-  try {
-    const firstToken = await getBalance(config, {
-      address: contestRewardModuleAddress as `0x${string}`,
-      chainId: chainId,
-      token: tokenAddress as `0x${string}`,
-    });
-    return firstToken;
-  } catch (error) {
-    console.error("Error fetching first token balance:", error);
-    return null;
-  }
-};
-
-const fetchParticipantData = async (contestAddress: string, userAddress: string, networkName: string) => {
+async function fetchParticipantData(contestAddress: string, userAddress: string, networkName: string) {
   const config = await import("@config/supabase");
   const supabase = config.supabase;
 
@@ -152,9 +21,9 @@ const fetchParticipantData = async (contestAddress: string, userAddress: string,
     .eq("network_name", networkName);
 
   return data && data.length > 0 ? data[0] : null;
-};
+}
 
-const updateContestWithUserQualifications = async (contest: any, userAddress: string) => {
+async function updateContestWithUserQualifications(contest: any, userAddress: string) {
   const { submissionMerkleRoot, network_name, address, votingMerkleRoot } = contest;
   const anyoneCanSubmit = submissionMerkleRoot === EMPTY_HASH;
   const anyoneCanVote = votingMerkleRoot === EMPTY_HASH;
@@ -174,173 +43,9 @@ const updateContestWithUserQualifications = async (contest: any, userAddress: st
   };
 
   return updatedContest;
-};
-
-async function getTokenDetails(tokenAddress: string, chainId: number) {
-  try {
-    const result = await readContracts(config, {
-      contracts: [
-        {
-          address: tokenAddress as `0x${string}`,
-          abi: erc20Abi,
-          functionName: "symbol",
-          chainId,
-        },
-        {
-          address: tokenAddress as `0x${string}`,
-          abi: erc20Abi,
-          functionName: "decimals",
-          chainId,
-        },
-      ],
-    });
-
-    return {
-      symbol: result[0].result as string,
-      decimals: result[1].result as number,
-    };
-  } catch (error) {
-    console.error("Error fetching token details:", error);
-    return { symbol: "Unknown", decimals: 18 };
-  }
 }
 
-const processContestRewardsData = async (
-  contestAddress: string,
-  contestChainName: string,
-): Promise<ContestReward | null> => {
-  try {
-    const chain = chains.find(
-      c => c.name.replace(/\s+/g, "").toLowerCase() === contestChainName.replace(/\s+/g, "").toLowerCase(),
-    );
-    if (!chain) throw new Error("Chain not found");
-
-    const contractConfig = await getContractConfig(contestAddress, chain.id);
-    if (!contractConfig || !contractConfig.abi?.some((el: { name: string }) => el.name === "officialRewardsModule")) {
-      return null;
-    }
-
-    const rewardsModuleAddress = (await readContract(config, {
-      ...contractConfig,
-      functionName: "officialRewardsModule",
-      args: [],
-    })) as string;
-
-    if (rewardsModuleAddress === EMPTY_ADDRESS || rewardsModuleAddress === EMPTY_HASH) return null;
-
-    const abiRewardsModule = await getRewardsModuleContractVersion(rewardsModuleAddress, chain.id);
-    if (!abiRewardsModule) return null;
-
-    const [winners, erc20TokenAddresses] = await Promise.all([
-      readContract(config, {
-        address: rewardsModuleAddress as `0x${string}`,
-        abi: abiRewardsModule,
-        chainId: chain.id,
-        functionName: "getPayees",
-      }) as Promise<bigint[]>,
-      getTokenAddresses(rewardsModuleAddress, contestChainName),
-    ]);
-
-    if (!winners.length) return null;
-
-    const checkReleasableAndReleased = async (isNative: boolean, tokenAddress?: string) => {
-      const [releasableAmounts, releasedAmounts] = await Promise.all([
-        readContracts(config, {
-          contracts: winners.map(ranking => ({
-            address: rewardsModuleAddress as `0x${string}`,
-            abi: abiRewardsModule as Abi,
-            chainId: chain.id,
-            functionName: "releasable",
-            args: isNative ? [ranking] : [tokenAddress, ranking],
-          })),
-        }),
-        readContracts(config, {
-          contracts: winners.map(ranking => ({
-            address: rewardsModuleAddress as `0x${string}`,
-            abi: abiRewardsModule as Abi,
-            chainId: chain.id,
-            functionName: isNative ? "released" : "erc20Released",
-            args: isNative ? [ranking] : [tokenAddress, ranking],
-          })),
-        }),
-      ]);
-
-      const totalReleasable = releasableAmounts.reduce((sum, amount) => sum + BigInt(amount.result as string), 0n);
-      const totalReleased = releasedAmounts.reduce((sum, amount) => sum + BigInt(amount.result as string), 0n);
-
-      return { totalReleasable, totalReleased };
-    };
-
-    // check native token first
-    const { totalReleasable: nativeReleasable, totalReleased: nativeReleased } = await checkReleasableAndReleased(true);
-
-    if (nativeReleasable > 0n) {
-      return {
-        contestAddress,
-        chain: contestChainName,
-        token: {
-          symbol: chain.nativeCurrency.symbol,
-          value: formatBalance(formatUnits(nativeReleasable, chain.nativeCurrency.decimals).toString()),
-        },
-        winners: winners.length,
-        numberOfTokens: 1,
-        rewardsPaidOut: false,
-      };
-    }
-
-    if (nativeReleased > 0n) {
-      return {
-        contestAddress,
-        chain: contestChainName,
-        token: null,
-        winners: winners.length,
-        numberOfTokens: 1,
-        rewardsPaidOut: true,
-      };
-    }
-
-    // 0check ERC20 tokens
-    for (const tokenAddress of erc20TokenAddresses) {
-      const { totalReleasable: erc20Releasable, totalReleased: erc20Released } = await checkReleasableAndReleased(
-        false,
-        tokenAddress,
-      );
-
-      if (erc20Releasable > 0n) {
-        const tokenDetails = await getTokenDetails(tokenAddress, chain.id);
-        return {
-          contestAddress,
-          chain: contestChainName,
-          token: {
-            symbol: tokenDetails.symbol ?? "",
-            value: formatBalance(formatUnits(erc20Releasable, tokenDetails.decimals).toString()),
-          },
-          winners: winners.length,
-          numberOfTokens: erc20TokenAddresses.length,
-          rewardsPaidOut: false,
-        };
-      }
-
-      if (erc20Released > 0n) {
-        return {
-          contestAddress,
-          chain: contestChainName,
-          token: null,
-          winners: winners.length,
-          numberOfTokens: erc20TokenAddresses.length,
-          rewardsPaidOut: true,
-        };
-      }
-    }
-
-    return null;
-  } catch (error) {
-    console.error("Error:", error);
-    return null;
-  }
-};
-
-const processContestQualifications = async (contest: any, userAddress: string) => {
+async function processContestQualifications(contest: any, userAddress: string) {
   try {
     return await updateContestWithUserQualifications(contest, userAddress);
   } catch (error) {
@@ -352,7 +57,7 @@ const processContestQualifications = async (contest: any, userAddress: string) =
       qualifiedToSubmit: false,
     };
   }
-};
+}
 
 // Search for contests based on the search options provided, table is contests by default and column is title by default
 export async function searchContests(options: SearchOptions = {}, userAddress?: string, sortBy?: string) {
@@ -400,11 +105,11 @@ export async function searchContests(options: SearchOptions = {}, userAddress?: 
 
       const processedData = await Promise.all(
         data.map(async contest => {
-          const title = await getContestTitle(contest.address, contest.network_name);
+          const { title, isCanceled } = await getContestTitleAndState(contest.address, contest.network_name);
           const processedContest = await processContestQualifications({ ...contest, title }, userAddress ?? "");
           return {
             ...processedContest,
-            isCanceled: await checkIfContestIsCanceled(processedContest.address, processedContest.network_name),
+            isCanceled,
           };
         }),
       );
@@ -469,11 +174,11 @@ export async function getUserContests(
 
       const processedData = await Promise.all(
         data.map(async contest => {
-          const title = await getContestTitle(contest.address, contest.network_name);
+          const { title, isCanceled } = await getContestTitleAndState(contest.address, contest.network_name);
           const processedContest = await processContestQualifications({ ...contest, title }, currentUserAddress);
           return {
             ...processedContest,
-            isCanceled: await checkIfContestIsCanceled(processedContest.address, processedContest.network_name),
+            isCanceled,
           };
         }),
       );
@@ -487,63 +192,34 @@ export async function getUserContests(
   return { data: [], count: 0 };
 }
 
-export async function getFeaturedContests(
+export async function* streamFeaturedContests(
   currentPage: number,
   itemsPerPage: number,
   userAddress?: string,
-): Promise<{ data: Contest[]; count: number | null }> {
-  if (!isSupabaseConfigured) return { data: [], count: 0 };
-
-  const config = await import("@config/supabase");
-  const { from, to } = getPagination(currentPage, itemsPerPage);
-  let processedData = [];
-
-  try {
-    const { data, count, error } = await config.supabase
-      .from("contests_v3")
-      .select(
-        "created_at, start_at, end_at, address, author_address, network_name, vote_start_at, featured, type, submissionMerkleRoot, votingMerkleRoot, voting_requirements, submission_requirements",
-        { count: "exact" },
-      )
-      .is("featured", true)
-      .range(from, to);
-
-    if (error) throw new Error(error.message);
-
-    processedData = await Promise.all(
-      data.map(async contest => {
-        const title = await getContestTitle(contest.address, contest.network_name);
-
+): AsyncGenerator<Contest, void, unknown> {
+  const contestStream = streamProcessItems<any, Contest>(
+    "contests_v3",
+    query => query.is("featured", true),
+    async contest => {
+      try {
+        const { title, isCanceled } = await getContestTitleAndState(contest.address, contest.network_name);
         const processedContest = await processContestQualifications({ ...contest, title }, userAddress ?? "");
+
         return {
           ...processedContest,
-          isCanceled: await checkIfContestIsCanceled(processedContest.address, processedContest.network_name),
+          isCanceled,
         };
-      }),
-    );
-
-    processedData.sort((a, b) => {
-      const now = moment();
-      const aIsHappening = moment(a.created_at).isBefore(now) && moment(a.end_at).isAfter(now);
-      const bIsHappening = moment(b.created_at).isBefore(now) && moment(b.end_at).isAfter(now);
-
-      // both are happening, sort by nearest end date. we could have a 'order' column in the future
-      if (aIsHappening && bIsHappening) {
-        return moment(a.end_at).diff(now) - moment(b.end_at).diff(now);
+      } catch (err) {
+        console.error(`Error processing contest ${contest.address}:`, err);
+        return null;
       }
+    },
+    { currentPage, itemsPerPage },
+    FEATURED_CONTEST_COLUMNS,
+  );
 
-      // only one is happening, it comes first
-      if (aIsHappening) return -1;
-      if (bIsHappening) return 1;
-
-      // none are happening, sort by nearest start date
-      return moment(a.created_at).diff(now) - moment(b.created_at).diff(now);
-    });
-
-    return { data: processedData, count };
-  } catch (e) {
-    console.error(e);
-    return { data: [], count: 0 };
+  for await (const contest of contestStream) {
+    yield contest;
   }
 }
 
@@ -583,11 +259,11 @@ export async function getLiveContests(
 
       const processedData = await Promise.all(
         data.map(async contest => {
-          const title = await getContestTitle(contest.address, contest.network_name);
+          const { title, isCanceled } = await getContestTitleAndState(contest.address, contest.network_name);
           const processedContest = await processContestQualifications({ ...contest, title }, userAddress ?? "");
           return {
             ...processedContest,
-            isCanceled: await checkIfContestIsCanceled(processedContest.address, processedContest.network_name),
+            isCanceled,
           };
         }),
       );
@@ -623,11 +299,11 @@ export async function getPastContests(currentPage: number, itemsPerPage: number,
 
       const processedData = await Promise.all(
         data.map(async contest => {
-          const title = await getContestTitle(contest.address, contest.network_name);
+          const { title, isCanceled } = await getContestTitleAndState(contest.address, contest.network_name);
           const processedContest = await processContestQualifications({ ...contest, title }, userAddress ?? "");
           return {
             ...processedContest,
-            isCanceled: await checkIfContestIsCanceled(processedContest.address, processedContest.network_name),
+            isCanceled,
           };
         }),
       );
@@ -677,11 +353,11 @@ export async function getUpcomingContests(
 
       const processedData = await Promise.all(
         data.map(async contest => {
-          const title = await getContestTitle(contest.address, contest.network_name);
+          const { title, isCanceled } = await getContestTitleAndState(contest.address, contest.network_name);
           const processedContest = await processContestQualifications({ ...contest, title }, userAddress ?? "");
           return {
             ...processedContest,
-            isCanceled: await checkIfContestIsCanceled(processedContest.address, processedContest.network_name),
+            isCanceled,
           };
         }),
       );

--- a/packages/react-app-revamp/lib/contests/types.ts
+++ b/packages/react-app-revamp/lib/contests/types.ts
@@ -1,0 +1,33 @@
+export interface ContestReward {
+  contestAddress: string;
+  chain: string;
+  token: {
+    symbol: string;
+    value: string;
+  } | null;
+  winners: number;
+  numberOfTokens: number;
+  rewardsPaidOut: boolean;
+}
+
+export interface Contest {
+  created_at: string;
+  start_at: string | null;
+  end_at: string | null;
+  address: string | null;
+  author_address: string | null;
+  network_name: string | null;
+  vote_start_at: string | null;
+  featured: boolean | null;
+  title: string | null;
+  type: string | null;
+  votingMerkleRoot: string | null;
+  submissionMerkleRoot: string | null;
+  hidden: boolean;
+  voting_requirements: Record<string, any> | null;
+  submission_requirements: Record<string, any> | null;
+  cost_to_propose: number | null;
+  percentage_to_propose: number | null;
+  cost_to_vote: number | null;
+  isCanceled: boolean;
+}

--- a/packages/react-app-revamp/lib/contests/utils/streamItems.ts
+++ b/packages/react-app-revamp/lib/contests/utils/streamItems.ts
@@ -1,0 +1,62 @@
+import { isSupabaseConfigured } from "@helpers/database";
+import getPagination from "@helpers/getPagination";
+
+/**
+ * Generic utility function for streaming database results with parallel processing.
+ * Processes each item as soon as it completes, yielding results one by one.
+ *
+ * @param tableName
+ * @param queryModifier
+ * @param processor
+ * @param pageOptions
+ * @param columns
+ */
+export async function* streamProcessItems<T, R>(
+  tableName: string,
+  queryModifier: (query: any) => any,
+  processor: (item: T) => Promise<R | null>,
+  pageOptions: { currentPage: number; itemsPerPage: number },
+  columns: string = "*",
+): AsyncGenerator<R, void, unknown> {
+  if (!isSupabaseConfigured) return;
+
+  const config = await import("@config/supabase");
+  const { from, to } = getPagination(pageOptions.currentPage, pageOptions.itemsPerPage);
+
+  try {
+    let query = config.supabase.from(tableName).select(columns).range(from, to);
+
+    query = queryModifier(query);
+
+    const { data, error } = await query;
+
+    if (error) throw new Error(error.message);
+    if (!data || data.length === 0) return;
+    const processPromises = data.map(item => processor(item as T));
+
+    const remaining = [...processPromises];
+    while (remaining.length > 0) {
+      try {
+        const nextPromiseIndex = await Promise.race(
+          remaining.map((promise, index) =>
+            promise
+              .then(() => index)
+              .catch(() => {
+                console.error(`Error processing an item, skipping.`);
+                return index;
+              }),
+          ),
+        );
+
+        const result = await remaining[nextPromiseIndex];
+        remaining.splice(nextPromiseIndex, 1);
+
+        if (result) yield result;
+      } catch (err) {
+        console.error("Error in streamProcessItems:", err);
+      }
+    }
+  } catch (e) {
+    console.error("Error in streamProcessItems:", e);
+  }
+}

--- a/packages/react-app-revamp/lib/user/index.tsx
+++ b/packages/react-app-revamp/lib/user/index.tsx
@@ -1,7 +1,7 @@
 import { supabase } from "@config/supabase";
 import getPagination from "@helpers/getPagination";
 import { Comment, CommentsResult, Contest, Submission, SubmissionCriteria, SubmissionsResult } from "./types";
-import { getContestTitle } from "lib/contests";
+import { getContestTitleAndState } from "lib/contests/contracts";
 
 function mergeSubmissionsWithContests(submissions: Submission[], contests: Contest[]): SubmissionsResult["data"] {
   const validsubmissions = submissions.filter(submission =>
@@ -167,7 +167,7 @@ async function getContestDetailsByAddresses(contests: { address: string; network
   try {
     const contestDetails = await Promise.all(
       contests.map(async contest => {
-        const title = await getContestTitle(contest.address, contest.network_name);
+        const { title } = await getContestTitleAndState(contest.address, contest.network_name);
         return {
           address: contest.address,
           title: title ?? "",


### PR DESCRIPTION
Closes #2820

I'm just doing some refactor for contests calls, mostly wanna optimize and set a ground for using a parallel technique where we load all contests one-by-one, this will first take effect for the featured contests (landing page), will write more technical info here soon.

In this PR we are introducing 2 functions that are responsible for streaming items one-by-one (`streamProcessItems` and `streamPromiseResults`) and it's reusable so we can use it across all other contests calls (search, live contests, past, upcoming) or even in some non-db calls by calling  `streamPromiseResults` but in this PR i would only implement it for featured contests to see how it behaves in prod and move on from there. 

Main idea is, whenever we have a batch of items that we want to load, we should load them one-by-one and in that way, render data almost instantly for a better effect on the user. Once this passes tests on the prod, we can continue and implement for all other contests calls. Additionally, i did a bit of refactor of the whole contests folder, and i split it into a database and contracts calls so it doesn't sit all into one file.
