### PR TITLE
chore: turn off linting on build with new foundry update

### DIFF
--- a/packages/forge/foundry.toml
+++ b/packages/forge/foundry.toml
@@ -6,4 +6,7 @@ solc-version = "0.8.19"  # most rollups don't support past this - https://twitte
 optimizer = true
 optimizer_runs = 200
 
+[lint]
+lint_on_build = false
+
 # See more config options at https://book.getfoundry.sh/config/?highlight=foundry.toml#configuring-with-foundrytoml


### PR DESCRIPTION
in foundryup's new stable version, v1.3.2, they default opt people in to linting on builds, which made our `yarn smartcheck` output unreadable because the linting logs were appended, so disabling for now.