### PR TITLE
bugfix: update foundry env vars

### DIFF
--- a/.github/workflows/forge_tests.yml
+++ b/.github/workflows/forge_tests.yml
@@ -2,9 +2,6 @@ name: forge
 
 on: push
 
-env:
-  FOUNDRY_PROFILE: ci
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false


### PR DESCRIPTION
<img width="731" height="387" alt="Screenshot 2026-04-28 at 11 41 26 AM" src="https://github.com/user-attachments/assets/b19d43ef-f390-4163-829f-ab69eaccc009" />

[forge tests](https://github.com/jk-labs-inc/confetti/actions/runs/25062050505/job/73420201287) started failing, trying removing the env var in the workflow file.