### PR TITLE
enhancement: allow submit entry modal without wallet connected

### DIFF
--- a/packages/react-app-revamp/components/UI/DialogModalV3/index.tsx
+++ b/packages/react-app-revamp/components/UI/DialogModalV3/index.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/no-unescaped-entities */
 import { Dialog, DialogPanel, DialogTitle } from "@headlessui/react";
-import { FC, useCallback } from "react";
+import { FC, useCallback, useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
 
 interface DialogModalProps {
   isOpen: boolean;
@@ -13,6 +14,7 @@ interface DialogModalProps {
   className?: string;
   isMobile?: boolean;
   disableClose?: boolean;
+  disableFocusTrap?: boolean;
   setIsOpen?: (isOpen: boolean) => void;
   onClose?: () => void;
 }
@@ -25,6 +27,7 @@ const DialogModalV3: FC<DialogModalProps> = ({
   onClose,
   isMobile,
   disableClose,
+  disableFocusTrap,
   className,
   closeButtonSize = { width: 24, height: 24 },
 }) => {
@@ -34,6 +37,22 @@ const DialogModalV3: FC<DialogModalProps> = ({
       onClose();
     }
   }, [setIsOpen, onClose]);
+
+  if (disableFocusTrap) {
+    return (
+      <DialogModalPlain
+        isOpen={isOpen}
+        title={title}
+        isMobile={isMobile}
+        disableClose={disableClose}
+        className={className}
+        closeButtonSize={closeButtonSize}
+        onClose={handleClose}
+      >
+        {children}
+      </DialogModalPlain>
+    );
+  }
 
   return (
     <Dialog open={isOpen} onClose={handleClose} className="relative z-50">
@@ -66,6 +85,95 @@ const DialogModalV3: FC<DialogModalProps> = ({
         </div>
       </div>
     </Dialog>
+  );
+};
+
+interface DialogModalPlainProps {
+  isOpen: boolean;
+  title: string;
+  children: React.ReactNode;
+  closeButtonSize: { width: number; height: number };
+  className?: string;
+  isMobile?: boolean;
+  disableClose?: boolean;
+  onClose: () => void;
+}
+
+const DialogModalPlain: FC<DialogModalPlainProps> = ({
+  isOpen,
+  title,
+  children,
+  onClose,
+  isMobile,
+  disableClose,
+  className,
+  closeButtonSize,
+}) => {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !disableClose) onClose();
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (!disableClose && panelRef.current && !panelRef.current.contains(e.target as Node)) {
+      onClose();
+    }
+  };
+
+  return createPortal(
+    <div className="fixed inset-0 z-[100]" role="dialog" aria-modal="true" aria-label={title}>
+      <div className="fixed inset-0 bg-neutral-8/60" aria-hidden="true" />
+      <div className="fixed inset-0 flex items-center justify-center 2xs:p-4" onClick={handleBackdropClick}>
+        <div className="flex min-h-full w-full items-center justify-center">
+          <div
+            ref={panelRef}
+            className={`text-sm mx-auto min-h-screen max-h-screen overflow-y-auto 2xs:min-h-auto 2xs:max-h-[calc(100vh-60px)] w-full px-4 2xs:pt-4 bg-true-black 2xs:rounded-[10px] ${className ?? ""}`}
+          >
+            <p className="sr-only">{title}</p>
+            <div className="p-0 md:p-2 relative">
+              <button
+                onClick={onClose}
+                title="Close this"
+                className={`${
+                  isMobile || disableClose ? "hidden" : "absolute"
+                } z-10 top-0 p-2 left-0 2xs:left-auto 2xs:right-0 pt-4 hover:scale-[1.1] text-neutral-11`}
+              >
+                <img
+                  src="/modal/modal_close.svg"
+                  width={closeButtonSize.width}
+                  height={closeButtonSize.height}
+                  alt="close"
+                />
+                <span className="sr-only">Close modal</span>
+              </button>
+              <div className={`${isMobile ? "pt-0" : "pt-3 pb-6"}`}>{children}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
   );
 };
 

--- a/packages/react-app-revamp/components/UI/EmailSubscription/index.tsx
+++ b/packages/react-app-revamp/components/UI/EmailSubscription/index.tsx
@@ -16,7 +16,7 @@ const EmailSubscription: FC<EmailSubscriptionProps> = ({
   handleEmailChange,
 }) => {
   return (
-    <div className="flex flex-col gap-4 animate-appear">
+    <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-1">
         <input
           value={emailForSubscription}

--- a/packages/react-app-revamp/components/UI/ImageUpload/components/UploadArea.tsx
+++ b/packages/react-app-revamp/components/UI/ImageUpload/components/UploadArea.tsx
@@ -27,7 +27,7 @@ const UploadArea: FC<UploadAreaProps> = ({
       onDragOver={onDragOver}
       onDrop={onDrop}
       onDragLeave={onDragLeave}
-      className={`relative flex shadow-file-upload flex-col w-full md:w-[376px] min-h-36 py-4 justify-center items-center border ${
+      className={`relative flex shadow-file-upload flex-col w-full md:w-[376px] min-h-28 py-3 justify-center items-center border ${
         validationError ? "border-negative-11" : "border-transparent hover:border-positive-11"
       } rounded-2xl cursor-pointer transition-all duration-300 ease-in-out`}
     >

--- a/packages/react-app-revamp/components/_pages/Contest/Contest/useContestSubmitButton.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/Contest/useContestSubmitButton.tsx
@@ -1,10 +1,6 @@
 import ButtonV3, { ButtonSize } from "@components/UI/ButtonV3";
-import useContestConfigStore from "@hooks/useContestConfig/store";
 import { ContestStateEnum, useContestStateStore } from "@hooks/useContestState/store";
 import { useSubmitProposalStore } from "@hooks/useSubmitProposal/store";
-import { useSubmitQualification } from "@hooks/useUserSubmitQualification";
-import { useWallet } from "@hooks/useWallet";
-import { useModal } from "@getpara/react-sdk-lite";
 import { useMediaQuery } from "react-responsive";
 import { useShallow } from "zustand/shallow";
 
@@ -13,17 +9,6 @@ interface UseContestSubmitButtonProps {
 }
 
 export const useContestSubmitButton = ({ onOpenModal }: UseContestSubmitButtonProps) => {
-  const { isConnected, userAddress } = useWallet();
-  const { openModal } = useModal();
-  const { contestConfig } = useContestConfigStore(state => state);
-  const { qualifies, anyoneCanSubmit, isLoading } = useSubmitQualification({
-    address: contestConfig.address,
-    chainId: contestConfig.chainId,
-    abi: contestConfig.abi,
-    userAddress: userAddress as `0x${string}` | undefined,
-    enabled: isConnected,
-  });
-
   const { setIsSuccess: setIsSubmitProposalSuccess } = useSubmitProposalStore(
     useShallow(state => ({
       setIsSuccess: state.setIsSuccess,
@@ -42,38 +27,16 @@ export const useContestSubmitButton = ({ onOpenModal }: UseContestSubmitButtonPr
   const renderSubmitButton = () => {
     if (isContestCanceled) return null;
 
-    if (!isConnected) {
-      return (
-        <ButtonV3
-          colorClass="bg-gradient-vote rounded-[40px]"
-          size={isMobile ? ButtonSize.EXTRA_LARGE_LONG_MOBILE : ButtonSize.EXTRA_LARGE_LONG}
-          onClick={() => openModal()}
-        >
-          connect wallet to submit entry
-        </ButtonV3>
-      );
-    }
-
-    if (isLoading) return null;
-
-    if (qualifies) {
-      return (
-        <ButtonV3
-          colorClass="bg-gradient-purple rounded-[40px]"
-          textColorClass="text-[16px] md:text-[20px] font-bold text-true-black"
-          size={isMobile ? ButtonSize.EXTRA_LARGE_LONG_MOBILE : ButtonSize.EXTRA_LARGE_LONG}
-          onClick={handleEnterContest}
-        >
-          submit entry
-        </ButtonV3>
-      );
-    }
-
-    if (!anyoneCanSubmit) {
-      return <p className="text-secondary-11 text-[16px]">only the contest creator can submit entries</p>;
-    }
-
-    return null;
+    return (
+      <ButtonV3
+        colorClass="bg-gradient-purple rounded-[40px]"
+        textColorClass="text-[16px] md:text-[20px] font-bold text-true-black"
+        size={isMobile ? ButtonSize.EXTRA_LARGE_LONG_MOBILE : ButtonSize.EXTRA_LARGE_LONG}
+        onClick={handleEnterContest}
+      >
+        submit entry
+      </ButtonV3>
+    );
   };
 
   return { renderSubmitButton };

--- a/packages/react-app-revamp/components/_pages/Contest/Contest/useContestSubmitButton.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/Contest/useContestSubmitButton.tsx
@@ -1,6 +1,10 @@
 import ButtonV3, { ButtonSize } from "@components/UI/ButtonV3";
+import useContestConfigStore from "@hooks/useContestConfig/store";
 import { ContestStateEnum, useContestStateStore } from "@hooks/useContestState/store";
 import { useSubmitProposalStore } from "@hooks/useSubmitProposal/store";
+import { useSubmitQualification } from "@hooks/useUserSubmitQualification";
+import { useWallet } from "@hooks/useWallet";
+import { useModal } from "@getpara/react-sdk-lite";
 import { useMediaQuery } from "react-responsive";
 import { useShallow } from "zustand/shallow";
 
@@ -9,6 +13,16 @@ interface UseContestSubmitButtonProps {
 }
 
 export const useContestSubmitButton = ({ onOpenModal }: UseContestSubmitButtonProps) => {
+  const { isConnected, userAddress } = useWallet();
+  const { openModal } = useModal();
+  const { contestConfig } = useContestConfigStore(state => state);
+  const { qualifies, anyoneCanSubmit, isLoading } = useSubmitQualification({
+    address: contestConfig.address,
+    chainId: contestConfig.chainId,
+    abi: contestConfig.abi,
+    userAddress: userAddress as `0x${string}` | undefined,
+  });
+
   const { setIsSuccess: setIsSubmitProposalSuccess } = useSubmitProposalStore(
     useShallow(state => ({
       setIsSuccess: state.setIsSuccess,
@@ -26,17 +40,47 @@ export const useContestSubmitButton = ({ onOpenModal }: UseContestSubmitButtonPr
 
   const renderSubmitButton = () => {
     if (isContestCanceled) return null;
+    if (isLoading) return null;
 
-    return (
-      <ButtonV3
-        colorClass="bg-gradient-purple rounded-[40px]"
-        textColorClass="text-[16px] md:text-[20px] font-bold text-true-black"
-        size={isMobile ? ButtonSize.EXTRA_LARGE_LONG_MOBILE : ButtonSize.EXTRA_LARGE_LONG}
-        onClick={handleEnterContest}
-      >
-        submit entry
-      </ButtonV3>
-    );
+    if (anyoneCanSubmit) {
+      return (
+        <ButtonV3
+          colorClass="bg-gradient-purple rounded-[40px]"
+          textColorClass="text-[16px] md:text-[20px] font-bold text-true-black"
+          size={isMobile ? ButtonSize.EXTRA_LARGE_LONG_MOBILE : ButtonSize.EXTRA_LARGE_LONG}
+          onClick={handleEnterContest}
+        >
+          submit entry
+        </ButtonV3>
+      );
+    }
+
+    if (!isConnected) {
+      return (
+        <ButtonV3
+          colorClass="bg-gradient-vote rounded-[40px]"
+          size={isMobile ? ButtonSize.EXTRA_LARGE_LONG_MOBILE : ButtonSize.EXTRA_LARGE_LONG}
+          onClick={() => openModal()}
+        >
+          connect wallet to submit entry
+        </ButtonV3>
+      );
+    }
+
+    if (qualifies) {
+      return (
+        <ButtonV3
+          colorClass="bg-gradient-purple rounded-[40px]"
+          textColorClass="text-[16px] md:text-[20px] font-bold text-true-black"
+          size={isMobile ? ButtonSize.EXTRA_LARGE_LONG_MOBILE : ButtonSize.EXTRA_LARGE_LONG}
+          onClick={handleEnterContest}
+        >
+          submit entry
+        </ButtonV3>
+      );
+    }
+
+    return <p className="text-secondary-11 text-[16px]">only the contest creator can submit entries</p>;
   };
 
   return { renderSubmitButton };

--- a/packages/react-app-revamp/components/_pages/DialogModalSendProposal/Desktop/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalSendProposal/Desktop/index.tsx
@@ -7,7 +7,6 @@ import CreateGradientTitle from "@components/_pages/Create/components/GradientTi
 import { FOOTER_LINKS } from "@config/links";
 import { chains } from "@config/wagmi";
 import { emailRegex } from "@helpers/regex";
-import shortenEthereumAddress from "@helpers/shortenEthereumAddress";
 import { useContestStore } from "@hooks/useContest/store";
 import useContestConfigStore from "@hooks/useContestConfig/store";
 import { Charge } from "@hooks/useDeployContest/types";
@@ -33,9 +32,6 @@ interface DialogModalSendProposalDesktopLayoutProps {
   isOpen: boolean;
   isConnected: boolean;
   isCorrectNetwork: boolean;
-  qualifies: boolean;
-  anyoneCanSubmit: boolean;
-  creator: string | undefined;
   isDragging: boolean;
   charge: Charge;
   accountData: GetBalanceReturnType | undefined;
@@ -60,9 +56,6 @@ const DialogModalSendProposalDesktopLayout: FC<DialogModalSendProposalDesktopLay
   isOpen,
   isConnected,
   isCorrectNetwork,
-  qualifies,
-  anyoneCanSubmit,
-  creator,
   charge,
   accountData,
   isDragging,
@@ -74,7 +67,6 @@ const DialogModalSendProposalDesktopLayout: FC<DialogModalSendProposalDesktopLay
   onSubmitProposal,
 }) => {
   const { openModal: openWalletModal } = useModal();
-  const isDisqualified = isConnected && !qualifies && !anyoneCanSubmit;
   const { contestConfig } = useContestConfigStore(useShallow(state => state));
   const { contestPrompt } = useContestStore(state => state);
   const {
@@ -163,20 +155,7 @@ const DialogModalSendProposalDesktopLayout: FC<DialogModalSendProposalDesktopLay
           />
         ) : (
           <div className="flex flex-col gap-5">
-            {!anyoneCanSubmit && creator && !qualifies && (
-              <div className="bg-gradient-create rounded-[10px] p-[1px] md:w-[650px]">
-                <div className="flex items-center gap-3 rounded-[10px] bg-true-black py-3 px-4">
-                  <p className="text-[14px] text-neutral-11">
-                    {isConnected
-                      ? `only the contest creator (${shortenEthereumAddress(creator)}) can submit entries`
-                      : `if you are not the contest creator (${shortenEthereumAddress(creator)}) you will not be able to submit an entry`}
-                  </p>
-                </div>
-              </div>
-            )}
-            <div className={`flex flex-col gap-5 transition-opacity duration-300 ${
-              isDisqualified ? "opacity-30 pointer-events-none select-none" : ""
-            }`}>
+            <div className="flex flex-col gap-5">
               <div className="flex flex-col gap-3">
                 <ContestPrompt type="modal" prompt={contestPrompt} hidePrompt />
               </div>
@@ -221,39 +200,37 @@ const DialogModalSendProposalDesktopLayout: FC<DialogModalSendProposalDesktopLay
                 </div>
               </div>
             </div>
-            {!isDisqualified && (
-              <div className="flex flex-col gap-6 mt-6">
-                {!isConnected ? (
+            <div className="flex flex-col gap-6 mt-6">
+              {!isConnected ? (
+                <ButtonV3
+                  colorClass="bg-gradient-vote rounded-[40px]"
+                  size={ButtonSize.EXTRA_LARGE_LONG}
+                  onClick={() => openWalletModal()}
+                >
+                  connect wallet to enter
+                </ButtonV3>
+              ) : isCorrectNetwork ? (
+                <div className="flex flex-col gap-2">
                   <ButtonV3
-                    colorClass="bg-gradient-vote rounded-[40px]"
+                    colorClass="bg-gradient-purple rounded-[40px]"
                     size={ButtonSize.EXTRA_LARGE_LONG}
-                    onClick={() => openWalletModal()}
+                    onClick={buttonText === ButtonText.SUBMIT ? handleConfirm : () => setShowAddFundsModal(true)}
+                    isDisabled={isLoading}
                   >
-                    connect wallet to enter
+                    {buttonText}
                   </ButtonV3>
-                ) : isCorrectNetwork ? (
-                  <div className="flex flex-col gap-2">
-                    <ButtonV3
-                      colorClass="bg-gradient-purple rounded-[40px]"
-                      size={ButtonSize.EXTRA_LARGE_LONG}
-                      onClick={buttonText === ButtonText.SUBMIT ? handleConfirm : () => setShowAddFundsModal(true)}
-                      isDisabled={isLoading}
-                    >
-                      {buttonText}
-                    </ButtonV3>
-                    {error && <>{error}</>}
-                  </div>
-                ) : (
-                  <ButtonV3
-                    colorClass="bg-gradient-create rounded-[40px]"
-                    size={ButtonSize.EXTRA_LARGE_LONG}
-                    onClick={onSwitchNetwork}
-                  >
-                    switch network
-                  </ButtonV3>
-                )}
-              </div>
-            )}
+                  {error && <>{error}</>}
+                </div>
+              ) : (
+                <ButtonV3
+                  colorClass="bg-gradient-create rounded-[40px]"
+                  size={ButtonSize.EXTRA_LARGE_LONG}
+                  onClick={onSwitchNetwork}
+                >
+                  switch network
+                </ButtonV3>
+              )}
+            </div>
           </div>
         )}
       </div>

--- a/packages/react-app-revamp/components/_pages/DialogModalSendProposal/Desktop/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalSendProposal/Desktop/index.tsx
@@ -2,12 +2,12 @@ import AddFunds from "@components/AddFunds";
 import ButtonV3, { ButtonSize } from "@components/UI/ButtonV3";
 import DialogModalV3 from "@components/UI/DialogModalV3";
 import EmailSubscription from "@components/UI/EmailSubscription";
-import UserProfileDisplay from "@components/UI/UserProfileDisplay";
 import ContestPrompt from "@components/_pages/Contest/components/Prompt";
 import CreateGradientTitle from "@components/_pages/Create/components/GradientTitle";
 import { FOOTER_LINKS } from "@config/links";
 import { chains } from "@config/wagmi";
 import { emailRegex } from "@helpers/regex";
+import shortenEthereumAddress from "@helpers/shortenEthereumAddress";
 import { useContestStore } from "@hooks/useContest/store";
 import useContestConfigStore from "@hooks/useContestConfig/store";
 import { Charge } from "@hooks/useDeployContest/types";
@@ -15,6 +15,7 @@ import useMetadataFields from "@hooks/useMetadataFields";
 import { useMetadataStore } from "@hooks/useMetadataFields/store";
 import useSubmitProposal from "@hooks/useSubmitProposal";
 import { useSubmitProposalStore } from "@hooks/useSubmitProposal/store";
+import { useModal } from "@getpara/react-sdk-lite";
 import { Editor } from "@tiptap/react";
 import { type GetBalanceReturnType } from "@wagmi/core";
 import { FC, ReactNode, useEffect, useState } from "react";
@@ -29,9 +30,12 @@ interface DialogModalSendProposalDesktopLayoutProps {
   contestId: string;
   proposal: string;
   editorProposal: Editor | null;
-  address: string;
   isOpen: boolean;
+  isConnected: boolean;
   isCorrectNetwork: boolean;
+  qualifies: boolean;
+  anyoneCanSubmit: boolean;
+  creator: string | undefined;
   isDragging: boolean;
   charge: Charge;
   accountData: GetBalanceReturnType | undefined;
@@ -53,9 +57,12 @@ const DialogModalSendProposalDesktopLayout: FC<DialogModalSendProposalDesktopLay
   contestId,
   proposal,
   editorProposal,
-  address,
   isOpen,
+  isConnected,
   isCorrectNetwork,
+  qualifies,
+  anyoneCanSubmit,
+  creator,
   charge,
   accountData,
   isDragging,
@@ -66,6 +73,8 @@ const DialogModalSendProposalDesktopLayout: FC<DialogModalSendProposalDesktopLay
   onSwitchNetwork,
   onSubmitProposal,
 }) => {
+  const { openModal: openWalletModal } = useModal();
+  const isDisqualified = isConnected && !qualifies && !anyoneCanSubmit;
   const { contestConfig } = useContestConfigStore(useShallow(state => state));
   const { contestPrompt } = useContestStore(state => state);
   const {
@@ -143,8 +152,8 @@ const DialogModalSendProposalDesktopLayout: FC<DialogModalSendProposalDesktopLay
   };
 
   return (
-    <DialogModalV3 title="submission" isOpen={isOpen} setIsOpen={onCloseModal} className="w-full xl:w-[1100px]">
-      <div className="flex flex-col gap-4 md:pl-[50px] lg:pl-[100px] mt-[60px] mb-[60px]">
+    <DialogModalV3 title="submission" isOpen={isOpen} setIsOpen={onCloseModal} disableFocusTrap className="w-full xl:w-[1100px]">
+      <div className="flex flex-col gap-4 md:pl-[50px] lg:pl-[100px] mt-[36px] mb-[36px]">
         {showAddFundsModal ? (
           <AddFunds
             className="md:w-[400px]"
@@ -153,76 +162,98 @@ const DialogModalSendProposalDesktopLayout: FC<DialogModalSendProposalDesktopLay
             onGoBack={() => setShowAddFundsModal(false)}
           />
         ) : (
-          <div className="flex flex-col gap-8">
-            <div className="flex flex-col gap-4">
-              <ContestPrompt type="modal" prompt={contestPrompt} hidePrompt />
-              <div className="flex flex-col gap-2">
-                <UserProfileDisplay ethereumAddress={address ?? ""} shortenOnFallback={true} />
-              </div>
-            </div>
-            <div className="flex flex-col gap-8 rounded-md md:w-[650px]">
-              {hasEntryPreview ? (
-                <DialogModalSendProposalEntryPreviewLayout
-                  entryPreviewLayout={metadataFields[0].prompt}
-                  editorProposal={editorProposal}
-                  isDragging={isDragging}
-                  handleDrop={handleDrop}
-                  handleDragOver={handleDragOver}
-                  handleDragLeave={handleDragLeave}
-                />
-              ) : (
-                <DialogModalSendProposalEditor
-                  editorProposal={editorProposal}
-                  handleDrop={handleDrop}
-                  handleDragOver={handleDragOver}
-                  handleDragLeave={handleDragLeave}
-                  isDragging={isDragging}
-                />
-              )}
-
-              {isMetadataFieldsLoading ? (
-                <p className="loadingDots font-sabo-filled text-[16px] text-neutral-14">loading metadata fields</p>
-              ) : isMetadataFieldsError ? (
-                <p className="text-negative-11">Error while loading metadata fields. Please reload the page.</p>
-              ) : metadataFields.length > 0 ? (
-                <DialogModalSendProposalMetadataFields />
-              ) : null}
-              <div className="flex flex-col gap-4 -mt-2">
-                <CreateGradientTitle textSize="small" additionalInfo="optional">
-                  get updates by email
-                </CreateGradientTitle>
-                <EmailSubscription
-                  emailAlreadyExists={emailAlreadyExists ?? false}
-                  emailError={emailError}
-                  emailForSubscription={emailForSubscription ?? ""}
-                  tosHref={tosHref ?? ""}
-                  handleEmailChange={handleEmailChange}
-                />
-              </div>
-            </div>
-            <div className="flex flex-col gap-12 mt-12">
-              {isCorrectNetwork ? (
-                <div className="flex flex-col gap-2">
-                  <ButtonV3
-                    colorClass="bg-gradient-purple rounded-[40px]"
-                    size={ButtonSize.EXTRA_LARGE_LONG}
-                    onClick={buttonText === ButtonText.SUBMIT ? handleConfirm : () => setShowAddFundsModal(true)}
-                    isDisabled={isLoading}
-                  >
-                    {buttonText}
-                  </ButtonV3>
-                  {error && <>{error}</>}
+          <div className="flex flex-col gap-5">
+            {!anyoneCanSubmit && creator && !qualifies && (
+              <div className="bg-gradient-create rounded-[10px] p-[1px] md:w-[650px]">
+                <div className="flex items-center gap-3 rounded-[10px] bg-true-black py-3 px-4">
+                  <p className="text-[14px] text-neutral-11">
+                    {isConnected
+                      ? `only the contest creator (${shortenEthereumAddress(creator)}) can submit entries`
+                      : `if you are not the contest creator (${shortenEthereumAddress(creator)}) you will not be able to submit an entry`}
+                  </p>
                 </div>
-              ) : (
-                <ButtonV3
-                  colorClass="bg-gradient-create rounded-[40px]"
-                  size={ButtonSize.EXTRA_LARGE_LONG}
-                  onClick={onSwitchNetwork}
-                >
-                  switch network
-                </ButtonV3>
-              )}
+              </div>
+            )}
+            <div className={`flex flex-col gap-5 transition-opacity duration-300 ${
+              isDisqualified ? "opacity-30 pointer-events-none select-none" : ""
+            }`}>
+              <div className="flex flex-col gap-3">
+                <ContestPrompt type="modal" prompt={contestPrompt} hidePrompt />
+              </div>
+              <div className="flex flex-col gap-5 rounded-md md:w-[650px]">
+                {hasEntryPreview ? (
+                  <DialogModalSendProposalEntryPreviewLayout
+                    entryPreviewLayout={metadataFields[0].prompt}
+                    editorProposal={editorProposal}
+                    isDragging={isDragging}
+                    handleDrop={handleDrop}
+                    handleDragOver={handleDragOver}
+                    handleDragLeave={handleDragLeave}
+                  />
+                ) : (
+                  <DialogModalSendProposalEditor
+                    editorProposal={editorProposal}
+                    handleDrop={handleDrop}
+                    handleDragOver={handleDragOver}
+                    handleDragLeave={handleDragLeave}
+                    isDragging={isDragging}
+                  />
+                )}
+
+                {isMetadataFieldsLoading ? (
+                  <p className="loadingDots font-sabo-filled text-[16px] text-neutral-14">loading metadata fields</p>
+                ) : isMetadataFieldsError ? (
+                  <p className="text-negative-11">Error while loading metadata fields. Please reload the page.</p>
+                ) : metadataFields.length > 0 ? (
+                  <DialogModalSendProposalMetadataFields />
+                ) : null}
+                <div className="flex flex-col gap-4 -mt-2">
+                  <CreateGradientTitle textSize="small" additionalInfo="optional">
+                    get updates by email
+                  </CreateGradientTitle>
+                  <EmailSubscription
+                    emailAlreadyExists={emailAlreadyExists ?? false}
+                    emailError={emailError}
+                    emailForSubscription={emailForSubscription ?? ""}
+                    tosHref={tosHref ?? ""}
+                    handleEmailChange={handleEmailChange}
+                  />
+                </div>
+              </div>
             </div>
+            {!isDisqualified && (
+              <div className="flex flex-col gap-6 mt-6">
+                {!isConnected ? (
+                  <ButtonV3
+                    colorClass="bg-gradient-vote rounded-[40px]"
+                    size={ButtonSize.EXTRA_LARGE_LONG}
+                    onClick={() => openWalletModal()}
+                  >
+                    connect wallet to submit entry
+                  </ButtonV3>
+                ) : isCorrectNetwork ? (
+                  <div className="flex flex-col gap-2">
+                    <ButtonV3
+                      colorClass="bg-gradient-purple rounded-[40px]"
+                      size={ButtonSize.EXTRA_LARGE_LONG}
+                      onClick={buttonText === ButtonText.SUBMIT ? handleConfirm : () => setShowAddFundsModal(true)}
+                      isDisabled={isLoading}
+                    >
+                      {buttonText}
+                    </ButtonV3>
+                    {error && <>{error}</>}
+                  </div>
+                ) : (
+                  <ButtonV3
+                    colorClass="bg-gradient-create rounded-[40px]"
+                    size={ButtonSize.EXTRA_LARGE_LONG}
+                    onClick={onSwitchNetwork}
+                  >
+                    switch network
+                  </ButtonV3>
+                )}
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/packages/react-app-revamp/components/_pages/DialogModalSendProposal/Desktop/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalSendProposal/Desktop/index.tsx
@@ -229,7 +229,7 @@ const DialogModalSendProposalDesktopLayout: FC<DialogModalSendProposalDesktopLay
                     size={ButtonSize.EXTRA_LARGE_LONG}
                     onClick={() => openWalletModal()}
                   >
-                    connect wallet to submit entry
+                    connect wallet to enter
                   </ButtonV3>
                 ) : isCorrectNetwork ? (
                   <div className="flex flex-col gap-2">

--- a/packages/react-app-revamp/components/_pages/DialogModalSendProposal/Mobile/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalSendProposal/Mobile/index.tsx
@@ -139,7 +139,7 @@ const DialogModalSendProposalMobileLayout: FC<DialogModalSendProposalMobileLayou
                 size={ButtonSize.EXTRA_LARGE_LONG_MOBILE}
                 onClick={() => openWalletModal()}
               >
-                connect wallet to submit entry
+                connect wallet to enter
               </ButtonV3>
             ) : isCorrectNetwork ? (
               <ButtonV3

--- a/packages/react-app-revamp/components/_pages/DialogModalSendProposal/Mobile/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalSendProposal/Mobile/index.tsx
@@ -1,13 +1,14 @@
 import ButtonV3, { ButtonSize } from "@components/UI/ButtonV3";
-import DialogModalV3 from "@components/UI/DialogModalV3";
-import UserProfileDisplay from "@components/UI/UserProfileDisplay";
+import Drawer from "@components/UI/Drawer";
 import ContestPrompt from "@components/_pages/Contest/components/Prompt";
+import shortenEthereumAddress from "@helpers/shortenEthereumAddress";
 import { useContestStore } from "@hooks/useContest/store";
 import useContestConfigStore from "@hooks/useContestConfig/store";
 import { Charge } from "@hooks/useDeployContest/types";
 import useMetadataFields from "@hooks/useMetadataFields";
 import { useMetadataStore } from "@hooks/useMetadataFields/store";
 import useSubmitProposal from "@hooks/useSubmitProposal";
+import { useModal } from "@getpara/react-sdk-lite";
 import { Editor } from "@tiptap/react";
 import { type GetBalanceReturnType } from "@wagmi/core";
 import { FC, useEffect, useState } from "react";
@@ -25,9 +26,12 @@ interface DialogModalSendProposalMobileLayoutProps {
   editorProposal: Editor | null;
   charge: Charge;
   accountData: GetBalanceReturnType | undefined;
-  address: string;
   isOpen: boolean;
+  isConnected: boolean;
   isCorrectNetwork: boolean;
+  qualifies: boolean;
+  anyoneCanSubmit: boolean;
+  creator: string | undefined;
   setIsOpen: (isOpen: boolean) => void;
   onSwitchNetwork?: () => void;
   onSubmitProposal?: () => void;
@@ -38,20 +42,23 @@ const DialogModalSendProposalMobileLayout: FC<DialogModalSendProposalMobileLayou
   contestId,
   proposal,
   editorProposal,
-  address,
   charge,
   accountData,
   isOpen,
+  isConnected,
   isCorrectNetwork,
+  qualifies,
+  anyoneCanSubmit,
+  creator,
   setIsOpen,
   onSwitchNetwork,
   onSubmitProposal,
 }) => {
+  const { openModal: openWalletModal } = useModal();
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
   const { isLoading, isSuccess, error } = useSubmitProposal();
   const { contestConfig } = useContestConfigStore(useShallow(state => state));
   const { contestPrompt } = useContestStore(state => state);
-  const isInPwaMode = window.matchMedia("(display-mode: standalone)").matches;
   const { isLoading: isMetadataFieldsLoading, isError: isMetadataFieldsError } = useMetadataFields({
     address: contestConfig.address,
     chainId: contestConfig.chainId,
@@ -60,6 +67,7 @@ const DialogModalSendProposalMobileLayout: FC<DialogModalSendProposalMobileLayou
   });
   const { fields: metadataFields } = useMetadataStore(state => state);
   const hasEntryPreview = metadataFields.length > 0 && isEntryPreviewPrompt(metadataFields[0].prompt);
+  const isDisqualified = isConnected && !qualifies && !anyoneCanSubmit;
 
   useEffect(() => {
     if (error || isSuccess) {
@@ -85,48 +93,23 @@ const DialogModalSendProposalMobileLayout: FC<DialogModalSendProposalMobileLayou
   };
 
   return (
-    <DialogModalV3 isOpen={isOpen} title="sendProposalMobile" isMobile>
-      <div
-        className={`${
-          isConfirmModalOpen ? "fixed" : "hidden"
-        } inset-0 z-50 pointer-events-none bg-neutral-8 bg-neutral-8/60`}
-        aria-hidden="true"
-      />
-      <div
-        className={`flex flex-col gap-8 ${isInPwaMode ? "mt-0" : "mt-12"} ${
-          isConfirmModalOpen ? "pointer-events-none" : ""
-        }`}
-      >
-        <div className="flex justify-between items-center">
-          <p className="text-neutral-11 text-[16px] font-bold" onClick={() => setIsOpen(false)}>
-            cancel
-          </p>
-          {isCorrectNetwork ? (
-            <ButtonV3
-              colorClass="bg-gradient-purple rounded-[40px]"
-              size={ButtonSize.DEFAULT_LONG}
-              onClick={handleOpenConfirmModal}
-              isDisabled={isLoading || isSubmitButtonDisabled()}
-            >
-              submit
-            </ButtonV3>
-          ) : (
-            <ButtonV3
-              colorClass="bg-gradient-create rounded-[40px]"
-              size={ButtonSize.DEFAULT}
-              onClick={onSwitchNetwork}
-            >
-              switch network
-            </ButtonV3>
-          )}
-        </div>
-        <div className="flex flex-col gap-6">
-          <div className="flex flex-col gap-2">
-            <ContestPrompt type="modal" prompt={contestPrompt} hidePrompt />
-            <div className="flex flex-col gap-2">
-              <UserProfileDisplay ethereumAddress={address ?? ""} shortenOnFallback={true} />
+    <Drawer isOpen={isOpen} onClose={() => setIsOpen(false)} className="bg-true-black">
+      <div className="flex flex-col gap-6 px-6 pb-6">
+        {!anyoneCanSubmit && creator && !qualifies && (
+          <div className="bg-gradient-create rounded-[10px] p-[1px]">
+            <div className="flex items-center gap-3 rounded-[10px] bg-true-black py-3 px-4">
+              <p className="text-[14px] text-neutral-11">
+                {isConnected
+                  ? `only the contest creator (${shortenEthereumAddress(creator)}) can submit entries`
+                  : `if you are not the contest creator (${shortenEthereumAddress(creator)}) you will not be able to submit an entry`}
+              </p>
             </div>
           </div>
+        )}
+        <div className={`flex flex-col gap-4 transition-opacity duration-300 ${
+          isDisqualified ? "opacity-30 pointer-events-none select-none" : ""
+        }`}>
+          <ContestPrompt type="modal" prompt={contestPrompt} hidePrompt />
           <div className="flex flex-col gap-4">
             {hasEntryPreview ? (
               <DialogModalSendProposalEntryPreviewLayout
@@ -148,18 +131,46 @@ const DialogModalSendProposalMobileLayout: FC<DialogModalSendProposalMobileLayou
             </div>
           </div>
         </div>
+        {!isDisqualified && (
+          <div className="flex flex-col gap-4">
+            {!isConnected ? (
+              <ButtonV3
+                colorClass="bg-gradient-vote rounded-[40px]"
+                size={ButtonSize.EXTRA_LARGE_LONG_MOBILE}
+                onClick={() => openWalletModal()}
+              >
+                connect wallet to submit entry
+              </ButtonV3>
+            ) : isCorrectNetwork ? (
+              <ButtonV3
+                colorClass="bg-gradient-purple rounded-[40px]"
+                size={ButtonSize.EXTRA_LARGE_LONG_MOBILE}
+                onClick={handleOpenConfirmModal}
+                isDisabled={isLoading || isSubmitButtonDisabled()}
+              >
+                submit
+              </ButtonV3>
+            ) : (
+              <ButtonV3
+                colorClass="bg-gradient-create rounded-[40px]"
+                size={ButtonSize.EXTRA_LARGE_LONG_MOBILE}
+                onClick={onSwitchNetwork}
+              >
+                switch network
+              </ButtonV3>
+            )}
+          </div>
+        )}
       </div>
-      <div>
-        <DialogModalSendProposalMobileLayoutConfirm
-          chainName={chainName}
-          isOpen={isConfirmModalOpen}
-          charge={charge}
-          accountData={accountData}
-          onConfirm={() => onSubmitProposal?.()}
-          onClose={() => setIsConfirmModalOpen(false)}
-        />
-      </div>
-    </DialogModalV3>
+      <DialogModalSendProposalMobileLayoutConfirm
+        chainName={chainName}
+        isOpen={isConfirmModalOpen}
+        charge={charge}
+        accountData={accountData}
+        onConfirm={() => onSubmitProposal?.()}
+        onClose={() => setIsConfirmModalOpen(false)}
+      />
+    </Drawer>
   );
 };
 

--- a/packages/react-app-revamp/components/_pages/DialogModalSendProposal/Mobile/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalSendProposal/Mobile/index.tsx
@@ -1,7 +1,6 @@
 import ButtonV3, { ButtonSize } from "@components/UI/ButtonV3";
 import Drawer from "@components/UI/Drawer";
 import ContestPrompt from "@components/_pages/Contest/components/Prompt";
-import shortenEthereumAddress from "@helpers/shortenEthereumAddress";
 import { useContestStore } from "@hooks/useContest/store";
 import useContestConfigStore from "@hooks/useContestConfig/store";
 import { Charge } from "@hooks/useDeployContest/types";
@@ -29,9 +28,6 @@ interface DialogModalSendProposalMobileLayoutProps {
   isOpen: boolean;
   isConnected: boolean;
   isCorrectNetwork: boolean;
-  qualifies: boolean;
-  anyoneCanSubmit: boolean;
-  creator: string | undefined;
   setIsOpen: (isOpen: boolean) => void;
   onSwitchNetwork?: () => void;
   onSubmitProposal?: () => void;
@@ -47,9 +43,6 @@ const DialogModalSendProposalMobileLayout: FC<DialogModalSendProposalMobileLayou
   isOpen,
   isConnected,
   isCorrectNetwork,
-  qualifies,
-  anyoneCanSubmit,
-  creator,
   setIsOpen,
   onSwitchNetwork,
   onSubmitProposal,
@@ -67,7 +60,6 @@ const DialogModalSendProposalMobileLayout: FC<DialogModalSendProposalMobileLayou
   });
   const { fields: metadataFields } = useMetadataStore(state => state);
   const hasEntryPreview = metadataFields.length > 0 && isEntryPreviewPrompt(metadataFields[0].prompt);
-  const isDisqualified = isConnected && !qualifies && !anyoneCanSubmit;
 
   useEffect(() => {
     if (error || isSuccess) {
@@ -95,20 +87,7 @@ const DialogModalSendProposalMobileLayout: FC<DialogModalSendProposalMobileLayou
   return (
     <Drawer isOpen={isOpen} onClose={() => setIsOpen(false)} className="bg-true-black">
       <div className="flex flex-col gap-6 px-6 pb-6">
-        {!anyoneCanSubmit && creator && !qualifies && (
-          <div className="bg-gradient-create rounded-[10px] p-[1px]">
-            <div className="flex items-center gap-3 rounded-[10px] bg-true-black py-3 px-4">
-              <p className="text-[14px] text-neutral-11">
-                {isConnected
-                  ? `only the contest creator (${shortenEthereumAddress(creator)}) can submit entries`
-                  : `if you are not the contest creator (${shortenEthereumAddress(creator)}) you will not be able to submit an entry`}
-              </p>
-            </div>
-          </div>
-        )}
-        <div className={`flex flex-col gap-4 transition-opacity duration-300 ${
-          isDisqualified ? "opacity-30 pointer-events-none select-none" : ""
-        }`}>
+        <div className="flex flex-col gap-4">
           <ContestPrompt type="modal" prompt={contestPrompt} hidePrompt />
           <div className="flex flex-col gap-4">
             {hasEntryPreview ? (
@@ -131,36 +110,34 @@ const DialogModalSendProposalMobileLayout: FC<DialogModalSendProposalMobileLayou
             </div>
           </div>
         </div>
-        {!isDisqualified && (
-          <div className="flex flex-col gap-4">
-            {!isConnected ? (
-              <ButtonV3
-                colorClass="bg-gradient-vote rounded-[40px]"
-                size={ButtonSize.EXTRA_LARGE_LONG_MOBILE}
-                onClick={() => openWalletModal()}
-              >
-                connect wallet to enter
-              </ButtonV3>
-            ) : isCorrectNetwork ? (
-              <ButtonV3
-                colorClass="bg-gradient-purple rounded-[40px]"
-                size={ButtonSize.EXTRA_LARGE_LONG_MOBILE}
-                onClick={handleOpenConfirmModal}
-                isDisabled={isLoading || isSubmitButtonDisabled()}
-              >
-                submit
-              </ButtonV3>
-            ) : (
-              <ButtonV3
-                colorClass="bg-gradient-create rounded-[40px]"
-                size={ButtonSize.EXTRA_LARGE_LONG_MOBILE}
-                onClick={onSwitchNetwork}
-              >
-                switch network
-              </ButtonV3>
-            )}
-          </div>
-        )}
+        <div className="flex flex-col gap-4">
+          {!isConnected ? (
+            <ButtonV3
+              colorClass="bg-gradient-vote rounded-[40px]"
+              size={ButtonSize.EXTRA_LARGE_LONG_MOBILE}
+              onClick={() => openWalletModal()}
+            >
+              connect wallet to enter
+            </ButtonV3>
+          ) : isCorrectNetwork ? (
+            <ButtonV3
+              colorClass="bg-gradient-purple rounded-[40px]"
+              size={ButtonSize.EXTRA_LARGE_LONG_MOBILE}
+              onClick={handleOpenConfirmModal}
+              isDisabled={isLoading || isSubmitButtonDisabled()}
+            >
+              submit
+            </ButtonV3>
+          ) : (
+            <ButtonV3
+              colorClass="bg-gradient-create rounded-[40px]"
+              size={ButtonSize.EXTRA_LARGE_LONG_MOBILE}
+              onClick={onSwitchNetwork}
+            >
+              switch network
+            </ButtonV3>
+          )}
+        </div>
       </div>
       <DialogModalSendProposalMobileLayoutConfirm
         chainName={chainName}

--- a/packages/react-app-revamp/components/_pages/DialogModalSendProposal/components/Editor/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalSendProposal/components/Editor/index.tsx
@@ -32,7 +32,7 @@ const DialogModalSendProposalEditor: FC<DialogModalSendProposalEditorProps> = ({
           onDrop={handleDrop}
           onDragOver={handleDragOver}
           onDragLeave={handleDragLeave}
-          className={`bg-secondary-1 outline-none rounded-[16px] w-full overflow-y-auto h-52 md:h-80 ${
+          className={`bg-secondary-1 outline-none rounded-[16px] w-full overflow-y-auto h-40 md:h-44 ${
             isDragging ? "backdrop-blur-md opacity-70" : ""
           }`}
         />

--- a/packages/react-app-revamp/components/_pages/DialogModalSendProposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalSendProposal/index.tsx
@@ -11,13 +11,11 @@ import {
   saveSubmissionToLocalStorage,
 } from "@helpers/submissionCaching";
 import { useContestStore } from "@hooks/useContest/store";
-import useContestConfigStore from "@hooks/useContestConfig/store";
 import { useEditorStore } from "@hooks/useEditor/store";
 import useEmailSignup from "@hooks/useEmailSignup";
 import useSubmitProposal from "@hooks/useSubmitProposal";
 import { useSubmitProposalStore } from "@hooks/useSubmitProposal/store";
 import { useUploadImageStore } from "@hooks/useUploadImage";
-import { useSubmitQualification } from "@hooks/useUserSubmitQualification";
 import { useWallet } from "@hooks/useWallet";
 import Document from "@tiptap/extension-document";
 import Heading from "@tiptap/extension-heading";
@@ -43,14 +41,6 @@ interface DialogModalSendProposalProps {
 
 export const DialogModalSendProposal: FC<DialogModalSendProposalProps> = ({ isOpen, setIsOpen }) => {
   const { isConnected, userAddress, chain } = useWallet();
-  const { contestConfig } = useContestConfigStore(state => state);
-  const { qualifies, anyoneCanSubmit, creator } = useSubmitQualification({
-    address: contestConfig.address,
-    chainId: contestConfig.chainId,
-    abi: contestConfig.abi,
-    userAddress: userAddress as `0x${string}` | undefined,
-    enabled: isOpen,
-  });
   const asPath = usePathname();
   const isMobile = useMediaQuery({ maxWidth: "768px" });
   const { subscribeUser, checkIfEmailExists } = useEmailSignup();
@@ -210,9 +200,6 @@ export const DialogModalSendProposal: FC<DialogModalSendProposalProps> = ({ isOp
           isOpen={isOpen}
           isConnected={isConnected}
           isCorrectNetwork={isCorrectNetwork}
-          qualifies={qualifies}
-          anyoneCanSubmit={anyoneCanSubmit}
-          creator={creator}
           setIsOpen={setIsOpen}
           onSwitchNetwork={onSwitchNetwork}
           onSubmitProposal={onSubmitProposal}
@@ -228,9 +215,6 @@ export const DialogModalSendProposal: FC<DialogModalSendProposalProps> = ({ isOp
           isOpen={isOpen}
           isConnected={isConnected}
           isCorrectNetwork={isCorrectNetwork}
-          qualifies={qualifies}
-          anyoneCanSubmit={anyoneCanSubmit}
-          creator={creator}
           isDragging={isDragging}
           setIsOpen={setIsOpen}
           handleDrop={handleDrop}

--- a/packages/react-app-revamp/components/_pages/DialogModalSendProposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalSendProposal/index.tsx
@@ -11,11 +11,13 @@ import {
   saveSubmissionToLocalStorage,
 } from "@helpers/submissionCaching";
 import { useContestStore } from "@hooks/useContest/store";
+import useContestConfigStore from "@hooks/useContestConfig/store";
 import { useEditorStore } from "@hooks/useEditor/store";
 import useEmailSignup from "@hooks/useEmailSignup";
 import useSubmitProposal from "@hooks/useSubmitProposal";
 import { useSubmitProposalStore } from "@hooks/useSubmitProposal/store";
 import { useUploadImageStore } from "@hooks/useUploadImage";
+import { useSubmitQualification } from "@hooks/useUserSubmitQualification";
 import { useWallet } from "@hooks/useWallet";
 import Document from "@tiptap/extension-document";
 import Heading from "@tiptap/extension-heading";
@@ -40,7 +42,15 @@ interface DialogModalSendProposalProps {
 }
 
 export const DialogModalSendProposal: FC<DialogModalSendProposalProps> = ({ isOpen, setIsOpen }) => {
-  const { userAddress, chain } = useWallet();
+  const { isConnected, userAddress, chain } = useWallet();
+  const { contestConfig } = useContestConfigStore(state => state);
+  const { qualifies, anyoneCanSubmit, creator } = useSubmitQualification({
+    address: contestConfig.address,
+    chainId: contestConfig.chainId,
+    abi: contestConfig.abi,
+    userAddress: userAddress as `0x${string}` | undefined,
+    enabled: isOpen,
+  });
   const asPath = usePathname();
   const isMobile = useMediaQuery({ maxWidth: "768px" });
   const { subscribeUser, checkIfEmailExists } = useEmailSignup();
@@ -195,11 +205,14 @@ export const DialogModalSendProposal: FC<DialogModalSendProposalProps> = ({ isOp
           contestId={contestId}
           proposal={proposal}
           editorProposal={editorProposal}
-          address={userAddress ?? ""}
           charge={charge}
           accountData={accountData}
           isOpen={isOpen}
+          isConnected={isConnected}
           isCorrectNetwork={isCorrectNetwork}
+          qualifies={qualifies}
+          anyoneCanSubmit={anyoneCanSubmit}
+          creator={creator}
           setIsOpen={setIsOpen}
           onSwitchNetwork={onSwitchNetwork}
           onSubmitProposal={onSubmitProposal}
@@ -210,11 +223,14 @@ export const DialogModalSendProposal: FC<DialogModalSendProposalProps> = ({ isOp
           chainName={chainName}
           contestId={contestId}
           editorProposal={editorProposal}
-          address={userAddress ?? ""}
           charge={charge}
           accountData={accountData}
           isOpen={isOpen}
+          isConnected={isConnected}
           isCorrectNetwork={isCorrectNetwork}
+          qualifies={qualifies}
+          anyoneCanSubmit={anyoneCanSubmit}
+          creator={creator}
           isDragging={isDragging}
           setIsOpen={setIsOpen}
           handleDrop={handleDrop}

--- a/packages/react-app-revamp/hooks/useUserSubmitQualification/useSubmitQualification.ts
+++ b/packages/react-app-revamp/hooks/useUserSubmitQualification/useSubmitQualification.ts
@@ -13,6 +13,7 @@ export interface UseSubmitQualificationParams {
 export interface UseSubmitQualificationResult {
   qualifies: boolean;
   anyoneCanSubmit: boolean;
+  creator: string | undefined;
   isLoading: boolean;
   isError: boolean;
 }
@@ -61,11 +62,13 @@ export const useSubmitQualification = ({
   });
 
   const anyoneCanSubmit = data?.anyoneCanSubmit ?? false;
-  const qualifies = userAddress ? anyoneCanSubmit || userAddress === data?.creator : false;
+  const creator = data?.creator;
+  const qualifies = userAddress ? anyoneCanSubmit || userAddress === creator : false;
 
   return {
     qualifies,
     anyoneCanSubmit,
+    creator,
     isLoading,
     isError,
   };

--- a/packages/react-app-revamp/hooks/useUserSubmitQualification/useSubmitQualification.ts
+++ b/packages/react-app-revamp/hooks/useUserSubmitQualification/useSubmitQualification.ts
@@ -13,7 +13,6 @@ export interface UseSubmitQualificationParams {
 export interface UseSubmitQualificationResult {
   qualifies: boolean;
   anyoneCanSubmit: boolean;
-  creator: string | undefined;
   isLoading: boolean;
   isError: boolean;
 }
@@ -62,13 +61,11 @@ export const useSubmitQualification = ({
   });
 
   const anyoneCanSubmit = data?.anyoneCanSubmit ?? false;
-  const creator = data?.creator;
-  const qualifies = userAddress ? anyoneCanSubmit || userAddress === creator : false;
+  const qualifies = userAddress ? anyoneCanSubmit || userAddress === data?.creator : false;
 
   return {
     qualifies,
     anyoneCanSubmit,
-    creator,
     isLoading,
     isError,
   };


### PR DESCRIPTION
Closes #3750 

We only have one caveat here and that is since by our contest design, either everyone can submit entries or only creator, in that case we need to give a light warning to the user in the submit entry modal when user doesn't have wallet connected and only creator can submit entries.

I was mostly thinking in a direction that it should be at the top and act like banner, since you want to see that instantly if you don't have wallet connected and not pursue in the actions below when you in fact can't submit it.

[anyone can submit](https://deploy-preview-5612--confetti-main.netlify.app/contest/basetestnet/0xcbe1c8180315fce8ed56a2a0aa0e45ebcde169a4)
[only creator can submit](https://deploy-preview-5612--confetti-main.netlify.app/contest/basetestnet/0xfbd25554a2f7417d2d0649dda1bc24f13fba641e)