### PR TITLE
chore: rm install for slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,6 @@ FROM node:22-slim AS base
 
 FROM base AS builder
 
-# Install
-RUN apk add --update python3 make g++\
-   && rm -rf /var/cache/apk/*
 WORKDIR /app
 COPY . .
 


### PR DESCRIPTION
removing python install to make slim work (slim introduced in #4378)