### PR TITLE
enhancement: open vote drawer on mobile entry tap

### DIFF
--- a/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
@@ -138,9 +138,14 @@ const ProposalContent: FC<ProposalContentProps> = ({
   };
 
   const handleCardClick = () => {
-    if (!isDesktop) return;
     if (isContestCanceled) return;
     if (contestStatus !== ContestStatus.VotingOpen) return;
+
+    if (!isDesktop) {
+      handleVotingDrawerOpen();
+      return;
+    }
+
     setPickedProposal(proposal.id);
   };
 


### PR DESCRIPTION
I realized that on mobile, since we do not have an entry page anymore, if user taps anywhere on the entry card, voting drawer should open (we keep upvote button there for a visibility but drawer also opens on that click as before)