### PR TITLE
enhancement: use custom dollar sign on landing ticker

### DIFF
--- a/packages/react-app-revamp/components/_pages/Landing/components/Ticker/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Landing/components/Ticker/index.tsx
@@ -1,6 +1,5 @@
 import Ticker from "@components/UI/Ticker";
 import TickerText from "./components/TickerText";
-import { FC } from "react";
 
 const LandingPageTicker = () => {
   return (
@@ -9,7 +8,20 @@ const LandingPageTicker = () => {
       items={[
         <TickerText>THE EARLIER YOU VOTE THE MORE YOU CAN EARN</TickerText>,
         <img src="/landing/confetti.svg" alt="confetti" className="w-12 h-12" />,
-        <TickerText>$1,500,000 GENERATED FOR VOTERS</TickerText>,
+        <TickerText>
+          <span
+            className="text-2xl font-lato font-black"
+            style={{
+              WebkitTextStroke: "3px #BB65FF",
+              WebkitTextFillColor: "#78ffc6",
+              paintOrder: "stroke fill",
+              textShadow: "-3px 3px 8px #BB65FF",
+            }}
+          >
+            $
+          </span>
+          1,500,000 GENERATED FOR VOTERS
+        </TickerText>,
         <img src="/landing/snake.svg" alt="" className="h-8" />,
       ]}
     />


### PR DESCRIPTION
<img width="173" height="49" alt="image" src="https://github.com/user-attachments/assets/e411d712-c33c-4d6d-b5e6-c5927c92e0b8" />

I have noticed that the dollar sign looks a bit different than other part of the text, and the reason for this is that `sabo-filled` font can't render symbols - you can see here https://www.1001freefonts.com/sabo-filled.font list of supported symbols, there are only few of them.

So the idea is to use `lato` font for the symbol but apply `text-shadow` and other properties on top of it and it's looking good now! 