### PR TITLE
chore: re-enable para dep updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,8 +35,7 @@
     },
     {
       "matchPackageNames":[
-        "@tiptap/**",
-        "@getpara/**"
+        "@tiptap/**"
       ],
       "enabled": false
     },


### PR DESCRIPTION
now that we've upgraded to v3 in #6119 we can go back to automatically getting updates for them