### PR TITLE
chore: replace react-type-animation lib with motion

### DIFF
--- a/packages/react-app-revamp/components/UI/TypewriterCycler/index.tsx
+++ b/packages/react-app-revamp/components/UI/TypewriterCycler/index.tsx
@@ -1,0 +1,48 @@
+import { delay, wrap } from "motion";
+import { Typewriter } from "motion-plus/react";
+import { useState } from "react";
+
+interface TypewriterCyclerProps {
+  words: string[];
+  as?: string;
+  delayBetweenWords?: number;
+  className?: string;
+  style?: React.CSSProperties;
+  onWordComplete?: (word: string, index: number) => void;
+}
+
+const TypewriterCycler = ({
+  words,
+  as = "span",
+  delayBetweenWords = 1,
+  className,
+  style,
+  onWordComplete,
+}: TypewriterCyclerProps) => {
+  const [wordIndex, setWordIndex] = useState(0);
+
+  const handleComplete = () => {
+    const currentWord = words[wordIndex];
+    onWordComplete?.(currentWord, wordIndex);
+
+    delay(() => {
+      setWordIndex(wrap(0, words.length, wordIndex + 1));
+    }, delayBetweenWords);
+  };
+
+  return (
+    <Typewriter
+      as={as}
+      onComplete={handleComplete}
+      className={className}
+      style={{
+        display: "inline-block",
+        ...style,
+      }}
+    >
+      {words[wordIndex]}
+    </Typewriter>
+  );
+};
+
+export default TypewriterCycler;

--- a/packages/react-app-revamp/components/_pages/Landing/components/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Landing/components/index.tsx
@@ -1,19 +1,21 @@
+"use client";
+
 import FeaturedContests from "@components/_pages/FeaturedContests";
 import CustomLink from "@components/UI/Link";
+import TypewriterCycler from "@components/UI/TypewriterCycler";
 import { ROUTE_CREATE_CONTEST, ROUTE_VIEW_LIVE_CONTESTS } from "@config/routes";
 import { isSupabaseConfigured } from "@helpers/database";
 import { ChevronRightIcon } from "@heroicons/react/24/outline";
 import { useQuery } from "@tanstack/react-query";
+import { streamFeaturedContests } from "lib/contests";
 import { CONTESTS_FEATURE_COUNT } from "lib/contests/constants";
+import { fetchTotalRewardsForContests } from "lib/contests/contracts";
 import { Contest } from "lib/contests/types";
 import moment from "moment";
 import { useState } from "react";
 import { useMediaQuery } from "react-responsive";
-import { TypeAnimation } from "react-type-animation";
 import LandingPageExplainer from "./Explainer";
 import LandingPageUsedBy from "./UsedBy";
-import { fetchTotalRewardsForContests } from "lib/contests/contracts";
-import { streamFeaturedContests } from "lib/contests";
 
 const wordConfig = {
   desktop: [
@@ -125,13 +127,7 @@ const LandingPage = () => {
           <p className="text-[28px] md:text-[48px] font-bold">
             contests for{" "}
             <span className="text-transparent bg-clip-text bg-gradient-purple inline-block">
-              <TypeAnimation
-                sequence={[...words.flatMap(word => [word, 500, "", 50])]}
-                wrapper="span"
-                speed={50}
-                style={{ display: "inline-block" }}
-                repeat={Infinity}
-              />
+              <TypewriterCycler words={words} delayBetweenWords={1} />
             </span>
           </p>
           <p className="text-[16px] md:text-[24px] font-bold">for communities to grow, run, and monetize</p>

--- a/packages/react-app-revamp/package.json
+++ b/packages/react-app-revamp/package.json
@@ -93,7 +93,6 @@
     "react-toastify": "11.0.5",
     "react-tooltip": "5.29.1",
     "react-tweet": "3.2.2",
-    "react-type-animation": "3.2.0",
     "react-use": "17.6.0",
     "react-window": "1.8.11",
     "safe-json-utils": "1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15807,11 +15807,6 @@ react-tweet@3.2.2:
     clsx "^2.0.0"
     swr "^2.2.4"
 
-react-type-animation@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/react-type-animation/-/react-type-animation-3.2.0.tgz#6863d5d60e3beb237f2bd690cceb585402c47e6a"
-  integrity sha512-WXTe0i3rRNKjmggPvT5ntye1QBt0ATGbijeW6V3cQe2W0jaMABXXlPPEdtofnS9tM7wSRHchEvI9SUw+0kUohw==
-
 react-universal-interface@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/react-universal-interface/-/react-universal-interface-0.6.2.tgz#5e8d438a01729a4dbbcbeeceb0b86be146fe2b3b"


### PR DESCRIPTION
In the latest motion updates, they introduced a `Typewriter` component that creates typewriter animations. With that update, we no longer need `react-type-animation` lib and we can remove it without adding any new one. 