### PR TITLE
chore: resolve css warning during build

### DIFF
--- a/packages/react-app-revamp/app/globals.css
+++ b/packages/react-app-revamp/app/globals.css
@@ -707,9 +707,7 @@ li {
   ::selection {
     background-color: var(--brand);
   }
-  ::marker:not(li) {
-    color: var(--brand);
-  }
+
   *::selection {
     color: var(--color-true-black);
   }


### PR DESCRIPTION
closes #4718 

We actually do not need this rule at all since it does nothing.