### PR TITLE
bugfix: fix ens resolution

### DIFF
--- a/packages/react-app-revamp/config/wagmi/custom-chains/mainnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/mainnet.ts
@@ -26,7 +26,7 @@ export const mainnet: Chain = {
       address: "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
     },
     ensUniversalResolver: {
-      address: "0xc0497E381f536Be9ce14B0dD3817cBcAe57d2F62",
+      address: "0xeeeeeeee14d718c2b47d9923deab1335e144eeee",
       blockCreated: 16966585,
     },
     multicall3: {

--- a/packages/react-app-revamp/helpers/getAddressProps.ts
+++ b/packages/react-app-revamp/helpers/getAddressProps.ts
@@ -1,5 +1,6 @@
 import { serverConfig } from "@config/wagmi/server";
 import { getEnsAddress, getEnsName } from "@wagmi/core";
+import { mainnet } from "wagmi/chains";
 
 export const REGEX_ETHEREUM_ADDRESS = /^0x[a-fA-F0-9]{40}$/;
 
@@ -30,7 +31,7 @@ export async function getAddressProps(pathAddress: string) {
     try {
       const fetchedEnsName = await getEnsName(serverConfig, {
         address: actualAddress as `0x${string}`,
-        chainId: 1,
+        chainId: mainnet.id,
       });
 
       if (fetchedEnsName) {

--- a/packages/react-app-revamp/hooks/useProfileData/index.ts
+++ b/packages/react-app-revamp/hooks/useProfileData/index.ts
@@ -1,13 +1,13 @@
 import { Clusters, getImageUrl, getProfileUrl } from "@clustersxyz/sdk";
 import { config } from "@config/wagmi";
-import { mainnet } from "@config/wagmi/custom-chains/mainnet";
 import shortenEthereumAddress from "@helpers/shortenEthereumAddress";
 import { useQuery } from "@tanstack/react-query";
 import { getEnsAvatar, getEnsName } from "@wagmi/core";
 import { normalize } from "viem/ens";
+import { mainnet } from "wagmi/chains";
 
 const DEFAULT_AVATAR_URL = "/contest/user.svg";
-const ETHERSCAN_BASE_URL = mainnet.blockExplorers?.etherscan?.url;
+const ETHERSCAN_BASE_URL = mainnet.blockExplorers?.default?.url;
 
 interface ProfileData {
   profileName: string;
@@ -51,7 +51,10 @@ const fetchProfileData = async (
   const clusters = new Clusters();
 
   try {
-    const ensName = await getEnsName(config, { address: ethereumAddress as `0x${string}` });
+    const ensName = await getEnsName(config, {
+      address: ethereumAddress as `0x${string}`,
+      chainId: mainnet.id,
+    });
 
     if (ensName) {
       const timeout = new Promise<string>((resolve, reject) => {
@@ -60,7 +63,7 @@ const fetchProfileData = async (
 
       const ensAvatarPromise = getEnsAvatar(config, {
         name: normalize(ensName),
-        chainId: 1,
+        chainId: mainnet.id,
       });
 
       try {


### PR DESCRIPTION
Closes #4427 

In order for all ens-related data to be successfully fetched, we had to change the previous `ensUniversalResolver` address in contracts in the `mainnet.ts` file with a new one because the most recent viem upgrade included support for UniversalResolver v3.