### PR TITLE
bugfix: fix year rollover in contest timing

### DIFF
--- a/packages/react-app-revamp/components/_pages/Create/pages/ContestTiming/components/VotingOpens/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Create/pages/ContestTiming/components/VotingOpens/index.tsx
@@ -8,30 +8,30 @@ import CreateContestTimingHourSelector from "../Selectors/HourSelector";
 import CreateContestTimingMonthSelector from "../Selectors/MonthSelector";
 
 const CreateContestTimingVotingOpens = () => {
-  const { votingOpen, updateVotingOpen, getVotingOpenMonthOptions, getVotingOpenDayOptions, getVotingOpenHourOptions } =
-    useDeployContestStore(
-      useShallow(state => ({
-        votingOpen: state.votingOpen,
-        updateVotingOpen: state.updateVotingOpen,
-        getVotingOpenMonthOptions: state.getVotingOpenMonthOptions,
-        getVotingOpenDayOptions: state.getVotingOpenDayOptions,
-        getVotingOpenHourOptions: state.getVotingOpenHourOptions,
-      })),
-    );
+  const {
+    votingOpen,
+    updateVotingOpen,
+    getVotingOpenDate,
+    getVotingOpenMonthOptions,
+    getVotingOpenDayOptions,
+    getVotingOpenHourOptions,
+  } = useDeployContestStore(
+    useShallow(state => ({
+      votingOpen: state.votingOpen,
+      updateVotingOpen: state.updateVotingOpen,
+      getVotingOpenDate: state.getVotingOpenDate,
+      getVotingOpenMonthOptions: state.getVotingOpenMonthOptions,
+      getVotingOpenDayOptions: state.getVotingOpenDayOptions,
+      getVotingOpenHourOptions: state.getVotingOpenHourOptions,
+    })),
+  );
 
   const monthOptions = getVotingOpenMonthOptions();
   const dayOptions = getVotingOpenDayOptions();
   const hourOptions = getVotingOpenHourOptions();
   const monthLabel = moment().month(votingOpen.month).format("MMMM");
   const hourLabel = `${votingOpen.hour}:00`;
-  const votingOpenMoment = moment()
-    .month(votingOpen.month)
-    .date(votingOpen.day)
-    .hour(votingOpen.hour)
-    .minute(0)
-    .second(0);
-
-  const daysUntilVotingOpens = votingOpenMoment.diff(moment(), "days");
+  const daysUntilVotingOpens = moment(getVotingOpenDate()).diff(moment(), "days");
   const shouldShowWeekRecommendation = daysUntilVotingOpens < 5;
 
   const handleMonthChange = (monthValue: string) => {

--- a/packages/react-app-revamp/hooks/useDeployContest/slices/helpers/dateHelpers.ts
+++ b/packages/react-app-revamp/hooks/useDeployContest/slices/helpers/dateHelpers.ts
@@ -27,6 +27,10 @@ export const createDateFromTiming = (timing: TimingDetails): Date => {
     .second(0)
     .millisecond(0);
 
+  if (date.isBefore(now)) {
+    date.add(1, "year");
+  }
+
   return date.toDate();
 };
 


### PR DESCRIPTION
I have noticed when selecting a month earlier than the current month (for example, January while in December), dates were incorrectly created with the current year instead of next year, you would get an error "voting time must be in the future"

This was missed since we do not handle year selection anymore, everything should be good now! 