### PR TITLE
bugfix: fix compare versions for entrants delete functionality

### DIFF
--- a/packages/react-app-revamp/hooks/useDeleteProposal/index.tsx
+++ b/packages/react-app-revamp/hooks/useDeleteProposal/index.tsx
@@ -14,6 +14,7 @@ import { Abi } from "viem";
 import { useAccount } from "wagmi";
 import { useDeleteProposalStore } from "./store";
 import { ContestStatus } from "@hooks/useContestStatus/store";
+import { compareVersions } from "compare-versions";
 
 export const ENTRANT_CAN_DELETE_VERSION = "5.3";
 
@@ -99,7 +100,7 @@ export function useDeleteProposal() {
   }
 
   function isEntrantCanDeleteVersion() {
-    return version === ENTRANT_CAN_DELETE_VERSION;
+    return compareVersions(version, ENTRANT_CAN_DELETE_VERSION) >= 0;
   }
 
   function canDeleteProposal(


### PR DESCRIPTION
There was a critical bug for comparing versions for entrants delete functionality, instead of using `compareVersions` package we used to compare if current version match exact `ENTRANT_CAN_DELETE_VERSION`, which resulted in entrants not seeing delete button.