### PR TITLE
chore: format balance on contest page

### DIFF
--- a/packages/react-app-revamp/components/_pages/Contest/components/StickyCards/components/VotingQualifier/shared/Balance/components/AnyoneCanVoteBalance/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/components/StickyCards/components/VotingQualifier/shared/Balance/components/AnyoneCanVoteBalance/index.tsx
@@ -1,5 +1,6 @@
 import AddFundsModal from "@components/AddFunds/components/Modal";
 import ButtonV3, { ButtonSize } from "@components/UI/ButtonV3";
+import { formatBalance } from "@helpers/formatBalance";
 import { formatNumberAbbreviated } from "@helpers/formatNumber";
 import { useContestStore } from "@hooks/useContest/store";
 import useContestConfigStore from "@hooks/useContestConfig/store";
@@ -16,7 +17,7 @@ const BalanceOrSkeleton = ({
   nativeCurrencySymbol,
 }: {
   isUserBalanceLoading: boolean;
-  userBalance?: string | number;
+  userBalance: string;
   nativeCurrencySymbol?: string;
 }) => {
   return isUserBalanceLoading ? (
@@ -33,7 +34,7 @@ const BalanceOrSkeleton = ({
     </span>
   ) : (
     <span className="text-neutral-9">
-      {userBalance} {nativeCurrencySymbol} =
+      {formatBalance(userBalance)} {nativeCurrencySymbol} =
     </span>
   );
 };


### PR DESCRIPTION
I have noticed that we do not format balance on the contest page, which results in lot of decimals and it breaks inline styling.
<img width="600" height="309" alt="image" src="https://github.com/user-attachments/assets/bee4e24c-d560-46af-9f91-81897d08ab9d" />
