### PR TITLE
enhancement: submit entry update

### DIFF
--- a/packages/react-app-revamp/components/UI/ButtonV3/index.tsx
+++ b/packages/react-app-revamp/components/UI/ButtonV3/index.tsx
@@ -21,6 +21,7 @@ export enum ButtonSize {
   EXTRA_LARGE_LONG_MOBILE = "extraLargeLongMobile",
   SUBMIT_ENTRY = "submitEntry",
   SUBMIT_ENTRY_MOBILE = "submitEntryMobile",
+  SUBMIT_ENTRY_FULL = "submitEntryFull",
   FULL = "full",
 }
 
@@ -47,6 +48,7 @@ const sizeClasses = {
   [ButtonSize.EXTRA_LARGE_LONG_MOBILE]: "w-[320px] h-[40px]",
   [ButtonSize.SUBMIT_ENTRY]: "w-[200px] h-8",
   [ButtonSize.SUBMIT_ENTRY_MOBILE]: "w-[120px] h-8",
+  [ButtonSize.SUBMIT_ENTRY_FULL]: "w-full h-8",
   [ButtonSize.FULL]: "w-full h-[40px]",
 };
 

--- a/packages/react-app-revamp/components/UI/ButtonV3/index.tsx
+++ b/packages/react-app-revamp/components/UI/ButtonV3/index.tsx
@@ -19,6 +19,8 @@ export enum ButtonSize {
   EXTRA_LARGE = "extraLarge",
   EXTRA_LARGE_LONG = "extraLargeLong",
   EXTRA_LARGE_LONG_MOBILE = "extraLargeLongMobile",
+  SUBMIT_ENTRY = "submitEntry",
+  SUBMIT_ENTRY_MOBILE = "submitEntryMobile",
   FULL = "full",
 }
 
@@ -43,6 +45,8 @@ const sizeClasses = {
   [ButtonSize.EXTRA_LARGE]: "w-[216px] h-[40px]",
   [ButtonSize.EXTRA_LARGE_LONG]: "w-[280px] h-[48px]",
   [ButtonSize.EXTRA_LARGE_LONG_MOBILE]: "w-[320px] h-[40px]",
+  [ButtonSize.SUBMIT_ENTRY]: "w-[200px] h-8",
+  [ButtonSize.SUBMIT_ENTRY_MOBILE]: "w-[120px] h-8",
   [ButtonSize.FULL]: "w-full h-[40px]",
 };
 

--- a/packages/react-app-revamp/components/_pages/Contest/Contest/ContestSubmitBar/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/Contest/ContestSubmitBar/index.tsx
@@ -69,7 +69,7 @@ const ContestSubmitBar = ({ variant }: ContestSubmitBarProps) => {
             {submitButton}
           </>
         ) : (
-          <div className="flex w-full justify-end">{submitButton}</div>
+          <div className="w-full">{submitButton}</div>
         )}
       </div>,
       mobileSlot,
@@ -107,7 +107,7 @@ const renderButton = (variant: SubmitBarVariant, isMobile: boolean) => {
       <ButtonV3
         colorClass="bg-gradient-vote rounded-[40px]"
         textColorClass="text-[16px] font-bold text-true-black"
-        size={ButtonSize.SUBMIT_ENTRY}
+        size={isMobile ? ButtonSize.SUBMIT_ENTRY_FULL : ButtonSize.SUBMIT_ENTRY}
         onClick={variant.onClick}
       >
         connect wallet to enter

--- a/packages/react-app-revamp/components/_pages/Contest/Contest/ContestSubmitBar/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/Contest/ContestSubmitBar/index.tsx
@@ -1,0 +1,121 @@
+import ButtonV3, { ButtonSize } from "@components/UI/ButtonV3";
+import { useContestStore } from "@hooks/useContest/store";
+import { useProposalStore } from "@hooks/useProposal/store";
+import { useEffect, useState } from "react";
+import ReactDOM from "react-dom";
+import { useMediaQuery } from "react-responsive";
+import { useShallow } from "zustand/shallow";
+import { SubmitBarVariant } from "../useContestSubmitButton";
+
+interface ContestSubmitBarProps {
+  variant: SubmitBarVariant;
+}
+
+const MOBILE_NAV_SLOT_ID = "mobile-create-nav-slot";
+
+const useMobileNavSlot = (enabled: boolean) => {
+  const [slot, setSlot] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      setSlot(null);
+      return;
+    }
+
+    const existing = document.getElementById(MOBILE_NAV_SLOT_ID);
+    if (existing) {
+      setSlot(existing);
+      return;
+    }
+
+    const observer = new MutationObserver(() => {
+      const el = document.getElementById(MOBILE_NAV_SLOT_ID);
+      if (el) {
+        setSlot(el);
+        observer.disconnect();
+      }
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [enabled]);
+
+  return slot;
+};
+
+const ContestSubmitBar = ({ variant }: ContestSubmitBarProps) => {
+  const isMobile = useMediaQuery({ maxWidth: 768 });
+  const submissionsCount = useProposalStore(useShallow(state => state.submissionsCount));
+  const contestMaxProposalCount = useContestStore(useShallow(state => state.contestMaxProposalCount));
+  const showsMobileBar = isMobile && (variant.kind === "counter-submit" || variant.kind === "connect");
+  const mobileSlot = useMobileNavSlot(showsMobileBar);
+
+  if (variant.kind === "hidden") return null;
+
+  if (variant.kind === "creator-only-message") {
+    return <p className="mt-6 text-[16px] text-secondary-11">only the contest creator can submit entries</p>;
+  }
+
+  const submitButton = renderButton(variant, isMobile);
+
+  if (isMobile) {
+    if (!mobileSlot) return null;
+    return ReactDOM.createPortal(
+      <div className="flex items-center justify-between gap-3 px-6 py-3 border-t border-neutral-2">
+        {variant.kind === "counter-submit" ? (
+          <>
+            <p className="text-[16px] font-bold text-neutral-9">
+              {submissionsCount} / {contestMaxProposalCount} entries submitted
+            </p>
+            {submitButton}
+          </>
+        ) : (
+          <div className="flex w-full justify-end">{submitButton}</div>
+        )}
+      </div>,
+      mobileSlot,
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-start gap-4 my-6">
+      {submitButton}
+      {variant.kind === "counter-submit" && (
+        <p className="text-[16px] font-bold text-neutral-9">
+          {submissionsCount} / {contestMaxProposalCount} entries submitted
+        </p>
+      )}
+    </div>
+  );
+};
+
+const renderButton = (variant: SubmitBarVariant, isMobile: boolean) => {
+  if (variant.kind === "counter-submit") {
+    return (
+      <ButtonV3
+        colorClass="bg-gradient-purple rounded-[40px]"
+        textColorClass="text-[16px] font-bold text-true-black"
+        size={isMobile ? ButtonSize.SUBMIT_ENTRY_MOBILE : ButtonSize.SUBMIT_ENTRY}
+        onClick={variant.onClick}
+      >
+        submit entry
+      </ButtonV3>
+    );
+  }
+
+  if (variant.kind === "connect") {
+    return (
+      <ButtonV3
+        colorClass="bg-gradient-vote rounded-[40px]"
+        textColorClass="text-[16px] font-bold text-true-black"
+        size={ButtonSize.SUBMIT_ENTRY}
+        onClick={variant.onClick}
+      >
+        connect wallet to enter
+      </ButtonV3>
+    );
+  }
+
+  return null;
+};
+
+export default ContestSubmitBar;

--- a/packages/react-app-revamp/components/_pages/Contest/Contest/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/Contest/index.tsx
@@ -10,6 +10,7 @@ import { useMediaQuery } from "react-responsive";
 import { useShallow } from "zustand/shallow";
 import ContestPrompt from "../components/Prompt";
 import ContestStickyCards from "../components/StickyCards";
+import ContestSubmitBar from "./ContestSubmitBar";
 import { useContestSubmitButton } from "./useContestSubmitButton";
 
 const ContestTab = () => {
@@ -27,9 +28,12 @@ const ContestTab = () => {
   const isMobile = useMediaQuery({ maxWidth: 768 });
   const isInPwaMode = window.matchMedia("(display-mode: standalone)").matches;
   const isContestCanceled = contestState === ContestStateEnum.Canceled;
-  const { renderSubmitButton } = useContestSubmitButton({
+  const { variant } = useContestSubmitButton({
     onOpenModal: () => setIsSubmitProposalModalOpen(true),
   });
+
+  const isSubmissionOpen = contestStatus === ContestStatus.SubmissionOpen;
+  const hasMobileFixedBar = isMobile && isSubmissionOpen && (variant.kind === "counter-submit" || variant.kind === "connect");
 
   return (
     <div className="animate-fade-in">
@@ -49,14 +53,10 @@ const ContestTab = () => {
           <ContestPrompt prompt={contestPrompt} type="page" />
         </div>
       </div>
-      {contestStatus === ContestStatus.SubmissionOpen && (
-        <div className="fixed z-50 bottom-20 left-0 right-0 flex w-full justify-center md:justify-normal md:static md:mt-8 md:mb-8">
-          {renderSubmitButton()}
-        </div>
-      )}
+      {isSubmissionOpen && <ContestSubmitBar variant={variant} />}
       {isMobile && <ContestStickyCards />}
 
-      <div className={`mt-6 ${isInPwaMode ? "mb-12" : "mb-0"}`}>
+      <div className={`mt-6 ${hasMobileFixedBar ? "pb-24" : ""} ${isInPwaMode ? "mb-12" : "mb-0"}`}>
         <div className="flex flex-col gap-2">
           {!isContestLoading && !isListProposalsLoading && isContestSuccess && isListProposalsSuccess && (
             <div className="animate-fade-in">

--- a/packages/react-app-revamp/components/_pages/Contest/Contest/useContestSubmitButton.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/Contest/useContestSubmitButton.tsx
@@ -1,12 +1,16 @@
-import ButtonV3, { ButtonSize } from "@components/UI/ButtonV3";
 import useContestConfigStore from "@hooks/useContestConfig/store";
 import { ContestStateEnum, useContestStateStore } from "@hooks/useContestState/store";
 import { useSubmitProposalStore } from "@hooks/useSubmitProposal/store";
 import { useSubmitQualification } from "@hooks/useUserSubmitQualification";
 import { useWallet } from "@hooks/useWallet";
 import { useModal } from "@getpara/react-sdk-lite";
-import { useMediaQuery } from "react-responsive";
 import { useShallow } from "zustand/shallow";
+
+export type SubmitBarVariant =
+  | { kind: "counter-submit"; onClick: () => void }
+  | { kind: "connect"; onClick: () => void }
+  | { kind: "creator-only-message" }
+  | { kind: "hidden" };
 
 interface UseContestSubmitButtonProps {
   onOpenModal: () => void;
@@ -29,7 +33,6 @@ export const useContestSubmitButton = ({ onOpenModal }: UseContestSubmitButtonPr
     })),
   );
   const contestState = useContestStateStore(useShallow(state => state.contestState));
-  const isMobile = useMediaQuery({ maxWidth: 768 });
 
   const isContestCanceled = contestState === ContestStateEnum.Canceled;
 
@@ -38,50 +41,24 @@ export const useContestSubmitButton = ({ onOpenModal }: UseContestSubmitButtonPr
     onOpenModal();
   };
 
-  const renderSubmitButton = () => {
-    if (isContestCanceled) return null;
-    if (isLoading) return null;
+  const resolveVariant = (): SubmitBarVariant => {
+    if (isContestCanceled) return { kind: "hidden" };
+    if (isLoading) return { kind: "hidden" };
 
     if (anyoneCanSubmit) {
-      return (
-        <ButtonV3
-          colorClass="bg-gradient-purple rounded-[40px]"
-          textColorClass="text-[16px] md:text-[20px] font-bold text-true-black"
-          size={isMobile ? ButtonSize.EXTRA_LARGE_LONG_MOBILE : ButtonSize.EXTRA_LARGE_LONG}
-          onClick={handleEnterContest}
-        >
-          submit entry
-        </ButtonV3>
-      );
+      return { kind: "counter-submit", onClick: handleEnterContest };
     }
 
     if (!isConnected) {
-      return (
-        <ButtonV3
-          colorClass="bg-gradient-vote rounded-[40px]"
-          size={isMobile ? ButtonSize.EXTRA_LARGE_LONG_MOBILE : ButtonSize.EXTRA_LARGE_LONG}
-          onClick={() => openModal()}
-        >
-          connect wallet to submit entry
-        </ButtonV3>
-      );
+      return { kind: "connect", onClick: () => openModal() };
     }
 
     if (qualifies) {
-      return (
-        <ButtonV3
-          colorClass="bg-gradient-purple rounded-[40px]"
-          textColorClass="text-[16px] md:text-[20px] font-bold text-true-black"
-          size={isMobile ? ButtonSize.EXTRA_LARGE_LONG_MOBILE : ButtonSize.EXTRA_LARGE_LONG}
-          onClick={handleEnterContest}
-        >
-          submit entry
-        </ButtonV3>
-      );
+      return { kind: "counter-submit", onClick: handleEnterContest };
     }
 
-    return <p className="text-secondary-11 text-[16px]">only the contest creator can submit entries</p>;
+    return { kind: "creator-only-message" };
   };
 
-  return { renderSubmitButton };
+  return { variant: resolveVariant() };
 };


### PR DESCRIPTION
Closes #5601

[anyone can submit contest](https://deploy-preview-5635--confetti-main.netlify.app/contest/basetestnet/0xd70382dc0af2b3c21e42dc7220d51029f81d63db)
[only creator can submit contest](https://deploy-preview-5635--confetti-main.netlify.app/contest/basetestnet/0x11429d1b37ffdfd6fa228386c248168b4b231083)



I just have one worry about UX here and it's related to mobile: 

When contest is open only for creator to submit entries and if user does not have wallet connected, we do not want to show entries submitted info and we show "connect wallet to enter" to determine if user is qualified. 

In that case, we need to have this button at the bottom, but i am not sure if it feels weird sitting like this alone, wdyt @divine-economy? Should it take full-width in this case?

<img width="556" height="751" alt="Screenshot 2026-04-17 at 13 23 52" src="https://github.com/user-attachments/assets/146e6d7e-ce47-4f98-afe9-adabb7d82d3a" />
