### PR TITLE
bugfix: apply text-center for dates at datepicker

### DIFF
--- a/packages/react-app-revamp/app/globals.css
+++ b/packages/react-app-revamp/app/globals.css
@@ -418,6 +418,10 @@ li {
   font-family: "Lato" !important;
 }
 
+.react-datepicker__day-names {
+  text-align: center !important;
+}
+
 .popper-custom {
   position: unset !important;
   transform: none !important;


### PR DESCRIPTION
Closes #4466 

It looks like bug is already reported over at `react-datepicker` lib https://github.com/Hacker0x01/react-datepicker/issues/5829 , so let's implement a fix on our side until they release a new version.