### PR TITLE
bugfix: fix percentage issue in vote price when below threshold

### DIFF
--- a/packages/react-app-revamp/components/_pages/Contest/components/StickyCards/components/VotingQualifier/components/AnyoneCanVote/components/Exponential/components/Timer/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/components/StickyCards/components/VotingQualifier/components/AnyoneCanVote/components/Exponential/components/Timer/index.tsx
@@ -29,7 +29,7 @@ const VotingQualifierAnyoneCanVoteExponentialTimer: FC<VotingQualifierAnyoneCanV
     })),
   );
 
-  const { currentPercentageIncrease, isError } = useCurrentPricePercentageIncrease({
+  const { currentPricePercentageData, isError } = useCurrentPricePercentageIncrease({
     address,
     abi,
     chainId,
@@ -46,13 +46,15 @@ const VotingQualifierAnyoneCanVoteExponentialTimer: FC<VotingQualifierAnyoneCanV
     return null;
   }
 
-  if (isError) {
-    <div className="flex items-center gap-1">
-      <ArrowLongUpIcon className="w-4 h-4 text-neutral-9" />
-      <p className="text-[12px] text-neutral-9">
-        in {secondsUntilNextUpdate} {isMobile ? "sec" : "seconds"}
-      </p>
-    </div>;
+  if (isError || !currentPricePercentageData || currentPricePercentageData.isBelowThreshold) {
+    return (
+      <div className="flex items-center gap-1">
+        <ArrowLongUpIcon className="w-4 h-4 text-neutral-9" />
+        <p className="text-[12px] text-neutral-9">
+          in {secondsUntilNextUpdate} {isMobile ? "sec" : "seconds"}
+        </p>
+      </div>
+    );
   }
 
   if (isMobile) {
@@ -60,7 +62,7 @@ const VotingQualifierAnyoneCanVoteExponentialTimer: FC<VotingQualifierAnyoneCanV
       <div className="flex items-center">
         <ArrowLongUpIcon className="w-4 h-4 text-neutral-9" />
         <p className="text-[12px] text-neutral-9">
-          {currentPercentageIncrease}% in {secondsUntilNextUpdate} sec
+          {currentPricePercentageData.percentageIncrease}% in {secondsUntilNextUpdate} sec
         </p>
       </div>
     );
@@ -69,7 +71,7 @@ const VotingQualifierAnyoneCanVoteExponentialTimer: FC<VotingQualifierAnyoneCanV
   return (
     <div className="flex items-center gap-1">
       <p className="text-[12px] text-neutral-9">
-        | increases {currentPercentageIncrease}% in {secondsUntilNextUpdate} seconds
+        | increases {currentPricePercentageData.percentageIncrease}% in {secondsUntilNextUpdate} seconds
       </p>
     </div>
   );

--- a/packages/react-app-revamp/hooks/useCurrentPricePercentageIncrease/index.ts
+++ b/packages/react-app-revamp/hooks/useCurrentPricePercentageIncrease/index.ts
@@ -16,7 +16,7 @@ interface CurrentPricePercentageIncreaseParams {
 }
 
 interface CurrentPricePercentageIncreaseResponse {
-  currentPercentageIncrease: number | null;
+  currentPricePercentageData: { percentageIncrease: number; isBelowThreshold: boolean } | null;
   isLoading: boolean;
   isError: boolean;
 }
@@ -63,7 +63,7 @@ const useCurrentPricePercentageIncrease = ({
     enabled,
   });
 
-  const currentPercentageIncrease = useMemo(() => {
+  const currentPricePercentageData = useMemo(() => {
     if (!costToVote || !priceCurveMultiple || !currentPricePerVote || isMultipleLoading || isPriceLoading) {
       return null;
     }
@@ -73,14 +73,14 @@ const useCurrentPricePercentageIncrease = ({
       const multiple = Number(priceCurveMultiple);
       const costToVoteNumber = Number(formatEther(BigInt(costToVote)));
 
-      const { percentageIncrease } = calculateNextPriceAndIncreaseFromStore(
+      const { percentageIncrease, isBelowThreshold } = calculateNextPriceAndIncreaseFromStore(
         { getCurrentVotingMinute, getTotalVotingMinutes },
         currentPriceNumber,
         costToVoteNumber,
         multiple,
       );
 
-      return percentageIncrease;
+      return { percentageIncrease, isBelowThreshold };
     } catch (error) {
       return null;
     }
@@ -90,7 +90,7 @@ const useCurrentPricePercentageIncrease = ({
   const isError = isPriceError || isMultipleError;
 
   return {
-    currentPercentageIncrease,
+    currentPricePercentageData,
     isLoading,
     isError,
   };


### PR DESCRIPTION
Closes #4124 

If the percentage is below `PERCENTAGE_INCREASE_THRESHOLD` which current value is `0.1` we track it and instead of displaying percentage in the UI, we just use an up arrow.