### PR TITLE
chore: turn off wagmi auto-merges

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -41,7 +41,8 @@
     },
     {
       "matchPackageNames":[
-        "viem"
+        "viem",
+        "wagmi"
       ],
       "automerge": false
     }


### PR DESCRIPTION
in the case of 68f12e4ccb1255964e5c4f9647167a161d1db9fe's build [here](https://68f0f8d2ad49e50008004dff--jokerace.netlify.app/), a wagmi update (#4721) was first merged in which didn't produce the `useConfig` runtime error, then #4724 was merged (which also didn't have the error before being merged), and then that had the error.

so something w the lockfile change brought about the error.

the error went away with the viem update in #4722 though, so the theory is that sometimes viem and wagmi have to line up, so just to be safe we're going to turn off auto-merging for both (already off for viem) so we can check the build at runtime before merging and either: try hard resetting the lockfile (what works most of the time) and seeing if we need both of them for the error to go away.

<img width="1071" height="368" alt="Screenshot 2025-10-16 at 2 52 13 PM" src="https://github.com/user-attachments/assets/face519d-785d-4665-ae84-7815ecafcbcb" />