### PR TITLE
chore: rm user permissions table

### DIFF
--- a/packages/react-app-revamp/database_schemas/supabase/user_permissions.sql
+++ b/packages/react-app-revamp/database_schemas/supabase/user_permissions.sql
@@ -1,7 +1,0 @@
-create table
-  public.user_permissions (
-    id uuid not null default gen_random_uuid (),
-    user_address character varying not null,
-    allowlist_max_size integer not null,
-    constraint user_permissions_pkey primary key (id)
-  ) tablespace pg_default;


### PR DESCRIPTION
no longer needed since we don't allow creation of allowlisted contests any longer as of #4469 

- [x] delete table in dev and prod