### PR TITLE
bugfix: retry entry title fetches on landing cards on RPC failure

### DIFF
--- a/packages/react-app-revamp/hooks/useContestEntriesPreviews/index.ts
+++ b/packages/react-app-revamp/hooks/useContestEntriesPreviews/index.ts
@@ -20,7 +20,7 @@ export function useContestEntriesPreviews({ config, proposalIds, enabled = true 
   const distinctIds = useMemo(() => Array.from(new Set(proposalIds)).sort(), [proposalIds]);
 
   const combine = useCallback(
-    (results: UseQueryResult<FetchedEntry | null>[]) => {
+    (results: UseQueryResult<FetchedEntry>[]) => {
       const byId = new Map<string, FetchedEntry>();
 
       const pendingIds = new Set<string>();
@@ -36,9 +36,11 @@ export function useContestEntriesPreviews({ config, proposalIds, enabled = true 
   const { byId, pendingIds, isLoading } = useQueries({
     queries: distinctIds.map(id => ({
       queryKey: ["contestEntryTitle", config?.address.toLowerCase(), config?.chainId, id],
-      queryFn: async (): Promise<FetchedEntry | null> => {
-        if (!config) return null;
-        const [result] = await readContracts(getWagmiConfig(), {
+
+      queryFn: async (): Promise<FetchedEntry> => {
+        if (!config) throw new Error(`missing card config for entry ${id}`);
+        const [proposal] = await readContracts(getWagmiConfig(), {
+          allowFailure: false,
           contracts: [
             {
               address: config.address,
@@ -49,8 +51,8 @@ export function useContestEntriesPreviews({ config, proposalIds, enabled = true 
             },
           ],
         });
-        if (result.status !== "success" || !result.result) return null;
-        const data = result.result as FetchedEntry;
+        if (!proposal) throw new Error(`getProposal(${id}) returned no data for ${config.address}`);
+        const data = proposal as FetchedEntry;
         return {
           description: data.description,
           fieldsMetadata: data.fieldsMetadata ?? (data.description ? { stringArray: [data.description] } : undefined),


### PR DESCRIPTION
Closes #6081

Ok this one looks clearly like an RPC failure (it loaded for me vs not for others)

The thing is, now we will retry 3 times (4 in total) with exponential backoff (1s, 2s, 4s), showing the skeleton the whole time and "untitle entry" only appears if all attempts fail.

Also one thing to note, in the future contests, we will grab entry title from the supabase, but since we only implemented it yesterday, this one will be available from the next contest we deploy (activity feed on the current contest is already grabbing entry titles from the supabase because PR got merged before voting started)