### PR TITLE
feat: add rankLimit validation in GovernorSorting constructor

### DIFF
--- a/packages/forge/src/governance/utils/GovernorSorting.sol
+++ b/packages/forge/src/governance/utils/GovernorSorting.sol
@@ -31,7 +31,10 @@ abstract contract GovernorSorting {
     // RULE: array length can never end lower than it started a transaction, otherwise erroneous ranking can happen
     uint256[] public sortedRanks; // value is votes counts, has the constraint of no duplicate values.
 
+    error RankLimitCannotBeZero();
+
     constructor(uint256 sortingEnabled_, uint256 rankLimit_) {
+        if (rankLimit_ == 0) revert RankLimitCannotBeZero();
         sortingEnabled = sortingEnabled_;
         rankLimit = rankLimit_;
     }


### PR DESCRIPTION
Add validation to prevent rankLimit from being set to 0

- Add custom error RankLimitCannotBeZero()
- Add constructor check: if (rankLimit_ == 0) revert RankLimitCannotBeZero()
- Prevents deployment with invalid rankLimit that breaks sorting functionality
- Ensures compliance with documented rule "RULE: Cannot be 0"