### PR TITLE
feat: add tracking IDs to fund and vote buttons

### DIFF
--- a/packages/react-app-revamp/components/Voting/components/VoteButton/index.tsx
+++ b/packages/react-app-revamp/components/Voting/components/VoteButton/index.tsx
@@ -97,7 +97,7 @@ const VoteButton: FC<VoteButtonProps> = ({ isDisabled, isInvalidBalance, isConne
           />
         ))}
       <ButtonV3
-        id={isInvalidBalance ? "add_funds_button" : isConnected ? "vote_button" : undefined}
+        id={isInvalidBalance ? "voting_add_funds_button" : isConnected ? "vote_button" : undefined}
         type={ButtonType.TX_ACTION}
         isDisabled={isInvalidBalance || !isConnected ? false : isDisabled}
         colorClass="px-[20px] text-[24px] font-bold bg-gradient-purple rounded-[40px] w-full"

--- a/packages/react-app-revamp/components/Voting/components/VoteButton/index.tsx
+++ b/packages/react-app-revamp/components/Voting/components/VoteButton/index.tsx
@@ -97,6 +97,7 @@ const VoteButton: FC<VoteButtonProps> = ({ isDisabled, isInvalidBalance, isConne
           />
         ))}
       <ButtonV3
+        id={isInvalidBalance ? "add_funds_button" : isConnected ? "vote_button" : undefined}
         type={ButtonType.TX_ACTION}
         isDisabled={isInvalidBalance || !isConnected ? false : isDisabled}
         colorClass="px-[20px] text-[24px] font-bold bg-gradient-purple rounded-[40px] w-full"


### PR DESCRIPTION
Closes #5771

We added `vote_button` and `add_funds_button` IDs to the buttons in the voting widget.

Just to keep in mind, we do not track add funds when user is trying to add funds from the profile dropdown, as this is scoped to the voting widget (when user does not have enough funds to vote and wants to add them from the voting widget)