### PR TITLE
bugfix: fix twitter theme in title preview

### DIFF
--- a/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalLayout/Leaderboard/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalLayout/Leaderboard/index.tsx
@@ -135,7 +135,7 @@ const ProposalLayoutLeaderboard: FC<ProposalLayoutLeaderboardProps> = ({
               <>
                 <div className="animate-reveal">
                   <Interweave
-                    className="prose prose-invert inline-block w-full overflow-hidden [&_*]:text-neutral-9 max-w-[560px]"
+                    className="prose prose-invert inline-block w-full overflow-hidden [&>*:not(.not-prose)]:text-neutral-9 [&>*:not(.not-prose) *]:text-neutral-9 max-w-[560px]"
                     content={proposal.content}
                     transform={transform}
                     tagName="div"

--- a/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalLayout/Tweet/components/CustomTweet/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/components/ProposalLayout/Tweet/components/CustomTweet/index.tsx
@@ -13,7 +13,7 @@ export const Tweet = ({ id, apiUrl, fallback = <TweetSkeleton />, components, on
   }
 
   return (
-    <div className="not-prose light">
+    <div data-theme="light" className="not-prose">
       <MyTweet tweet={data} components={components} />
     </div>
   );


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/61afd76f-475c-4274-aa25-3ebdaa305ef9)

I have noticed that if you render a tweet inside a title preview contest, light theme is not applied to the tweet itself. Reason for this is, because when you expand title preview, we change color of the markdown elements to `text-neutral-9`, therefore that class was also applied to the twitter container.

Fix here was to update wrapper around entry to ignore styling on `not-prose` container which is a container around tweet.

I also updated wrapper around tweet to use `data-theme` instead of `className`, this doesn't change anything though but it's more descriptive.