### PR TITLE
bugfix: fix contest time intervals on landing page

### DIFF
--- a/packages/react-app-revamp/components/_pages/FeaturedContests/components/Contest.tsx
+++ b/packages/react-app-revamp/components/_pages/FeaturedContests/components/Contest.tsx
@@ -68,7 +68,7 @@ const FeaturedContestCard: FC<FeaturedContestCardProps> = ({ contestData, reward
     isError: isUserProfileError,
   } = useProfileData(contestData.author_address ?? "", true);
 
-  const updateInterval = useCallback(() => {
+  const getUpdateInterval = useCallback(() => {
     const now = moment();
     let nextUpdate = moment(contestData.end_at);
 
@@ -98,15 +98,13 @@ const FeaturedContestCard: FC<FeaturedContestCardProps> = ({ contestData, reward
 
     updateStatus();
 
+    const intervalTime = getUpdateInterval();
     const interval = setInterval(() => {
       updateStatus();
-      clearInterval(interval);
-      const newInterval = updateInterval();
-      setInterval(updateStatus, newInterval);
-    }, updateInterval());
+    }, intervalTime);
 
-    return () => clearInterval(interval); // Cleanup on unmount
-  }, [contestData, updateInterval]);
+    return () => clearInterval(interval);
+  }, [contestData, getUpdateInterval]);
 
   const getContestUrl = (network_name: string, address: string) => {
     return ROUTE_VIEW_CONTEST_BASE_PATH.replace("[chain]", network_name).replace("[address]", address);


### PR DESCRIPTION
I have noticed a weird bug on contests on landing page where sometimes for the contests that voting or entries are still open, it shows that it ended. Quickly i found out that i was using `setInterval` wrongly in the component.

Basically for all things react, i follow Dan Abramov blog and what he says about it - https://overreacted.io/making-setinterval-declarative-with-react-hooks/ and we are using a declarative principle now with a simpler approach (we do not need to use `useInterval` as that's complex for our case)

