### PR TITLE
fix(contest): collapse price curve by default on mobile (#6003)

### DIFF
--- a/packages/react-app-revamp/components/_pages/Contest/Contest/index.tsx
+++ b/packages/react-app-revamp/components/_pages/Contest/Contest/index.tsx
@@ -7,7 +7,7 @@ import { ContestStateEnum, useContestStateStore } from "@hooks/useContestState/s
 import { ContestStatus, useContestStatusStore } from "@hooks/useContestStatus/store";
 import { useProposalStore } from "@hooks/useProposal/store";
 import moment from "moment";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useMediaQuery } from "react-responsive";
 import { useShallow } from "zustand/shallow";
 import VotingActionBar from "@components/VotingActionBar";
@@ -42,6 +42,19 @@ const ContestTab = () => {
 
   const isContestOver = votesClose ? moment().isSameOrAfter(moment(votesClose)) : false;
   const [isPriceCurveExpanded, setIsPriceCurveExpanded] = useState(!isContestOver);
+
+  // #6003: on mobile, default the price curve to collapsed so the essentials
+  // (entries, voting bar, price-per-vote, timing) are visible first. `isMobile`
+  // resolves to `false` on the first (SSR) render and updates after mount, so we
+  // apply the collapse in an effect. A ref ensures it runs only once and never
+  // fights a user who then manually expands the curve.
+  const didApplyMobileCollapse = useRef(false);
+  useEffect(() => {
+    if (isMobile && !didApplyMobileCollapse.current) {
+      setIsPriceCurveExpanded(false);
+      didApplyMobileCollapse.current = true;
+    }
+  }, [isMobile]);
 
   const isSubmissionOpen = contestStatus === ContestStatus.SubmissionOpen;
   const isVotingOpen = contestStatus === ContestStatus.VotingOpen;


### PR DESCRIPTION
Addresses part of #6003.

## What
On mobile, the price curve now defaults to **collapsed** so the essentials — entries, voting bar, price-per-vote, and timing — are visible immediately when opening a contest. It's one tap to expand.

## How
`isMobile` (react-responsive) returns `false` on the first/SSR render and updates after mount, so a `useState` initializer wouldn't reliably catch mobile. The collapse is applied in a `useEffect` once `isMobile` becomes true, guarded by a `useRef` so it runs a single time and never overrides a user who manually expands the curve.

## On the "activity feed" part of the issue
I couldn't find a separate activity-feed component on the contest page (it renders the price curve, sticky cards, and the proposals list). Could you point me to where the activity feed lives? Happy to handle that in this PR or a follow-up.

## Testing
Verified against the contest page's expand-state wiring by inspection. I wasn't able to complete a full local build to eyeball it (the monorepo install kept dropping on my connection) — happy to adjust after CI or on request.