### PR TITLE
chore: use new clusters api

### DIFF
--- a/packages/react-app-revamp/hooks/useProfileData/index.ts
+++ b/packages/react-app-revamp/hooks/useProfileData/index.ts
@@ -18,10 +18,6 @@ interface ProfileData {
   };
 }
 
-const normalizeClusterName = (clusterName: string): string => {
-  return clusterName.split("/")[0] + "/";
-};
-
 const checkImageUrl = async (url: string): Promise<string> => {
   return new Promise((resolve, reject) => {
     const img = new Image();
@@ -81,15 +77,16 @@ const fetchProfileData = async (
       }
     } else {
       const clusterName = (await clusters.getName(ethereumAddress)).clusterName;
+
       if (clusterName) {
         try {
-          const imageUrl = getImageUrl(normalizeClusterName(clusterName).slice(0, -1));
+          const imageUrl = getImageUrl(clusterName);
 
           await checkImageUrl(imageUrl ?? DEFAULT_AVATAR_URL);
           profileAvatar = imageUrl ?? DEFAULT_AVATAR_URL;
-          profileName = normalizeClusterName(clusterName);
+          profileName = clusterName;
         } catch {
-          profileName = normalizeClusterName(clusterName);
+          profileName = clusterName;
           profileAvatar = DEFAULT_AVATAR_URL;
         }
       }
@@ -100,7 +97,7 @@ const fetchProfileData = async (
       let clusterProfileUrl = "";
 
       if (clusterName) {
-        const clusterMetadata = getProfileUrl(normalizeClusterName(clusterName));
+        const clusterMetadata = getProfileUrl(clusterName);
         clusterProfileUrl = clusterMetadata ?? "";
       }
 


### PR DESCRIPTION
<img width="374" height="256" alt="image" src="https://github.com/user-attachments/assets/8a738691-07f4-47eb-b3d8-57531e41db02" />


I have noticed that same cluster name appears on voters list multiple times, it looks like clusters are now returning it's name in a response so we do not need `normalizeClusterName` helper anymore, issue is that we were splitting text by `/` and that was returning back just `campnetwork/` instead of `campnetwork/median` 

