### PR TITLE
bugfix: switch chain in claim rewards

### DIFF
--- a/packages/react-app-revamp/hooks/useClaimRewards/index.ts
+++ b/packages/react-app-revamp/hooks/useClaimRewards/index.ts
@@ -1,15 +1,16 @@
 import { toastLoading, toastSuccess } from "@components/UI/Toast";
 import { LoadingToastMessageType } from "@components/UI/Toast/components/Loading";
-import { config } from "@config/wagmi";
+import { chains, config } from "@config/wagmi";
 import { extractPathSegments } from "@helpers/extractPath";
 import { transform } from "@helpers/transform";
 import { useError } from "@hooks/useError";
-import { waitForTransactionReceipt, writeContract } from "@wagmi/core";
+import { switchChain, waitForTransactionReceipt, writeContract } from "@wagmi/core";
 import { updateRewardAnalytics } from "lib/analytics/rewards";
 import { ModuleType } from "lib/rewards/types";
 import { usePathname } from "next/navigation";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Abi } from "viem";
+import { useAccount } from "wagmi";
 
 interface UseClaimRewardsProps {
   contractRewardsModuleAddress: `0x${string}`;
@@ -33,6 +34,7 @@ export const useClaimRewards = ({
   moduleType,
   userAddress,
 }: UseClaimRewardsProps) => {
+  const { chainId: userChainId } = useAccount();
   const asPath = usePathname();
   const { chainName, address: contestAddress } = extractPathSegments(asPath ?? "");
   const { handleError } = useError();
@@ -59,6 +61,10 @@ export const useClaimRewards = ({
     setSuccess(payee, tokenAddress, false);
     toastLoading(`Claiming rewards...`, LoadingToastMessageType.KEEP_BROWSER_OPEN);
     const amountReleasableFormatted = transform(tokenBalance, tokenAddress, tokenDecimals);
+
+    if (userChainId && userChainId !== chainId) {
+      await switchChain(config, { chainId });
+    }
 
     try {
       const args =

--- a/packages/react-app-revamp/hooks/useClaimRewards/index.ts
+++ b/packages/react-app-revamp/hooks/useClaimRewards/index.ts
@@ -1,6 +1,6 @@
 import { toastLoading, toastSuccess } from "@components/UI/Toast";
 import { LoadingToastMessageType } from "@components/UI/Toast/components/Loading";
-import { chains, config } from "@config/wagmi";
+import { config } from "@config/wagmi";
 import { extractPathSegments } from "@helpers/extractPath";
 import { transform } from "@helpers/transform";
 import { useError } from "@hooks/useError";


### PR DESCRIPTION
I just noticed a small bug, if your wallet is connected to a different chain than a contest chain and if you try to claim rewards, we throw an error. I just added our standard technique where we switch to a contest chain with `switchChain` fn from wagmi.