### PR TITLE
bugfix: fix circular dependency in add funds store

### DIFF
--- a/packages/react-app-revamp/components/AddFunds/components/Toggle/index.tsx
+++ b/packages/react-app-revamp/components/AddFunds/components/Toggle/index.tsx
@@ -1,6 +1,6 @@
 import { animate, motion, useMotionValue } from "motion/react";
 import { FC, useEffect, useRef } from "react";
-import { AddFundsProviderType } from "../../providers";
+import { AddFundsProviderType } from "../../types";
 
 interface AddFundsToggleProps {
   value: AddFundsProviderType;

--- a/packages/react-app-revamp/components/AddFunds/providers/hooks/useAddFundsProviders.tsx
+++ b/packages/react-app-revamp/components/AddFunds/providers/hooks/useAddFundsProviders.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import AddFundsJumperProvider from "../bridges/jumper";
 import AddFundsCoinbaseProvider from "../onramp/coinbase";
-import { AddFundsProviderType } from "../index";
+import { AddFundsProviderType } from "../../types";
 
 interface UseAddFundsProvidersParams {
   type: AddFundsProviderType;

--- a/packages/react-app-revamp/components/AddFunds/providers/index.tsx
+++ b/packages/react-app-revamp/components/AddFunds/providers/index.tsx
@@ -1,10 +1,8 @@
 import { FC, ReactNode } from "react";
 import useAddFundsProviders from "./hooks/useAddFundsProviders";
+import { AddFundsProviderType } from "../types";
 
-export enum AddFundsProviderType {
-  BRIDGE = "bridge",
-  ONRAMP = "onramp",
-}
+export { AddFundsProviderType };
 
 interface AddFundsProvidersProps {
   type: AddFundsProviderType;

--- a/packages/react-app-revamp/components/AddFunds/store/index.ts
+++ b/packages/react-app-revamp/components/AddFunds/store/index.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { AddFundsProviderType } from "../providers";
+import { AddFundsProviderType } from "../types";
 
 interface AddFundsStore {
   providerType: AddFundsProviderType;

--- a/packages/react-app-revamp/components/AddFunds/types.ts
+++ b/packages/react-app-revamp/components/AddFunds/types.ts
@@ -1,0 +1,4 @@
+export enum AddFundsProviderType {
+  BRIDGE = "bridge",
+  ONRAMP = "onramp",
+}


### PR DESCRIPTION
I've noticed that local environment and staging is broken if you go from landing to create flow, the issue is a circular dependency in the add funds store.

The issue is that we are trying to load enums in the store but module (store) didn't load yet, so it's best practice to define those types outside of the store and in separate file. 


edit: gonna merge in to fix staging, but you have a context here @siobh9, code is very straightforward! 