### PR TITLE
chore: add missing coinbase supported chains

### DIFF
--- a/packages/react-app-revamp/components/AddFunds/providers/onramp/coinbase/utils.ts
+++ b/packages/react-app-revamp/components/AddFunds/providers/onramp/coinbase/utils.ts
@@ -10,6 +10,8 @@ const COINBASE_CHAIN_MAPPING: Record<string, string> = {
   polygon: "polygon",
   avalanche: "avalanche-c-chain",
   celo: "celo",
+  world: "Worldchain",
+  monad: "Monad",
 };
 
 export const isChainSupportedForOnramp = (chainName: string): boolean => {


### PR DESCRIPTION
Closes #5485

It looks like `worldchain` and `monad` are supported for coinbase onramp, while the only one missing is `abstract` which is not supported.