### PR TITLE
bugfix: fix old contests entries rendering

### DIFF
--- a/packages/react-app-revamp/app/globals.css
+++ b/packages/react-app-revamp/app/globals.css
@@ -577,7 +577,6 @@ li {
 }
 
 .interweave-container {
-  line-height: 0 !important;
   width: 100%;
   max-width: 100%;
 }


### PR DESCRIPTION
I have noticed for the classic view (before we implemented leaderboard and gallery views) text isn't rendering, you can see example [here](https://www.jokerace.io/contest/polygon/0x4dbfe924158e3686620266c16f9da9b9eda624b6)

This was because of the `interweave-container` class and it was likely due to tailwind update as i was running `$ npx @tailwindcss/upgrade` back then to update styles.