### PR TITLE
chore: rm deprecated versions

### DIFF
--- a/packages/react-app-revamp/helpers/getContestContractVersion.ts
+++ b/packages/react-app-revamp/helpers/getContestContractVersion.ts
@@ -1,31 +1,4 @@
 import { serverConfig } from "@config/wagmi/server";
-import LegacyDeployedContestContract from "@contracts/bytecodeAndAbi/Contest.2.1.pre-prompt.sol/Contest.json";
-import BetterRewardsNotesContract from "@contracts/bytecodeAndAbi/Contest.2.10.betterRewardsNotes.sol/Contest.json";
-import PromptDeployedContestContract from "@contracts/bytecodeAndAbi/Contest.2.2.prompt.sol/Contest.json";
-import AllProposalTotalVotesDeployedContestContract from "@contracts/bytecodeAndAbi/Contest.2.3.allProposalTotalVotes.sol/Contest.json";
-import ProposalVotesDownvotesContract from "@contracts/bytecodeAndAbi/Contest.2.4.proposalVotesDownvotes.sol/Contest.json";
-import SubmissionTokenGatingContract from "@contracts/bytecodeAndAbi/Contest.2.5.submissionTokenGating.sol/Contest.json";
-import RewardsContract from "@contracts/bytecodeAndAbi/Contest.2.6.rewards.sol/Contest.json";
-import NumberedVersioningContract from "@contracts/bytecodeAndAbi/Contest.2.8.numberedVersioning.sol/Contest.json";
-import GateSubmissionsOpenContract from "@contracts/bytecodeAndAbi/Contest.2.9.gateSubmissionsOpen.sol/Contest.json";
-import MerkleVotesContract from "@contracts/bytecodeAndAbi/Contest.3.1.merkleVotes.sol/Contest.json";
-import CantVoteOnDeletedContract from "@contracts/bytecodeAndAbi/Contest.3.10.cantVoteOnDeletedProps.sol/Contest.json";
-import AuditMinorFixesContract from "@contracts/bytecodeAndAbi/Contest.3.11.auditMinorFixes.sol/Contest.json";
-import AuditInfoAndOptimizationsContract from "@contracts/bytecodeAndAbi/Contest.3.12.auditInfoAndOptimizations.sol/Contest.json";
-import CleanUpContractDocsContract from "@contracts/bytecodeAndAbi/Contest.3.13.cleanUpContractDocs.sol/Contest.json";
-import TrackProposalAuthorsContract from "@contracts/bytecodeAndAbi/Contest.3.14.trackProposalAuthors.sol/Contest.json";
-import TrackVotersContract from "@contracts/bytecodeAndAbi/Contest.3.15.trackVoters.sol/Contest.json";
-import MakeVarsPublicContract from "@contracts/bytecodeAndAbi/Contest.3.16.makeVarsPublic.sol/Contest.json";
-import LetJkLabsCancelContract from "@contracts/bytecodeAndAbi/Contest.3.17.letJkLabsCancel.sol/Contest.json";
-import AddJokeraceCreatedEventContract from "@contracts/bytecodeAndAbi/Contest.3.18.addJokeraceCreatedEvent.sol/Contest.json";
-import TotalVotesCastContract from "@contracts/bytecodeAndAbi/Contest.3.2.totalVotesCast.sol/Contest.json";
-import SetCompilerContract from "@contracts/bytecodeAndAbi/Contest.3.3.setCompilerTo8Dot19.sol/Contest.json";
-import AddIsDeletedContract from "@contracts/bytecodeAndAbi/Contest.3.4.addIsDeleted.sol/Contest.json";
-import DeletedDontHitLimitContract from "@contracts/bytecodeAndAbi/Contest.3.5.deletedDontHitLimit.sol/Contest.json";
-import BringBackDeletedIdsContract from "@contracts/bytecodeAndAbi/Contest.3.6.bringBackDeletedIds.sol/Contest.json";
-import ArrayOfDeletedIdsContract from "@contracts/bytecodeAndAbi/Contest.3.7.makeArrayOfDeletedIds.sol/Contest.json";
-import DeletedIdAccessorContract from "@contracts/bytecodeAndAbi/Contest.3.8.makeDeletedIdAccessor.sol/Contest.json";
-import PrivateDeletedIdsContract from "@contracts/bytecodeAndAbi/Contest.3.9.privateDeletedIds.sol/Contest.json";
 import AddEntryChargeContract from "@contracts/bytecodeAndAbi/Contest.4.1.addEntryCharge.sol/Contest.json";
 import RmImmutableKeywordContract from "@contracts/bytecodeAndAbi/Contest.4.10.rmImmutableKeyword.sol/Contest.json";
 import GasOptimizeGettersContract from "@contracts/bytecodeAndAbi/Contest.4.11.gasOptimizeGetters.sol/Contest.json";
@@ -83,7 +56,8 @@ export async function getContestContractVersion(address: string, chainId: number
   try {
     const provider = getEthersProvider(serverConfig, { chainId });
 
-    const contract = new ethers.Contract(address, NumberedVersioningContract.abi, provider);
+    // Get earliest ABI just so we can call VERSION() to start, since we know all ABIs will have that function
+    const contract = new ethers.Contract(address, AddEntryChargeContract.abi, provider);
 
     // Here we check if all RPC calls are successful, otherwise we throw an error and return empty ABI
     const version: string = await executeWithTimeout(MAX_TIME_TO_WAIT_FOR_RPC, contract.version());
@@ -185,69 +159,9 @@ export async function getContestContractVersion(address: string, chainId: number
       return { abi: UpdateSortingAlgoContract.abi, version };
     } else if (version === "4.1") {
       return { abi: AddEntryChargeContract.abi, version };
-    } else if (version === "3.18") {
-      return { abi: AddJokeraceCreatedEventContract.abi, version };
-    } else if (version === "3.17") {
-      return { abi: LetJkLabsCancelContract.abi, version };
-    } else if (version === "3.16") {
-      return { abi: MakeVarsPublicContract.abi, version };
-    } else if (version === "3.15") {
-      return { abi: TrackVotersContract.abi, version };
-    } else if (version === "3.14") {
-      return { abi: TrackProposalAuthorsContract.abi, version };
-    } else if (version === "3.13") {
-      return { abi: CleanUpContractDocsContract.abi, version };
-    } else if (version === "3.12") {
-      return { abi: AuditInfoAndOptimizationsContract.abi, version };
-    } else if (version === "3.11") {
-      return { abi: AuditMinorFixesContract.abi, version };
-    } else if (version === "3.10") {
-      return { abi: CantVoteOnDeletedContract.abi, version };
-    } else if (version === "3.9") {
-      return { abi: PrivateDeletedIdsContract.abi, version };
-    } else if (version === "3.8") {
-      return { abi: DeletedIdAccessorContract.abi, version };
-    } else if (version === "3.7") {
-      return { abi: ArrayOfDeletedIdsContract.abi, version };
-    } else if (version === "3.6") {
-      return { abi: BringBackDeletedIdsContract.abi, version };
-    } else if (version === "3.5") {
-      return { abi: DeletedDontHitLimitContract.abi, version };
-    } else if (version === "3.4") {
-      return { abi: AddIsDeletedContract.abi, version };
-    } else if (version === "3.3") {
-      return { abi: SetCompilerContract.abi, version };
-    } else if (version === "3.2") {
-      return { abi: TotalVotesCastContract.abi, version };
-    } else if (version === "3.1") {
-      return { abi: MerkleVotesContract.abi, version };
-    } else if (version === "2.10") {
-      return { abi: BetterRewardsNotesContract.abi, version };
-    } else if (version === "2.9") {
-      return { abi: GateSubmissionsOpenContract.abi, version };
-    } else if (version === "2.8") {
-      return { abi: NumberedVersioningContract.abi, version };
+    } else {
+      return { abi: DeployedContestContract.abi, version };
     }
-
-    if (version === "1") {
-      const bytecode = await provider.getCode(address);
-      if (bytecode.length <= 2) return defaultReturn;
-      if (!bytecode.includes(id("prompt()").slice(2, 10))) {
-        return { abi: LegacyDeployedContestContract.abi, version };
-      } else if (!bytecode.includes(id("allProposalTotalVotes()").slice(2, 10))) {
-        return { abi: PromptDeployedContestContract.abi, version };
-      } else if (!bytecode.includes(id("downvotingAllowed()").slice(2, 10))) {
-        return { abi: AllProposalTotalVotesDeployedContestContract.abi, version };
-      } else if (!bytecode.includes(id("submissionGatingByVotingToken()").slice(2, 10))) {
-        return { abi: ProposalVotesDownvotesContract.abi, version };
-      } else if (!bytecode.includes(id("officialRewardsModule()").slice(2, 10))) {
-        return { abi: SubmissionTokenGatingContract.abi, version };
-      } else {
-        return { abi: RewardsContract.abi, version };
-      }
-    }
-
-    return { abi: DeployedContestContract.abi, version };
   } catch (error: unknown) {
     console.error(`Error while fetching the contract version for address ${address} on chainId ${chainId}:`, error);
     return { abi: null, version: "error" };

--- a/packages/react-app-revamp/helpers/getRewardsModuleContractVersion.ts
+++ b/packages/react-app-revamp/helpers/getRewardsModuleContractVersion.ts
@@ -1,26 +1,4 @@
 import { config } from "@config/wagmi";
-import LegacyDeployedRewardsModuleContract from "@contracts/bytecodeAndAbi/modules/RewardsModule.2.1.first.sol/RewardsModule.json";
-import NumberedVersioningRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.2.3.numberedVersioning.sol/RewardsModule.json";
-import GateSubmissionsOpenRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.2.4.gateSubmissionsOpen.sol/RewardsModule.json";
-import BetterRewardsNotesRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.2.5.betterRewardsNotes.sol/RewardsModule.json";
-import MerkleVotesRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.3.1.merkleVotes.sol/RewardsModule.json";
-import CantVoteOnDeletedPropsRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.3.10.cantVoteOnDeletedProps.sol/RewardsModule.json";
-import AuditMinorFixesRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.3.11.auditMinorFixes.sol/RewardsModule.json";
-import AuditInfoAndOptimizationsRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.3.12.auditInfoAndOptimizations.sol/RewardsModule.json";
-import CleanUpContractDocsRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.3.13.cleanUpContractDocs.sol/RewardsModule.json";
-import TrackProposalAuthorsRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.3.14.trackProposalAuthors.sol/RewardsModule.json";
-import TrackVotersRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.3.15.trackVoters.sol/RewardsModule.json";
-import MakeVarsPublicRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.3.16.makeVarsPublic.sol/RewardsModule.json";
-import LetJkLabsCancelRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.3.17.letJkLabsCancel.sol/RewardsModule.json";
-import AddJokeraceCreatedEventRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.3.18.addJokeraceCreatedEvent.sol/RewardsModule.json";
-import TotalVotesCastRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.3.2.totalVotesCast.sol/RewardsModule.json";
-import SetCompilerRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.3.3.setCompilerTo8Dot19.sol/RewardsModule.json";
-import AddIsDeletedRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.3.4.addIsDeleted.sol/RewardsModule.json";
-import DeletedDontHitLimitRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.3.5.deletedDontHitLimit.sol/RewardsModule.json";
-import BringBackDeletedIdsRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.3.6.bringBackDeletedIds.sol/RewardsModule.json";
-import ArrayOfDeletedIdsRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.3.7.makeArrayOfDeletedIds.sol/RewardsModule.json";
-import DeletedIdAccessorRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.3.8.makeDeletedIdAccessor.sol/RewardsModule.json";
-import PrivateDeletedIdsRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.3.9.privateDeletedIds.sol/RewardsModule.json";
 import AddEntryChargeRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.4.1.addEntryCharge.sol/RewardsModule.json";
 import RmImmutableKeywordRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.4.10.rmImmutableKeyword.sol/RewardsModule.json";
 import GasOptimizeGettersRewards from "@contracts/bytecodeAndAbi/modules/RewardsModule.4.11.gasOptimizeGetters.sol/RewardsModule.json";
@@ -76,7 +54,7 @@ import { executeWithTimeout, MAX_TIME_TO_WAIT_FOR_RPC } from "./timeout";
 
 export async function getRewardsModuleContractVersion(address: string, chainId: number) {
   const provider = getEthersProvider(config, { chainId });
-  const contract = new ethers.Contract(address, NumberedVersioningRewards.abi, provider);
+  const contract = new ethers.Contract(address, AddEntryChargeRewards.abi, provider);
 
   try {
     const version: string = await executeWithTimeout(MAX_TIME_TO_WAIT_FOR_RPC, contract.version());
@@ -177,56 +155,12 @@ export async function getRewardsModuleContractVersion(address: string, chainId: 
       return { abi: UpdateSortingAlgoRewards.abi, version };
     } else if (version === "4.1") {
       return { abi: AddEntryChargeRewards.abi, version };
-    } else if (version === "3.18") {
-      return { abi: AddJokeraceCreatedEventRewards.abi, version };
-    } else if (version === "3.17") {
-      return { abi: LetJkLabsCancelRewards.abi, version };
-    } else if (version === "3.16") {
-      return { abi: MakeVarsPublicRewards.abi, version };
-    } else if (version === "3.15") {
-      return { abi: TrackVotersRewards.abi, version };
-    } else if (version === "3.14") {
-      return { abi: TrackProposalAuthorsRewards.abi, version };
-    } else if (version === "3.13") {
-      return { abi: CleanUpContractDocsRewards.abi, version };
-    } else if (version === "3.12") {
-      return { abi: AuditInfoAndOptimizationsRewards.abi, version };
-    } else if (version === "3.11") {
-      return { abi: AuditMinorFixesRewards.abi, version };
-    } else if (version === "3.10") {
-      return { abi: CantVoteOnDeletedPropsRewards.abi, version };
-    } else if (version === "3.9") {
-      return { abi: PrivateDeletedIdsRewards.abi, version };
-    } else if (version === "3.8") {
-      return { abi: DeletedIdAccessorRewards.abi, version };
-    } else if (version === "3.7") {
-      return { abi: ArrayOfDeletedIdsRewards.abi, version };
-    } else if (version === "3.6") {
-      return { abi: BringBackDeletedIdsRewards.abi, version };
-    } else if (version === "3.5") {
-      return { abi: DeletedDontHitLimitRewards.abi, version };
-    } else if (version === "3.4") {
-      return { abi: AddIsDeletedRewards.abi, version };
-    } else if (version === "3.3") {
-      return { abi: SetCompilerRewards.abi, version };
-    } else if (version === "3.2") {
-      return { abi: TotalVotesCastRewards.abi, version };
-    } else if (version === "3.1") {
-      return { abi: MerkleVotesRewards.abi, version };
-    } else if (version === "2.5") {
-      return { abi: BetterRewardsNotesRewards.abi, version };
-    } else if (version === "2.4") {
-      return { abi: GateSubmissionsOpenRewards.abi, version };
-    } else if (version === "2.3") {
-      return { abi: NumberedVersioningRewards.abi, version };
-    } else if (version === "1") {
-      return { abi: LegacyDeployedRewardsModuleContract.abi, version };
     } else {
       return { abi: DeployedRewardsContract.abi, version };
     }
   } catch (error) {
-    // If the version method does not exist, use the legacy ABI
-    return { abi: LegacyDeployedRewardsModuleContract.abi, version: "1" };
+    // If the version method does not exist, use the oldest ABI
+    return { abi: AddEntryChargeRewards.abi, version: "1" };
   }
 }
 


### PR DESCRIPTION
we deprecated support for v4 contests in #4331, this is just wrapping up by removing them from the versioning logic too.