### PR TITLE
chore: preload fonts in layout

### DIFF
--- a/packages/react-app-revamp/app/globals.css
+++ b/packages/react-app-revamp/app/globals.css
@@ -1,47 +1,6 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
-/* Font Face Declarations */
-@font-face {
-  font-family: "Lato";
-  font-style: normal;
-  font-weight: 400;
-  font-display: swap;
-  src: url("/fonts/Lato-Regular.woff2") format("woff2");
-}
-
-@font-face {
-  font-family: "Lato";
-  font-style: normal;
-  font-weight: 700;
-  font-display: swap;
-  src: url("/fonts/Lato-Bold.woff2") format("woff2");
-}
-
-@font-face {
-  font-family: "Lato";
-  font-style: normal;
-  font-weight: 900;
-  font-display: swap;
-  src: url("/fonts/Lato-Black.woff2") format("woff2");
-}
-
-@font-face {
-  font-family: "Sabo-Regular";
-  font-style: normal;
-  font-weight: 400;
-  font-display: swap;
-  src: url("/fonts/Sabo-Regular.otf") format("opentype");
-}
-
-@font-face {
-  font-family: "Sabo-Filled";
-  font-style: normal;
-  font-weight: 400;
-  font-display: swap;
-  src: url("/fonts/Sabo-Filled.otf") format("opentype");
-}
-
 @theme {
   /* Breakpoints */
   --breakpoint-min: 320px;
@@ -56,10 +15,9 @@
   --breakpoint-3xl: 1500px;
   --breakpoint-4xl: 1660px;
 
-  /* Font Families */
-  --font-sabo-regular: "Sabo-Regular", sans-serif;
-  --font-sabo-filled: "Sabo-Filled", sans-serif;
-  --font-sans: "Lato", sans-serif;
+  --font-sabo-regular: var(--font-family-sabo-regular), sans-serif;
+  --font-sabo-filled: var(--font-family-sabo-filled), sans-serif;
+  --font-sans: var(--font-family-lato), sans-serif;
   --font-mono: monospace;
 
   /* Font Sizes */

--- a/packages/react-app-revamp/app/layout.tsx
+++ b/packages/react-app-revamp/app/layout.tsx
@@ -7,12 +7,51 @@ import { polyfill } from "interweave-ssr";
 import { GA_TRACKING_ID } from "lib/gtag";
 import { Metadata, Viewport } from "next";
 import dynamic from "next/dynamic";
+import localFont from "next/font/local";
 import { headers } from "next/headers";
 import NextTopLoader from "nextjs-toploader";
 import "react-loading-skeleton/dist/skeleton.css";
 import "react-tooltip/dist/react-tooltip.css";
 import "simplebar-react/dist/simplebar.min.css";
 import Providers from "./providers";
+
+const lato = localFont({
+  src: [
+    {
+      path: "./_fonts/Lato-Regular.woff2",
+      weight: "400",
+      style: "normal",
+    },
+    {
+      path: "./_fonts/Lato-Bold.woff2",
+      weight: "700",
+      style: "normal",
+    },
+    {
+      path: "./_fonts/Lato-Black.woff2",
+      weight: "900",
+      style: "normal",
+    },
+  ],
+  display: "swap",
+  variable: "--font-family-lato",
+});
+
+const saboRegular = localFont({
+  src: "../public/fonts/Sabo-Regular.otf",
+  weight: "400",
+  style: "normal",
+  display: "swap",
+  variable: "--font-family-sabo-regular",
+});
+
+const saboFilled = localFont({
+  src: "./_fonts/Sabo-Filled.otf",
+  weight: "400",
+  style: "normal",
+  display: "swap",
+  variable: "--font-family-sabo-filled",
+});
 
 polyfill();
 
@@ -49,8 +88,8 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   const cookie = headersList.get("cookie") ?? "";
 
   return (
-    <html lang="en">
-      <body>
+    <html lang="en" className={`${lato.variable} ${saboRegular.variable} ${saboFilled.variable} antialiased`}>
+      <body className={lato.className}>
         <div id="__next">
           <NextTopLoader color="#BB65FF" shadow="0 0 10px #BB65FF, 0 0 5px #78FFC6" showSpinner={false} />
           <Providers cookie={cookie}>


### PR DESCRIPTION
We had this logic before, i think we deleted it at some point where we upgraded to some nextjs version or something else. 

We need to preload fonts correctly in the layout, this is important for nextjs, sometimes you can see that for a split second fonts aren't loaded. 