### PR TITLE
chore: bring back react native dep

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,9 +6,6 @@
   "labels": [
     "renovate"
   ],
-  "ignoreDeps": [
-    "react-native"
-  ],
   "schedule": [
     "after 11pm every weekday",
     "before 6am every weekday",


### PR DESCRIPTION
bringing back `react-native` dependency updates after pausing them in #2107 to see if working correctly now