### PR TITLE
bugfix: fix wrong entering info in rules tab

### DIFF
--- a/packages/react-app-revamp/hooks/useUserSubmitQualification/useSubmitQualification.ts
+++ b/packages/react-app-revamp/hooks/useUserSubmitQualification/useSubmitQualification.ts
@@ -57,8 +57,6 @@ export const useSubmitQualification = (userAddress: `0x${string}` | undefined) =
   };
 
   const checkIfCurrentUserQualifyToSubmit = async (contractConfig: ContractConfig) => {
-    if (!userAddress) return;
-
     setLoadingState(true);
 
     if (!contractConfig.abi) {


### PR DESCRIPTION
If user does not have wallet connected, in the rules tab we will show "anyone can enter", issue was because we were returning early from the function where we check submission qualification.