### PR TITLE
bugfix: fix masonic items order

### DIFF
--- a/packages/react-app-revamp/components/_pages/ListProposals/container.tsx
+++ b/packages/react-app-revamp/components/_pages/ListProposals/container.tsx
@@ -6,10 +6,16 @@ import { useMediaQuery } from "react-responsive";
 interface ListProposalsContainerProps {
   enabledPreview: EntryPreview | null;
   children: ReactNode;
-  recalculateKey?: string | number; // Add this prop to force re-render
+  recalculateKey?: string | number;
 }
 
-const MasonicCard = ({ data, width }: { data: ReactNode; width: number }) => <div style={{ width }}>{data}</div>;
+const TitleContainer = ({ children }: { children: ReactNode }) => <div className="flex flex-col gap-4">{children}</div>;
+
+const MasonicCard = ({ data, width }: { data: ReactNode; width: number }) => (
+  <div style={{ width }} className="min-h-52">
+    {data}
+  </div>
+);
 
 const MasonicContainer = ({
   children,
@@ -37,7 +43,7 @@ const ListProposalsContainer = ({ enabledPreview, children, recalculateKey }: Li
 
   switch (enabledPreview) {
     case EntryPreview.TITLE:
-      return <MasonicContainer children={children} columnCount={1} recalculateKey={recalculateKey} />;
+      return <TitleContainer children={children} />;
 
     case EntryPreview.IMAGE:
     case EntryPreview.IMAGE_AND_TITLE:
@@ -45,7 +51,7 @@ const ListProposalsContainer = ({ enabledPreview, children, recalculateKey }: Li
       return <MasonicContainer children={children} columnCount={isMobile ? 1 : 2} recalculateKey={recalculateKey} />;
 
     default:
-      return <MasonicContainer children={children} columnCount={1} recalculateKey={recalculateKey} />;
+      return <TitleContainer children={children} />;
   }
 };
 


### PR DESCRIPTION
We had an issue where entries with a gallery format (image, image & title or tweet) would not be displayed in a sequential order but rather masonic, lib that we use for virtualized masonry grid was using an empty space to fill whatever comes next. 

By setting a minimal height for the each card, we prevent masonic from doing that as written [here](https://github.com/jaredLunde/masonic/issues/17#issuecomment-635546588) 