### PR TITLE
chore: rm simulation for setOfficialRewardsModule fn

### DIFF
--- a/packages/react-app-revamp/hooks/useDeployRewards/index.ts
+++ b/packages/react-app-revamp/hooks/useDeployRewards/index.ts
@@ -135,13 +135,11 @@ export function useDeployRewardsPool() {
         abi: DeployedContestContract.abi,
       };
 
-      const { request } = await simulateContract(config, {
+      const hash = await writeContract(config, {
         ...contractConfig,
         functionName: "setOfficialRewardsModule",
         args: [contractRewardsModuleAddress as `0x${string}`],
       });
-
-      const hash = await writeContract(config, request);
 
       await waitForTransactionReceipt(config, { hash });
 


### PR DESCRIPTION
We are seeing repeated reports from users that they are failing to deploy rewards, and specifically that it is failing at the second step (when we are trying to attach rewards to the contest)

I have tested it multiple times and confirmed that we are waiting for first step to be finished in order for rewards address to be passed for attachment.

First guess is that `simulateContract` for `setOfficialRewardsModule` fn is failing for unknown reasons (either estimates that gas is too high or other reason) and for now let's test this behavior without simulating it