### PR TITLE
bugfix: prevent user from submitting invalid tweet entry

### DIFF
--- a/packages/react-app-revamp/components/_pages/DialogModalSendProposal/Desktop/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalSendProposal/Desktop/index.tsx
@@ -111,7 +111,7 @@ const DialogModalSendProposalDesktopLayout: FC<DialogModalSendProposalDesktopLay
       if (isAnyMetadataFieldEmpty()) {
         setError(
           <p className="text-negative-11 font-bold text-[12px]">
-            Please fill in all additional fields before submitting.
+            Please fill in all required fields before submitting.
           </p>,
         );
         return;

--- a/packages/react-app-revamp/components/_pages/DialogModalSendProposal/components/EntryPreviewLayout/components/TweetLayout/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalSendProposal/components/EntryPreviewLayout/components/TweetLayout/index.tsx
@@ -25,18 +25,20 @@ const DialogModalSendProposalEntryPreviewTweetLayout: FC<DialogModalSendProposal
       const match = url.match(twitterRegex);
       if (!match) {
         setIsValid(false);
+        onChange?.("");
         return;
       }
 
       const tweetId = match[2] || match[4]; // get id from either twitter.com or x.com match
       if (!tweetId) {
         setIsValid(false);
+        onChange?.("");
         return;
       }
 
       setIsValid(true);
     }, 500),
-    [],
+    [onChange],
   );
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/react-app-revamp/components/_pages/DialogModalSendProposal/components/EntryPreviewLayout/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalSendProposal/components/EntryPreviewLayout/index.tsx
@@ -27,7 +27,7 @@ const DialogModalSendProposalEntryPreviewLayout: FC<DialogModalSendProposalEntry
   handleDragLeave,
 }) => {
   const { enabledPreview, isDescriptionEnabled } = verifyEntryPreviewPrompt(entryPreviewLayout);
-  const { setInputValue, fields } = useMetadataStore();
+  const { setInputValue } = useMetadataStore();
 
   const handleMetadataFieldChange = (value: string) => {
     // always set the first input value ( index = 0 )


### PR DESCRIPTION
Closes #3778

While we had internal validation check for tweet, in case it is invalid, we didn't set it to empty string in order to activate validation in the parent components.