### PR TITLE
bugfix: fix erratic GTM click tracking on vote and calendar buttons

### DIFF
--- a/packages/react-app-revamp/components/Voting/components/VoteButton/index.tsx
+++ b/packages/react-app-revamp/components/Voting/components/VoteButton/index.tsx
@@ -83,7 +83,7 @@ const VoteButton: FC<VoteButtonProps> = ({ isDisabled, isInvalidBalance, isConne
         size={ButtonSize.FULL}
         onClick={handleClick}
       >
-        <span className="w-full text-center">buy votes</span>
+        buy votes
       </ButtonV3>
     </div>
     </div>

--- a/packages/react-app-revamp/components/VotingActionBar/index.tsx
+++ b/packages/react-app-revamp/components/VotingActionBar/index.tsx
@@ -224,6 +224,7 @@ const VotingActionBar = () => {
           </div>
 
           <button
+            id="vote_button"
             onClick={handleClick}
             // Keep the input focused through the tap so the keyboard doesn't
             // collapse and shift the bar mid-press.

--- a/packages/react-app-revamp/components/_pages/FeaturedContests/components/Contest/components/CalendarButton/index.tsx
+++ b/packages/react-app-revamp/components/_pages/FeaturedContests/components/Contest/components/CalendarButton/index.tsx
@@ -32,11 +32,9 @@ const CalendarButton: FC<CalendarButtonProps> = ({ contestName, contestAddress, 
       id="add_to_calendar_button_click"
       onClick={handleClick}
       aria-label="Remind me when voting opens"
-      className="flex items-center justify-center w-8 h-8 rounded-full bg-gradient-calendar cursor-pointer shrink-0 self-start"
+      className="flex items-center justify-center w-8 h-8 rounded-full bg-gradient-calendar cursor-pointer shrink-0 self-start after:content-[''] after:w-4 after:h-4 after:bg-[url('/contest/reminder.svg')] after:bg-contain after:bg-center after:bg-no-repeat"
       whileTap={{ scale: 0.97 }}
-    >
-      <img src="/contest/reminder.svg" alt="" width={16} height={16} />
-    </motion.button>
+    />
   );
 };
 


### PR DESCRIPTION
The thing is GTM's Click ID triggers read the ID of the inner element clicked so nested elements inside the buttons (label span in buy votes, icon img in add to calendar) swallowed most clicks, so tags only fired when clicks landed on the buttons edges.

This also explains why all other buttons never had an issue, since none of them had any inner element