### PR TITLE
chore: enable monetized 0 cost to enter contests

### DIFF
--- a/packages/react-app-revamp/components/ChargeLayout/components/Vote/components/TotalCharge/index.tsx
+++ b/packages/react-app-revamp/components/ChargeLayout/components/Vote/components/TotalCharge/index.tsx
@@ -34,7 +34,7 @@ const TotalCharge: React.FC<TotalChargeProps> = ({ charge: contestCharge, amount
       return;
     }
 
-    if (contestCharge.type.costToVote === 0 && contestCharge.type.costToPropose === 0) {
+    if (contestCharge.type.costToVote === 0) {
       setTotalCharge("0");
       return;
     }

--- a/packages/react-app-revamp/components/_pages/Create/hooks/useNextStep.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/hooks/useNextStep.tsx
@@ -19,13 +19,7 @@ const stepValidations: Record<StepTitle, (state: DeployContestStore, isConnected
   },
 
   [StepTitle.Monetization]: (state, isConnected) => {
-    return (
-      isConnected &&
-      !!state.charge.type.costToPropose &&
-      state.charge.type.costToPropose > 0 &&
-      !!state.charge.type.costToVote &&
-      state.charge.type.costToVote > 0
-    );
+    return isConnected && !!state.charge.type.costToVote && state.charge.type.costToVote > 0;
   },
   [StepTitle.Rules]: state => {
     return !!state.title && !!state.prompt.summarize && !!state.prompt.evaluateVoters;

--- a/packages/react-app-revamp/hooks/useContest/index.ts
+++ b/packages/react-app-revamp/hooks/useContest/index.ts
@@ -156,9 +156,6 @@ export function useContest() {
         costToVote = Number(results[12].result);
       }
 
-      console.log("results:", results);
-      console.log("results 12 result:", results[12].result);
-
       if (compareVersions(version, "4.29") >= 0) {
         creatorSplitDestination = results[14].result as string;
       }

--- a/packages/react-app-revamp/hooks/useDeployContest/index.ts
+++ b/packages/react-app-revamp/hooks/useDeployContest/index.ts
@@ -383,8 +383,9 @@ export function useDeployContest() {
     chargeType: { costToPropose: number; costToVote: number },
   ): Promise<string> {
     const chain = chains.find(c => c.id === chainId);
-    // check if either costToPropose or costToVote is 0 ( this means no monetization )
-    if (chargeType.costToPropose === 0 || chargeType.costToVote === 0) {
+
+    // check if costToVote is 0 ( this means no monetization )
+    if (chargeType.costToVote === 0) {
       return "";
     }
 


### PR DESCRIPTION
solving issue ran into with/context in #4149 

- [x] fix anywhere else that is assuming that if `costToPropose` is 0 then it's not a monetized contest