### PR TITLE
feat: add docker build and push

### DIFF
--- a/.github/workflows/nextjs_docker.yml
+++ b/.github/workflows/nextjs_docker.yml
@@ -3,7 +3,7 @@ name: nextjs-docker
 on: 
   push:
     branches:
-      - main-docker
+      - main
 
 permissions:
   packages: write
@@ -37,8 +37,8 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          push: ${{ github.ref == 'refs/heads/main-docker' }}
-          tags: ghcr.io/jk-labs-inc/jokerace:main-docker
+          push: ${{ github.ref == 'refs/heads/main' }}
+          tags: ghcr.io/jk-labs-inc/jokerace:main
           build-args: |
             NEXT_PUBLIC_SUPABASE_URL= ${{ secrets.PROD_NEXT_PUBLIC_SUPABASE_URL }}
             NEXT_PUBLIC_SUPABASE_ANON_KEY= ${{ secrets.PROD_NEXT_PUBLIC_SUPABASE_ANON_KEY }}

--- a/.github/workflows/nextjs_docker.yml
+++ b/.github/workflows/nextjs_docker.yml
@@ -1,0 +1,59 @@
+name: nextjs-docker
+
+on: 
+  push:
+    branches:
+      - main-docker
+
+permissions:
+  packages: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set short git commit SHA
+        id: vars
+        run: |
+          calculatedSha=$(git rev-parse --short ${{ github.sha }})
+          echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_ENV
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: https://ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.ref == 'refs/heads/main-docker' }}
+          tags: ghcr.io/jk-labs-inc/jokerace:main-docker
+          build-args: |
+            NEXT_PUBLIC_SUPABASE_URL= ${{ secrets.PROD_NEXT_PUBLIC_SUPABASE_URL }}
+            NEXT_PUBLIC_SUPABASE_ANON_KEY= ${{ secrets.PROD_NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+            NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID= ${{ secrets.PROD_NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}
+            NEXT_PUBLIC_R2_ACCOUNT_ID= ${{ secrets.PROD_NEXT_PUBLIC_R2_ACCOUNT_ID }}
+            NEXT_PUBLIC_R2_ACCESS_KEY_ID= ${{ secrets.PROD_NEXT_PUBLIC_R2_ACCESS_KEY_ID }}
+            NEXT_PUBLIC_R2_SECRET_ACCESS_KEY= ${{ secrets.PROD_NEXT_PUBLIC_R2_SECRET_ACCESS_KEY }}
+            NEXT_PUBLIC_MERKLE_TREES_BUCKET= ${{ secrets.PROD_NEXT_PUBLIC_MERKLE_TREES_BUCKET }}
+            NEXT_PUBLIC_IMAGE_UPLOAD_BUCKET= ${{ secrets.PROD_NEXT_PUBLIC_IMAGE_UPLOAD_BUCKET }}
+            NEXT_PUBLIC_ETHERSCAN_KEY= ${{ secrets.PROD_NEXT_PUBLIC_ETHERSCAN_KEY }}
+            NEXT_PUBLIC_QUICKNODE_SLUG= ${{ secrets.PROD_NEXT_PUBLIC_QUICKNODE_SLUG }}
+            NEXT_PUBLIC_QUICKNODE_KEY= ${{ secrets.PROD_NEXT_PUBLIC_QUICKNODE_KEY }}
+            NEXT_PUBLIC_ALCHEMY_KEY= ${{ secrets.PROD_NEXT_PUBLIC_ALCHEMY_KEY }}
+            NEXT_PUBLIC_PARA_API_KEY= ${{ secrets.PROD_NEXT_PUBLIC_PARA_API_KEY }}
+            NEXT_PUBLIC_PARA_ENVIRONMENT= ${{ secrets.PROD_NEXT_PUBLIC_PARA_ENVIRONMENT }}
+            NEXT_PUBLIC_BREVO_API_KEY= ${{ secrets.PROD_NEXT_PUBLIC_BREVO_API_KEY }}
+            NEXT_PUBLIC_CDP_PROJECT_ID= ${{ secrets.PROD_NEXT_PUBLIC_CDP_PROJECT_ID }}
+            NEXT_PUBLIC_ENVIRONMENT= ${{ secrets.PROD_NEXT_PUBLIC_ENVIRONMENT }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS base
+FROM node:22-alpine AS base
 
 FROM base AS builder
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,83 @@
+FROM node:18-alpine AS base
+
+FROM base AS builder
+
+# Install
+RUN apk add --update python3 make g++\
+   && rm -rf /var/cache/apk/*
+WORKDIR /app
+COPY . .
+
+RUN yarn --production 
+
+# Build
+# disable telemetry during the build
+ENV NEXT_TELEMETRY_DISABLED=1 
+
+ARG NEXT_PUBLIC_SUPABASE_URL
+ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
+ARG NEXT_PUBLIC_R2_ACCOUNT_ID
+ARG NEXT_PUBLIC_R2_ACCESS_KEY_ID
+ARG NEXT_PUBLIC_R2_SECRET_ACCESS_KEY
+ARG NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID
+ARG NEXT_PUBLIC_MERKLE_TREES_BUCKET
+ARG NEXT_PUBLIC_IMAGE_UPLOAD_BUCKET
+ARG NEXT_PUBLIC_ETHERSCAN_KEY
+ARG NEXT_PUBLIC_QUICKNODE_SLUG
+ARG NEXT_PUBLIC_QUICKNODE_KEY
+ARG NEXT_PUBLIC_ALCHEMY_KEY
+ARG NEXT_PUBLIC_PARA_API_KEY
+ARG NEXT_PUBLIC_PARA_ENVIRONMENT
+ARG NEXT_PUBLIC_BREVO_API_KEY
+ARG NEXT_PUBLIC_CDP_PROJECT_ID
+ARG NEXT_PUBLIC_ENVIRONMENT
+
+ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL 
+ENV NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY
+ENV NEXT_PUBLIC_R2_ACCOUNT_ID=$NEXT_PUBLIC_R2_ACCOUNT_ID
+ENV NEXT_PUBLIC_R2_ACCESS_KEY_ID=$NEXT_PUBLIC_R2_ACCESS_KEY_ID
+ENV NEXT_PUBLIC_R2_SECRET_ACCESS_KEY=$NEXT_PUBLIC_R2_SECRET_ACCESS_KEY
+ENV NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=$NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID
+ENV NEXT_PUBLIC_MERKLE_TREES_BUCKET=$NEXT_PUBLIC_MERKLE_TREES_BUCKET
+ENV NEXT_PUBLIC_IMAGE_UPLOAD_BUCKET=$NEXT_PUBLIC_IMAGE_UPLOAD_BUCKET
+ENV NEXT_PUBLIC_ETHERSCAN_KEY=$NEXT_PUBLIC_ETHERSCAN_KEY
+ENV NEXT_PUBLIC_QUICKNODE_SLUG=$NEXT_PUBLIC_QUICKNODE_SLUG
+ENV NEXT_PUBLIC_QUICKNODE_KEY=$NEXT_PUBLIC_QUICKNODE_KEY
+ENV NEXT_PUBLIC_ALCHEMY_KEY=$NEXT_PUBLIC_ALCHEMY_KEY
+ENV NEXT_PUBLIC_PARA_API_KEY=$NEXT_PUBLIC_PARA_API_KEY
+ENV NEXT_PUBLIC_PARA_ENVIRONMENT=$NEXT_PUBLIC_PARA_ENVIRONMENT
+ENV NEXT_PUBLIC_BREVO_API_KEY=$NEXT_PUBLIC_BREVO_API_KEY
+ENV NEXT_PUBLIC_CDP_PROJECT_ID=$NEXT_PUBLIC_CDP_PROJECT_ID
+ENV NEXT_PUBLIC_ENVIRONMENT=$NEXT_PUBLIC_ENVIRONMENT
+
+RUN yarn build
+
+FROM base AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+# Uncomment the following line in case you want to disable telemetry during runtime.
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# Set the correct permission for prerender cache
+RUN addgroup nodejs
+RUN adduser -SDH nextjs
+RUN mkdir .next
+RUN chown nextjs:nodejs .next
+
+# Automatically leverage output traces to reduce image size
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=builder --chown=nextjs:nodejs /app/packages/react-app-revamp/.next/standalone/packages/react-app-revamp ./ 
+COPY --from=builder --chown=nextjs:nodejs /app/packages/react-app-revamp/.next/standalone/node_modules ./node_modules
+COPY --from=builder --chown=nextjs:nodejs /app/packages/react-app-revamp/.next/static ./.next/static 
+COPY --from=builder /app/packages/react-app-revamp/public ./public 
+
+USER nextjs
+
+# Exposed port (for orchestrators and dynamic reverse proxies)
+EXPOSE 3000
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD [ "wget", "-q0", "http://localhost:3000/health" ]
+
+CMD ["node", "server.js"]

--- a/packages/react-app-revamp/next.config.js
+++ b/packages/react-app-revamp/next.config.js
@@ -25,6 +25,7 @@ const nextConfig = {
     ],
   },
   transpilePackages: ["react-tweet"],
+  output: "standalone",
 };
 
 module.exports = withPWA({


### PR DESCRIPTION
DigitalOcean has started being weird with running out of memory when building the site, and also builds have gotten really long with them, like up to 16 minutes now. So moving to building our own image and then just having DigitalOcean use that will give us a lot more control over the process, isolate DigitalOcean's role to just hosting and serving the site, and also speed up deployment time.