### PR TITLE
chore: switch over to quicknode where we can

### DIFF
--- a/packages/react-app-revamp/config/wagmi/custom-chains/abstract.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/abstract.ts
@@ -10,8 +10,8 @@ export const abstract: Chain = {
     symbol: "ETH",
   },
   rpcUrls: {
-    public: { http: ["https://api.mainnet.abs.xyz"] },
-    default: { http: ["https://api.mainnet.abs.xyz"] },
+    public: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.abstract-mainnet.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
+    default: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.abstract-mainnet.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
   },
   blockExplorers: {
     etherscan: { name: "Abstract Mainnet Scan", url: "https://abscan.org/" },

--- a/packages/react-app-revamp/config/wagmi/custom-chains/berachain.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/berachain.ts
@@ -10,12 +10,8 @@ export const berachain: Chain = {
     symbol: "BERA",
   },
   rpcUrls: {
-    public: {
-      http: [ "https://rpc.berachain.com/" ],
-    },
-    default: {
-      http: [ "https://rpc.berachain.com/" ],
-    },
+    public: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.bera-mainnet.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
+    default: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.bera-mainnet.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
   },
   blockExplorers: {
     etherscan: { name: "Berachain Mainnet Scan", url: "https://berascan.com/" },

--- a/packages/react-app-revamp/config/wagmi/custom-chains/celo.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/celo.ts
@@ -10,12 +10,8 @@ export const celo: Chain = {
     symbol: "CELO",
   },
   rpcUrls: {
-    public: {
-      http: ["https://forno.celo.org"],
-    },
-    default: {
-      http: ["https://forno.celo.org"],
-    },
+    public: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.celo-mainnet.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
+    default: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.celo-mainnet.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
   },
   blockExplorers: {
     etherscan: { name: "Celo Block Explorer", url: "https://celoscan.io/" },

--- a/packages/react-app-revamp/config/wagmi/custom-chains/cyber.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/cyber.ts
@@ -10,12 +10,8 @@ export const cyber: Chain = {
     symbol: "ETH",
   },
   rpcUrls: {
-    public: {
-      http: ["https://cyber.alt.technology/"],
-    },
-    default: {
-      http: ["https://cyber.alt.technology/"],
-    },
+    public: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.cyber-mainnet.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
+    default: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.cyber-mainnet.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
   },
   blockExplorers: {
     etherscan: { name: "Cyber Block Explorer", url: "https://cyber-explorer.alt.technology/" },

--- a/packages/react-app-revamp/config/wagmi/custom-chains/gnosis.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/gnosis.ts
@@ -10,12 +10,8 @@ export const gnosis: Chain = {
     symbol: "xDAI",
   },
   rpcUrls: {
-    public: {
-      http: ["https://rpc.gnosischain.com"],
-    },
-    default: {
-      http: ["https://rpc.gnosischain.com"],
-    },
+    public: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.xdai.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
+    default: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.xdai.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
   },
   blockExplorers: {
     etherscan: { name: "Gnosis Etherscan", url: "https://gnosisscan.io/" },

--- a/packages/react-app-revamp/config/wagmi/custom-chains/hyperliquid.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/hyperliquid.ts
@@ -10,8 +10,8 @@ export const hyperliquid: Chain = {
     symbol: "HYPE",
   },
   rpcUrls: {
-    public: { http: ["https://rpc.hyperliquid.xyz/evm"] },
-    default: { http: ["https://rpc.hyperliquid.xyz/evm"] },
+    public: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.hype-mainnet.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}/evm`] },
+    default: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.hype-mainnet.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}/evm`] },
   },
   blockExplorers: {
     etherscan: { name: "Hyperliquid Mainnet Scan", url: "https://hyperevmscan.io/" },

--- a/packages/react-app-revamp/config/wagmi/custom-chains/linea.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/linea.ts
@@ -10,12 +10,8 @@ export const linea: Chain = {
     symbol: "ETH",
   },
   rpcUrls: {
-    public: {
-      http: ["https://linea-mainnet.infura.io/v3"],
-    },
-    default: {
-      http: ["https://linea-mainnet.infura.io/v3"],
-    },
+    public: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.linea-mainnet.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
+    default: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.linea-mainnet.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
   },
   blockExplorers: {
     etherscan: { name: "Lineascan", url: "https://lineascan.build/" },

--- a/packages/react-app-revamp/config/wagmi/custom-chains/mainnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/mainnet.ts
@@ -11,7 +11,7 @@ export const mainnet: Chain = {
   },
   rpcUrls: {
     public: {
-      http: ["https://eth.llamarpc.com"],
+      http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`],
     },
     default: {
       http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`],

--- a/packages/react-app-revamp/config/wagmi/custom-chains/scroll.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/scroll.ts
@@ -10,12 +10,8 @@ export const scroll: Chain = {
     symbol: "ETH",
   },
   rpcUrls: {
-    public: {
-      http: ["https://mainnet-rpc.scroll.io"],
-    },
-    default: {
-      http: ["https://mainnet-rpc.scroll.io"],
-    },
+    public: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.scroll-mainnet.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
+    default: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.scroll-mainnet.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
   },
   blockExplorers: {
     etherscan: { name: "Scroll Block Explorer", url: "https://scrollscan.com/" },

--- a/packages/react-app-revamp/config/wagmi/custom-chains/sei.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/sei.ts
@@ -10,12 +10,8 @@ export const sei: Chain = {
     symbol: "SEI",
   },
   rpcUrls: {
-    public: {
-      http: ["https://evm-rpc.sei-apis.com"],
-    },
-    default: {
-      http: ["https://evm-rpc.sei-apis.com"],
-    },
+    public: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.sei-pacific.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
+    default: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.sei-pacific.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
   },
   blockExplorers: {
     etherscan: { name: "Sei Block Explorer", url: "https://seitrace.com/" },

--- a/packages/react-app-revamp/config/wagmi/custom-chains/soneium.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/soneium.ts
@@ -10,10 +10,10 @@ export const soneium: Chain = {
     symbol: "ETH",
   },
   rpcUrls: {
-    public: { http: ["https://rpc.soneium.org/"] },
-    default: { http: ["https://rpc.soneium.org/"] },
+    public: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.soneium-mainnet.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
+    default: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.soneium-mainnet.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
   },
-  blockExplorers: {
+ blockExplorers: {
     etherscan: { name: "Soneium Mainnet Scan", url: "https://soneium.blockscout.com/" },
     default: { name: "Soneium Mainnet Scan", url: "https://soneium.blockscout.com/" },
   },

--- a/packages/react-app-revamp/config/wagmi/custom-chains/sonic.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/sonic.ts
@@ -10,8 +10,8 @@ export const sonic: Chain = {
     symbol: "S",
   },
   rpcUrls: {
-    public: { http: ["https://rpc.soniclabs.com"] },
-    default: { http: ["https://rpc.soniclabs.com"] },
+    public: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.sonic-mainnet.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
+    default: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.sonic-mainnet.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
   },
   blockExplorers: {
     etherscan: { name: "Sonic Mainnet Scan", url: "https://sonicscan.org/" },

--- a/packages/react-app-revamp/config/wagmi/custom-chains/story.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/story.ts
@@ -10,12 +10,8 @@ export const story: Chain = {
     symbol: "IP",
   },
   rpcUrls: {
-    public: {
-      http: ["https://mainnet.storyrpc.io"],
-    },
-    default: {
-      http: ["https://mainnet.storyrpc.io"],
-    },
+    public: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.story-mainnet.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
+    default: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.story-mainnet.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
   },
   blockExplorers: {
     etherscan: { name: "Story Mainnet Scan", url: "https://storyscan.io/" },

--- a/packages/react-app-revamp/config/wagmi/custom-chains/unichain.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/unichain.ts
@@ -10,8 +10,8 @@ export const unichain: Chain = {
     symbol: "ETH",
   },
   rpcUrls: {
-    public: { http: [ "https://mainnet.unichain.org/" ] },
-    default: { http: [ "https://mainnet.unichain.org/" ] },
+    public: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.unichain-mainnet.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
+    default: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.unichain-mainnet.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
   },
   blockExplorers: {
     etherscan: { name: "Unichain Mainnet Scan", url: "https://uniscan.xyz/" },

--- a/packages/react-app-revamp/config/wagmi/custom-chains/world.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/world.ts
@@ -10,8 +10,8 @@ export const world: Chain = {
     symbol: "ETH",
   },
   rpcUrls: {
-    public: { http: ["https://worldchain-mainnet.g.alchemy.com/public"] },
-    default: { http: ["https://worldchain-mainnet.g.alchemy.com/public"] },
+    public: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.worldchain-mainnet.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
+    default: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.worldchain-mainnet.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
   },
   blockExplorers: {
     etherscan: { name: "World Mainnet Scan", url: "https://worldscan.org/" },

--- a/packages/react-app-revamp/config/wagmi/custom-chains/zksyncEra.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/zksyncEra.ts
@@ -10,8 +10,8 @@ export const zksyncEra: Chain = {
     symbol: "ETH",
   },
   rpcUrls: {
-    public: { http: ["https://mainnet.era.zksync.io"] },
-    default: { http: ["https://mainnet.era.zksync.io"] },
+    public: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.zksync-mainnet.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
+    default: { http: [`https://${process.env.NEXT_PUBLIC_QUICKNODE_SLUG}.zksync-mainnet.quiknode.pro/${process.env.NEXT_PUBLIC_QUICKNODE_KEY}`] },
   },
   blockExplorers: {
     etherscan: { name: "ZkSync Mainnet Scan", url: "https://explorer.zksync.io/" },


### PR DESCRIPTION
don't want to keep having to do one by one anymore.

also for reference quicknode doesn't support manta, forma, metis, mode, swell, and zora - all other chains we're live on it does though.